### PR TITLE
Send arm animation when placing custom blocks.

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -105,6 +105,7 @@ public class BlockMechanicListener implements Listener {
         final BlockMechanic mechanic = ((BlockMechanic) factory.getMechanic(itemID));
         final int customVariation = mechanic.getCustomVariation();
         BlockMechanic.setBlockFacing(newBlockData, customVariation);
+        Utils.sendAnimation(player, event.getHand());
 
         // set the new block
         target.setBlockData(newBlockData); // false to cancel physic


### PR DESCRIPTION
Small fix which sends the arm animation to the player when placing a block which uses the mushroom stem mechanic.