### PR TITLE
Added check if stand is null for seat removing (NullPointerException)

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -254,9 +254,11 @@ public class FurnitureMechanic extends Mechanic {
                 if (entity.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
                     Entity stand = Bukkit.getEntity(UUID.fromString(entity.getPersistentDataContainer()
                             .get(SEAT_KEY, PersistentDataType.STRING)));
-                    for (Entity passenger : stand.getPassengers())
-                        stand.removePassenger(passenger);
-                    stand.remove();
+                    if(stand != null) {
+                        for (Entity passenger : stand.getPassengers())
+                            stand.removePassenger(passenger);
+                        stand.remove();
+                    }
                 }
                 frame.remove();
                 if (light != -1)
@@ -273,9 +275,11 @@ public class FurnitureMechanic extends Mechanic {
         if (frame.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
             Entity stand = Bukkit.getEntity(UUID.fromString(frame.getPersistentDataContainer()
                     .get(SEAT_KEY, PersistentDataType.STRING)));
-            for (Entity passenger : stand.getPassengers())
-                stand.removePassenger(passenger);
-            stand.remove();
+            if(stand != null) {
+                for (Entity passenger : stand.getPassengers())
+                    stand.removePassenger(passenger);
+                stand.remove();
+            }
         }
         Location location = frame.getLocation().getBlock().getLocation();
         if (light != -1) {


### PR DESCRIPTION
Seems like stand could be removed. This commit will add a check if stand is null

```
[19:27:45 ERROR]: Could not pass event BlockBreakEvent to Oraxen v1.125.0
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Entity.getPassengers()" because "stand" is null
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.removeSolid(FurnitureMechanic.java:257) ~[oraxen-1_125_0.jar:?]
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureListener.onFurnitureBreak(FurnitureListener.java:243) ~[oraxen-1_125_0.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor58.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:git-Paper-132]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.level.ServerPlayerGameMode.destroyBlock(ServerPlayerGameMode.java:400) ~[?:?]
        at net.minecraft.server.level.ServerPlayerGameMode.destroyAndAck(ServerPlayerGameMode.java:354) ~[?:?]
        at net.minecraft.server.level.ServerPlayerGameMode.handleBlockBreakAction(ServerPlayerGameMode.java:238) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:1762) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:34) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:8) ~[?:?]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:56) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:149) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:23) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1413) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.c(MinecraftServer.java:189) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:122) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1391) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1384) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:132) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1362) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1268) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:317) ~[paper-1.18.1.jar:git-Paper-132]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
```
[19:25:40 ERROR]: Could not pass event EntityDamageByEntityEvent to Oraxen v1.125.0
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Entity.getPassengers()" because "stand" is null
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.removeAirFurniture(FurnitureMechanic.java:276) ~[oraxen-1_125_0.jar:?]
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureListener.onPlayerBreakHanging(FurnitureListener.java:223) ~[oraxen-1_125_0.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor61.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:git-Paper-132]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory.callEvent(CraftEventFactory.java:247) ~[paper-1.18.1.jar:git-Paper-132]
        at org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory.callEntityDamageEvent(CraftEventFactory.java:1122) ~[paper-1.18.1.jar:git-Paper-132]
        at org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory.handleEntityDamageEvent(CraftEventFactory.java:998) ~[paper-1.18.1.jar:git-Paper-132]
        at org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory.handleNonLivingEntityDamageEvent(CraftEventFactory.java:1173) ~[paper-1.18.1.jar:git-Paper-132]
        at org.bukkit.craftbukkit.v1_18_R1.event.CraftEventFactory.handleNonLivingEntityDamageEvent(CraftEventFactory.java:1163) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.world.entity.decoration.ItemFrame.hurt(ItemFrame.java:185) ~[?:?]
        at net.minecraft.world.entity.decoration.HangingEntity.skipAttackInteraction(HangingEntity.java:185) ~[?:?]
        at net.minecraft.world.entity.player.Player.attack(Player.java:1196) ~[?:?]
        at net.minecraft.server.level.ServerPlayer.attack(ServerPlayer.java:2035) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl$5.a(ServerGamePacketListenerImpl.java:2519) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket$1.dispatch(ServerboundInteractPacket.java:24) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket.dispatch(ServerboundInteractPacket.java:80) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleInteract(ServerGamePacketListenerImpl.java:2446) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket.handle(ServerboundInteractPacket.java:67) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundInteractPacket.handle(ServerboundInteractPacket.java:12) ~[?:?]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:56) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:149) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:23) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1413) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.c(MinecraftServer.java:189) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:122) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1391) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1384) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:132) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1362) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1268) ~[paper-1.18.1.jar:git-Paper-132]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:317) ~[paper-1.18.1.jar:git-Paper-132]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```