### PR TITLE
"fix" piston interactions

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -35,6 +35,18 @@ public class NoteBlockMechanicListener implements Listener {
         BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPistonPush(BlockPistonExtendEvent event) {
+        if (event.getBlocks().stream().anyMatch(block -> block.getType().equals(Material.NOTE_BLOCK)))
+            event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPistonPull(BlockPistonRetractEvent event) {
+        if (event.getBlocks().stream().anyMatch(block -> block.getType().equals(Material.NOTE_BLOCK)))
+            event.setCancelled(true);
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockPhysics(final BlockPhysicsEvent event) {
         final Block aboveBlock = event.getBlock().getLocation().add(0, 1, 0).getBlock();


### PR DESCRIPTION
Closes #301 

Currently noteblocks will update their blockstate if pushed onto specific blocks. Tried cancelling this but couldnt get a reliable way.
Not to mention the block will simply drop a noteblock and loose all other behaviour.
Therefore I just set it to cancel them

For tripwires it would normally drop just a string, now it creates a drop from the tripwire


https://user-images.githubusercontent.com/62521371/161433615-a19436ca-4400-4330-8824-4d8738e97217.mp4


