### PR TITLE
Fixed Loots

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -16,7 +16,7 @@ public class Loot {
     private LinkedHashMap<String, Object> config;
 
     public Loot(LinkedHashMap<String, Object> config) {
-        this.probability = config.containsValue("max_amount")
+        this.probability = config.containsValue("probability")
                 ? (int) (1D / (double) config.get("probability")) : 1;
         this.maxAmount = config.containsValue("max_amount")
                 ? (int) config.get("max_amount") : 1;

--- a/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -16,10 +16,8 @@ public class Loot {
     private LinkedHashMap<String, Object> config;
 
     public Loot(LinkedHashMap<String, Object> config) {
-        this.probability = config.containsValue("probability")
-                ? (int) (1D / (double) config.get("probability")) : 1;
-        this.maxAmount = config.containsValue("max_amount")
-                ? (int) config.get("max_amount") : 1;
+        this.probability = config.containsKey("probability") ? (int) (1D / (double) config.get("probability")) : 1;
+        this.maxAmount = config.containsKey("max_amount") ? (int) config.get("max_amount") : 1;
         this.config = config;
     }
 


### PR DESCRIPTION
Was having issues with loot on block drops. Usage should work following the format below.

```yaml
drop:
        loots:
          - {oraxen_item: caveblock, probability: 1.0, max_amount: 32}
          - {minecraft_type: DIRT, probability: 1.0, max_amount: 64}
```