### PR TITLE
Fix potion generation

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
@@ -27,13 +27,22 @@ public class PredicatesGenerator {
         json.addProperty("parent", getParent(material));
 
         // textures
+        final ItemMeta exampleMeta = new ItemStack(material).getItemMeta();
         final JsonObject textures = new JsonObject();
+
+        // potions use the overlay as the base layer
+        if (exampleMeta instanceof PotionMeta) {
+            textures.addProperty("layer0", getVanillaTextureName(material, false) + "_overlay");
+        } else
         textures.addProperty("layer0", getVanillaTextureName(material, false));
 
-        // to support colored leather armors + potions
-        final ItemMeta exampleMeta = new ItemStack(material).getItemMeta();
-        if (exampleMeta instanceof LeatherArmorMeta || exampleMeta instanceof PotionMeta)
+        // to support colored leather armor
+        if (exampleMeta instanceof LeatherArmorMeta)
             textures.addProperty("layer1", getVanillaTextureName(material, false) + "_overlay");
+        // to support colored potions
+        if (exampleMeta instanceof PotionMeta) {
+            textures.addProperty("layer1", getVanillaTextureName(material, false));
+        }
 
         json.add("textures", textures);
 


### PR DESCRIPTION
Currently, oraxen generates the JSON file for potions incorrectly:

```json
{
    "parent": "item/generated",
    "textures": {
        "layer0": "item/potion",
        "layer1": "item/potion_overlay"
    }
}
```
![image](https://user-images.githubusercontent.com/60053521/152212042-693bd2ce-65c2-4131-b912-552d3377292e.png)

It should generate like this:
```json
{
  "parent": "item/generated",
  "textures": {
    "layer0": "item/potion_overlay",
    "layer1": "item/potion"
  }
}
```
This PR fixes it! 😄 

