### PR TITLE
add NBTAPI to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,5 +4,5 @@ version: ${projectVersion}
 author: Th0rgal
 api-version: "1.16"
 softdepend: [ ProtocolLib, LightAPI, PlaceholderAPI, MythicMobs, MMOItems, BossShopPro,
-              CrateReloaded, ItemBridge, WorldGuard, Towny, Factions, Lands ]
+              CrateReloaded, ItemBridge, WorldGuard, Towny, Factions, Lands, NBTAPI ]
 loadbefore: [ Realistic_World ]


### PR DESCRIPTION
Add NBTAPI to plugin.yml to stop this error:

`[io.th0rgal.oraxen.OraxenPlugin] [Oraxen] Oraxen | Loaded class de.tr7zw.nbtapi.NBTContainer from NBTAPI v2.8.0 which is not a depend, softdepend or loadbefore of this plugin.`