### PR TITLE
Multiple seating and custom block fixes

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -113,7 +113,6 @@ public class FurnitureListener implements Listener {
                         && mechanic.getBarriers().size() > 1);
 
         final float yaw = mechanic.getYaw(rotation) + mechanic.getSeatYaw();
-        final String entityId = spawnSeat(mechanic, target, yaw);
 
         if (!mechanic.isEnoughSpace(yaw, target.getLocation())) {
             blockPlaceEvent.setCancelled(true);
@@ -127,7 +126,7 @@ public class FurnitureListener implements Listener {
             return;
         }
 
-        mechanic.place(rotation, yaw, event.getBlockFace(), target.getLocation(), entityId, item);
+        mechanic.place(rotation, yaw, event.getBlockFace(), target.getLocation(), item);
         Utils.sendAnimation(player, event.getHand());
         if (!player.getGameMode().equals(GameMode.CREATIVE))
             item.setAmount(item.getAmount() - 1);
@@ -162,26 +161,6 @@ public class FurnitureListener implements Listener {
                 return null;
 
         return (FurnitureMechanic) factory.getMechanic(itemID);
-    }
-
-    private String spawnSeat(FurnitureMechanic mechanic, Block target, float yaw) {
-        if (mechanic.hasSeat()) {
-            final ArmorStand seat = target.getWorld().spawn(target.getLocation()
-                    .add(0.5, mechanic.getSeatHeight() - 1, 0.5), ArmorStand.class, (ArmorStand stand) -> {
-                stand.setVisible(false);
-                stand.setRotation(yaw, 0);
-                stand.setInvulnerable(true);
-                stand.setPersistent(true);
-                stand.setAI(false);
-                stand.setCollidable(false);
-                stand.setGravity(false);
-                stand.setSilent(true);
-                stand.setCustomNameVisible(false);
-                stand.getPersistentDataContainer().set(FURNITURE_KEY, PersistentDataType.STRING, mechanic.getItemID());
-            });
-            return seat.getUniqueId().toString();
-        }
-        return null;
     }
 
     private Rotation getRotation(final double yaw, final boolean restricted) {
@@ -280,12 +259,13 @@ public class FurnitureListener implements Listener {
             }
         }
 
-        final ItemFrame frame = getItemFrame(block.getLocation());
-        if (frame == null || !frame.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING))
-            return;
-        final String entityId = frame.getPersistentDataContainer().get(SEAT_KEY, PersistentDataType.STRING);
+        final ArmorStand seat = getSeat(block.getLocation());
+        if (seat == null || !seat.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) return;
+
+        final String entityId = seat.getPersistentDataContainer().get(SEAT_KEY, PersistentDataType.STRING);
         final Entity stand = Bukkit.getEntity(UUID.fromString(entityId));
-        if (stand != null && stand.getPassengers().size() == 0) {
+
+        if (stand != null && stand.getPassengers().isEmpty()) {
             stand.addPassenger(event.getPlayer());
             event.setCancelled(true);
         }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -76,7 +76,7 @@ public class FurnitureListener implements Listener {
         };
     }
 
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     public void onHangingPlaceEvent(final PlayerInteractEvent event) {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -11,13 +11,12 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.Evolvin
 import io.th0rgal.oraxen.utils.actions.ClickAction;
 import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.drops.Loot;
+import net.Indyuce.mmoitems.stat.Armor;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -115,14 +114,16 @@ public class FurnitureMechanic extends Mechanic {
         clickActions = ClickAction.parseList(section);
     }
 
-    public static ItemFrame getItemFrame(Location location) {
-        for (Entity entity : location.getWorld().getNearbyEntities(location, 1, 1, 1))
-            if (entity instanceof ItemFrame frame
-                    && entity.getLocation().getBlockX() == location.getBlockX()
-                    && entity.getLocation().getBlockY() == location.getBlockY()
-                    && entity.getLocation().getBlockZ() == location.getBlockZ()
-                    && entity.getPersistentDataContainer().has(FURNITURE_KEY, PersistentDataType.STRING))
-                return frame;
+    public static ArmorStand getSeat(Location location) {
+        Location seatLoc = location.clone().add(0.5, 0.0, 0.5);
+        for (Entity entity : location.getWorld().getNearbyEntities(seatLoc, 0.1, 10, 0.1)) {
+            if (entity instanceof ArmorStand seat
+                    && entity.getLocation().getX() == seatLoc.getX()
+                    && entity.getLocation().getZ() == seatLoc.getZ()
+                    && entity.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
+                return seat;
+            }
+        }
         return null;
     }
 
@@ -183,12 +184,12 @@ public class FurnitureMechanic extends Mechanic {
         }
     }
 
-    public ItemFrame place(Rotation rotation, float yaw, BlockFace facing, Location location, String entityId) {
+    public ItemFrame place(Rotation rotation, float yaw, BlockFace facing, Location location) {
         setPlacedItem();
-        return place(rotation, yaw, facing, location, entityId, placedItem);
+        return place(rotation, yaw, facing, location, placedItem);
     }
 
-    public ItemFrame place(Rotation rotation, float yaw, BlockFace facing, Location location, String entityId,
+    public ItemFrame place(Rotation rotation, float yaw, BlockFace facing, Location location,
                            ItemStack item) {
         if (!this.isEnoughSpace(yaw, location))
             return null;
@@ -212,8 +213,10 @@ public class FurnitureMechanic extends Mechanic {
 
             frame.setFacingDirection(hasFacing() ? getFacing() : facing, true);
             frame.getPersistentDataContainer().set(FURNITURE_KEY, PersistentDataType.STRING, getItemID());
-            if (hasSeat())
+            if (hasSeat() && !hasBarriers()) {
+                String entityId = spawnSeat(this, location.getBlock(), seatYaw);
                 frame.getPersistentDataContainer().set(SEAT_KEY, PersistentDataType.STRING, entityId);
+            }
             if (hasEvolution())
                 frame.getPersistentDataContainer().set(EVOLUTION_KEY, PersistentDataType.INTEGER, 0);
         });
@@ -223,8 +226,10 @@ public class FurnitureMechanic extends Mechanic {
                 Block block = sideLocation.getBlock();
                 PersistentDataContainer data = new CustomBlockData(block, OraxenPlugin.get());
                 data.set(FURNITURE_KEY, PersistentDataType.STRING, getItemID());
-                if (hasSeat())
+                if (hasSeat()) {
+                    String entityId = spawnSeat(this, block, seatYaw);
                     data.set(SEAT_KEY, PersistentDataType.STRING, entityId);
+                }
                 data.set(ROOT_KEY, PersistentDataType.STRING, new BlockLocation(location).toString());
                 data.set(ORIENTATION_KEY, PersistentDataType.FLOAT, yaw);
                 block.setType(Material.BARRIER, false);
@@ -244,6 +249,13 @@ public class FurnitureMechanic extends Mechanic {
                 getBarriers())) {
             if (light != -1)
                 WrappedLightAPI.removeBlockLight(location);
+            if (hasSeat()) {
+                ArmorStand seat = getSeat(location);
+                 if(seat != null && seat.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
+                     seat.getPassengers().clear();
+                     seat.remove();
+                 }
+            }
             location.getBlock().setType(Material.AIR);
         }
 
@@ -258,8 +270,7 @@ public class FurnitureMechanic extends Mechanic {
                     Entity stand = Bukkit.getEntity(UUID.fromString(entity.getPersistentDataContainer()
                             .get(SEAT_KEY, PersistentDataType.STRING)));
                     if (stand != null) {
-                        for (Entity passenger : stand.getPassengers())
-                            stand.removePassenger(passenger);
+                        stand.getPassengers().clear();
                         stand.remove();
                     }
                 }
@@ -329,4 +340,24 @@ public class FurnitureMechanic extends Mechanic {
         return !clickActions.isEmpty();
     }
 
+    private String spawnSeat(FurnitureMechanic mechanic, Block target, float yaw) {
+        if (mechanic.hasSeat()) {
+            final ArmorStand seat = target.getWorld().spawn(target.getLocation()
+                    .add(0.5, mechanic.getSeatHeight() - 1, 0.5), ArmorStand.class, (ArmorStand stand) -> {
+                stand.setVisible(false);
+                stand.setRotation(yaw, 0);
+                stand.setInvulnerable(true);
+                stand.setPersistent(true);
+                stand.setAI(false);
+                stand.setCollidable(false);
+                stand.setGravity(false);
+                stand.setSilent(true);
+                stand.setCustomNameVisible(false);
+                stand.getPersistentDataContainer().set(FURNITURE_KEY, PersistentDataType.STRING, mechanic.getItemID());
+                stand.getPersistentDataContainer().set(SEAT_KEY, PersistentDataType.STRING, stand.getUniqueId().toString());
+            });
+            return seat.getUniqueId().toString();
+        }
+        return null;
+    }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -108,6 +108,8 @@ public class StringBlockMechanicListener implements Listener {
                 .getBlockMechanic(StringBlockMechanicFactory.getCode(tripwire));
         if (stringBlockMechanic == null)
             return;
+        event.setCancelled(true);
+        block.setType(Material.AIR, false);
         if (stringBlockMechanic.hasBreakSound())
             block.getWorld().playSound(block.getLocation(), stringBlockMechanic.getBreakSound(), 1.0f, 0.8f);
         if (stringBlockMechanic.getLight() != -1)


### PR DESCRIPTION
Main feature is the addition of multiple seat support.
Currently it spawns a new saeat wherever the furniture has a barrierblock
Was unsure if it should be a separate map of BlockLocation or what. [Examples](https://discord.com/channels/480068531132563476/589036101411274765/964656568283045958)
If you want it changed I can do so

https://user-images.githubusercontent.com/62521371/163673368-488aac54-3c90-4633-ae2b-1349f532cced.mp4


Also fixes placing furniture on custom blocks

https://user-images.githubusercontent.com/62521371/163673371-59273c51-cc4c-4075-85bd-3279fbaafd9a.mp4


And Tripwire breaking bug.

https://user-images.githubusercontent.com/62521371/163673374-ba5250e6-a097-477f-ab3d-7434660d117a.mp4


