### PR TITLE
Update LifeLeechMechanicListener.java

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/lifeleech/LifeLeechMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/lifeleech/LifeLeechMechanicListener.java
@@ -12,6 +12,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Objects;
+
 public class LifeLeechMechanicListener implements Listener {
 
     private final MechanicFactory factory;
@@ -34,9 +36,23 @@ public class LifeLeechMechanicListener implements Listener {
 
         LifeLeechMechanic mechanic = (LifeLeechMechanic) factory.getMechanic(itemID);
         double health = damager.getHealth() + mechanic.getAmount();
-        double maxHealth = damager.getAttribute(Attribute.GENERIC_MAX_HEALTH).getDefaultValue();
+        /**
+         * double maxHealth = damager.getAttribute(Attribute.GENERIC_MAX_HEALTH).getDefaultValue();
+         *
+         * Fixe d'un bug duquel le maxHealth n'est pas bien compté.
+         * Fixe d'un second byg que le GENERIC_MAX_HEALTH avec getDefaultValue ne dépasse pas les 20
+         */
+        //
+
+        double maxHealth = damager.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+
         damager.setHealth(Math.min(health, maxHealth));
         LivingEntity damaged = (LivingEntity) event.getEntity();
-        damaged.setHealth(damaged.getHealth() - mechanic.getAmount());
+        /**
+         Could not pass event EntityDamageByEntityEvent to Oraxen v1.35.2
+         java.lang.IllegalArgumentException: Health must be between 0 and 20.0, but was -1.8572006225585938. (attribute base value: 20.0)
+         at org.bukkit.craftbukkit.v1_15_R1.entity.CraftLivingEntity.setHealth(CraftLivingEntity.java:112) ~[server.jar:git-Purpur-"6158389"]
+         */
+        damaged.setHealth(damaged.getHealth() - mechanic.getAmount() <= 0 ? 0.0 : damaged.getHealth() - mechanic.getAmount());
     }
 }


### PR DESCRIPTION
Fixe de 2 bugs : 
Premier, passé de getDefaultValue à getValue pour dépasser les 20 de base.

Le second est lorsqu'on tue un mob, une erreur est affiché, bug fixé avec une condition .