### PR TITLE
fix naming of noteblock blockstate variable

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/noteblock/NoteBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/noteblock/NoteBlockMechanicFactory.java
@@ -46,14 +46,14 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
     }
 
     private String getBlockstateContent() {
-        JsonObject mushroomStem = new JsonObject();
+        JsonObject noteblock = new JsonObject();
         JsonArray multipart = new JsonArray();
         // adds default override
         multipart.add(getBlockstateOverride("required/note_block", "harp"));
         for (JsonObject override : BLOCKSTATE_OVERRIDES)
             multipart.add(override);
-        mushroomStem.add("multipart", multipart);
-        return mushroomStem.toString();
+        noteblock.add("multipart", multipart);
+        return noteblock.toString();
     }
 
     public static String getInstrumentName(int id) {


### PR DESCRIPTION
A very minor mistake in the variable naming I spotted.