### PR TITLE
Fixing Maven not being able to find jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ processResources {
 }
 
 shadowJar {
+    classifier = null
     relocate 'org.yaml.snakeyaml', 'io.th0rgal.oraxen.shaded.snakeyaml'
     relocate 'org.bstats', 'io.th0rgal.oraxen.shaded.bstats'
     relocate 'net.kyori', 'io.th0rgal.oraxen.shaded.kyori'

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ processResources {
 }
 
 shadowJar {
-    classifier = null
+    archiveClassifier = null
     relocate 'org.yaml.snakeyaml', 'io.th0rgal.oraxen.shaded.snakeyaml'
     relocate 'org.bstats', 'io.th0rgal.oraxen.shaded.bstats'
     relocate 'net.kyori', 'io.th0rgal.oraxen.shaded.kyori'


### PR DESCRIPTION
If you don't set the classifier to null, "-all" will be added at the end of the jar's name so Maven't won't recognize it.
This causes that, even if JitPack shows the compilation was successful, Maven won't be able to load the dependency.