### PR TITLE
Add support for custom meta in items in BossShopPro and fix potion overlay textures applying to wrong layer (Closes #281)

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/compatibilities/provided/bossshoppro/BossShopProCompatibility.java
+++ b/src/main/java/io/th0rgal/oraxen/compatibilities/provided/bossshoppro/BossShopProCompatibility.java
@@ -7,10 +7,15 @@ import net.kyori.adventure.text.minimessage.Template;
 import org.black_ixx.bossshop.BossShop;
 import org.black_ixx.bossshop.events.BSCreatedShopItemEvent;
 import org.black_ixx.bossshop.events.BSRegisterTypesEvent;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class BossShopProCompatibility extends CompatibilityProvider<BossShop> {
 
@@ -24,10 +29,30 @@ public class BossShopProCompatibility extends CompatibilityProvider<BossShop> {
         if (itemID == null)
             return;
         ItemStack itemStack = new ItemStack(Material.AIR);
-        if (OraxenItems.exists(itemID))
+        if (OraxenItems.exists(itemID)){
             itemStack = OraxenItems.getItemById(itemID).build().clone();
-        else
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta != null) {
+                String name = menuItem.getString("name");
+                if (name != null) {
+                    itemMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+                }
+
+                List<String> lore = menuItem.getStringList("lore");
+                if (lore != null && lore.size() > 0) {
+                    List<String> newLore = lore
+                            .stream()
+                            .map((line) -> ChatColor.translateAlternateColorCodes('&', line))
+                            .collect(Collectors.toList());
+                    itemMeta.setLore(newLore);
+                }
+
+                itemStack.setItemMeta(itemMeta);
+            }
+        } else {
             Message.ITEM_NOT_FOUND.log(Template.template("item", itemID));
+        }
+
         if (amount != 0)
             itemStack.setAmount(amount);
         event.getShopItem().setItem(itemStack, false);

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
@@ -28,12 +28,20 @@ public class PredicatesGenerator {
 
         // textures
         final JsonObject textures = new JsonObject();
-        textures.addProperty("layer0", getVanillaTextureName(material, false));
 
         // to support colored leather armors + potions
         final ItemMeta exampleMeta = new ItemStack(material).getItemMeta();
-        if (exampleMeta instanceof LeatherArmorMeta || exampleMeta instanceof PotionMeta)
+        if (exampleMeta instanceof LeatherArmorMeta) {
+            // overlay textures must be on layer 1 in armor
+            textures.addProperty("layer0", getVanillaTextureName(material, false));
             textures.addProperty("layer1", getVanillaTextureName(material, false) + "_overlay");
+        } else if (exampleMeta instanceof PotionMeta) {
+            // overlay textures must be on layer 0 in potions
+            textures.addProperty("layer0", getVanillaTextureName(material, false) + "_overlay");
+            textures.addProperty("layer1", getVanillaTextureName(material, false));
+        } else {
+            textures.addProperty("layer0", getVanillaTextureName(material, false));
+        }
 
         json.add("textures", textures);
 


### PR DESCRIPTION
The overlay layer for potions is layer0 while the overlay layer for leather armor is 1

default potion model
https://raw.githubusercontent.com/InventivetalentDev/minecraft-assets/1.18.1/assets/minecraft/models/item/potion.json

default leather armor models
https://raw.githubusercontent.com/InventivetalentDev/minecraft-assets/1.18.1/assets/minecraft/models/item/leather_boots.json
https://raw.githubusercontent.com/InventivetalentDev/minecraft-assets/1.18.1/assets/minecraft/models/item/leather_leggings.json
https://raw.githubusercontent.com/InventivetalentDev/minecraft-assets/1.18.1/assets/minecraft/models/item/leather_chestplate.json
https://raw.githubusercontent.com/InventivetalentDev/minecraft-assets/1.18.1/assets/minecraft/models/item/leather_helmet.json

(On a side note, who decided potion would use layer0 and armor layer1?)