### PR TITLE
Fix checking for wrong material

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -127,7 +127,7 @@ public class StringBlockMechanicListener implements Listener {
 
             @Override
             public boolean isTriggered(final Player player, final Block block, final ItemStack tool) {
-                if (block.getType() != Material.NOTE_BLOCK)
+                if (block.getType() != Material.TRIPWIRE)
                     return false;
                 final Tripwire tripwire = (Tripwire) block.getBlockData();
                 final int code = StringBlockMechanicFactory.getCode(tripwire);


### PR DESCRIPTION
Fixes the error that is being thrown when breaking a note_block  - Casting it as tripwire