### PR TITLE
Add maven plugin to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,12 @@ plugins {
     id "eclipse"
     id "maven-publish"
     id "com.github.johnrengelman.shadow" version "5.2.0"
+    id 'maven'
 }
 
 group "io.th0rgal"
 def pluginVersion = "1.60.2"
+version = pluginVersion
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This change fixes issue #81 by adding the maven plugin to  build.gradle, so that the jar gets installed to the local repository and that jitpack can grab it.