### PR TITLE
Fixed JitPack support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10

--- a/build.gradle
+++ b/build.gradle
@@ -94,3 +94,11 @@ shadowJar {
 
 compileJava.dependsOn clean
 build.dependsOn shadowJar
+
+publishing {
+    publications {
+        grp(MavenPublication) {
+            from(components.java)
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ processResources {
 }
 
 java {
-    withJavadocJar()
     withSourcesJar()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,20 +95,3 @@ shadowJar {
 
 compileJava.dependsOn clean
 build.dependsOn shadowJar
-publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/oraxen/Oraxen"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-    publications {
-        grp(MavenPublication) {
-            from(components.java)
-        }
-    }
-}

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+jdk: openjdk16
+before_install:
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install java 16.0.1-open
+  - sdk use java 16.0.1-open


### PR DESCRIPTION
- Removed github packages auth (you can put it back)
- Removed withJavadocJar (missing javadoc creates a lot of warnings, you can put it back / add the javadoc: I just don't like warnings)
- Added working jitpack.yml for java 16