### PR TITLE
Fixed JitPack builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,9 +98,6 @@ build.dependsOn shadowJar
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
         shadow(MavenPublication) {
             artifact shadowJar
         }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ import java.text.SimpleDateFormat
 
 plugins {
     id "java"
+    id "idea"
+    id "eclipse"
     id "maven-publish"
     id "com.github.johnrengelman.shadow" version '7.0.0'
 }
@@ -90,6 +92,7 @@ shadowJar {
                         "${System.properties['os.version']}"
         )
     }
+    archiveName = "$baseName-$version.$extension"
 }
 
 compileJava.dependsOn clean

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version '7.0.0'
 }
 
-apply plugin: 'java'
 apply plugin: 'maven-publish'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 group "io.th0rgal"
 def pluginVersion = "1.116.4"

--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,8 @@ build.dependsOn shadowJar
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
         shadow(MavenPublication) {
-            artifact shadowJar
+            from components.shadow
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,13 +97,12 @@ shadowJar {
 compileJava.dependsOn clean
 build.dependsOn shadowJar
 
-artifacts {
-    archives shadowJar
-}
-
 publishing {
     publications {
-        shadow(MavenPublication) {
+        mavenJava(MavenPublication) {
+            groupId project.group
+            artifactId project.name
+            version project.version
             from components.java
             artifact shadowJar
         }

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,12 @@ plugins {
     id "java"
     id "idea"
     id "eclipse"
-    id "maven-publish"
+    id "maven"
     id "com.github.johnrengelman.shadow" version '7.0.0'
 }
 
 apply plugin: 'java'
-apply plugin: 'maven-publish'
+apply plugin: 'maven'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group "io.th0rgal"

--- a/build.gradle
+++ b/build.gradle
@@ -100,10 +100,9 @@ build.dependsOn shadowJar
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId project.group
-            artifactId project.name
-            version project.version
             from components.java
+        }
+        shadow(MavenPublication) {
             artifact shadowJar
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,12 @@ plugins {
     id "java"
     id "idea"
     id "eclipse"
-    id "maven"
+    id "maven-publish"
     id "com.github.johnrengelman.shadow" version '7.0.0'
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group "io.th0rgal"
@@ -92,9 +92,20 @@ shadowJar {
                         "${System.properties['os.version']}"
         )
     }
-    archiveName = "$baseName-$version.$extension"
 }
+
+compileJava.dependsOn clean
+build.dependsOn shadowJar
 
 artifacts {
     archives shadowJar
+}
+
+publishing {
+    publications {
+        shadow(MavenPublication) {
+            from components.java
+            artifact shadowJar
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -95,14 +95,6 @@ shadowJar {
     archiveName = "$baseName-$version.$extension"
 }
 
-compileJava.dependsOn clean
-build.dependsOn shadowJar
-
-publishing {
-    publications {
-        shadow(MavenPublication) {
-            from components.java
-            artifact shadowJar
-        }
-    }
+artifacts {
+    archives shadowJar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,8 +98,10 @@ build.dependsOn shadowJar
 
 publishing {
     publications {
-        shadow(MavenPublication) {
+        mavenJava(MavenPublication) {
             from components.java
+        }
+        shadow(MavenPublication) {
             artifact shadowJar
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ processResources {
 }
 
 shadowJar {
+    classifier = null
     relocate "org.yaml.snakeyaml", "io.th0rgal.oraxen.shaded.snakeyaml"
     relocate "org.bstats", "io.th0rgal.oraxen.shaded.bstats"
     relocate "net.kyori", "io.th0rgal.oraxen.shaded.kyori"
@@ -98,6 +99,7 @@ build.dependsOn shadowJar
 publishing {
     publications {
         shadow(MavenPublication) {
+            from components.java
             artifact shadowJar
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,12 @@
 import java.text.SimpleDateFormat
 
 plugins {
-    id "java"
-    id "idea"
-    id "eclipse"
-    id "maven-publish"
     id "com.github.johnrengelman.shadow" version '7.0.0'
 }
 
-apply plugin: 'maven-publish'
+apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group "io.th0rgal"
 def pluginVersion = "1.116.4"

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ build.dependsOn shadowJar
 publishing {
     publications {
         shadow(MavenPublication) {
-            from components.shadow
+            artifact shadowJar
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 import java.text.SimpleDateFormat
 
 plugins {
+    id "java"
+    id "maven-publish"
     id "com.github.johnrengelman.shadow" version '7.0.0'
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group "io.th0rgal"


### PR DESCRIPTION
This fixes JitPack builds and allows the use of this plugin as a dependency.
Tested on this fork by adding it as a maven dependency of another plugin.
Sorry about all the commits I made, I needed a lot of attempts to fix it since I don't know how to use Gradle or JitPack.