### PR TITLE
fix various unintended custom block bugs

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -13,10 +13,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -24,6 +21,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -205,6 +203,15 @@ public class FurnitureListener implements Listener {
                         mechanic.getDrop().spawns(frame.getLocation(), player.getInventory().getItemInMainHand());
                 }
             }
+    }
+
+    @EventHandler
+    public void onProjectileHitFurniture(final ProjectileHitEvent event) {
+        if (event.getHitEntity() instanceof ItemFrame frame) {
+            if (frame.getPersistentDataContainer().has(FURNITURE_KEY, PersistentDataType.STRING)) {
+                event.setCancelled(true);
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -27,6 +27,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -55,15 +56,18 @@ public class FurnitureListener implements Listener {
             public void breakBlock(final Player player, final Block block, final ItemStack tool) {
                 Bukkit.getScheduler().runTask(OraxenPlugin.get(), () -> {
                     final PersistentDataContainer customBlockData = new CustomBlockData(block, OraxenPlugin.get());
-                    if (!customBlockData.has(FURNITURE_KEY, PersistentDataType.STRING))
-                        return;
+                    if (!customBlockData.has(FURNITURE_KEY, PersistentDataType.STRING)) return;
+
                     final String mechanicID = customBlockData.get(FURNITURE_KEY, PersistentDataType.STRING);
                     final FurnitureMechanic mechanic = (FurnitureMechanic) factory.getMechanic(mechanicID);
-                    final BlockLocation rootBlockLocation = new BlockLocation(customBlockData.get(ROOT_KEY,
-                            PersistentDataType.STRING));
+                    final ItemFrame frame = mechanic.getItemFrame(block.getLocation());
+                    final BlockLocation rootBlockLocation =
+                            new BlockLocation(customBlockData.get(ROOT_KEY, PersistentDataType.STRING));
+
                     if (mechanic.removeSolid(block.getWorld(), rootBlockLocation, customBlockData
-                            .get(ORIENTATION_KEY, PersistentDataType.FLOAT)))
-                        mechanic.getDrop().spawns(block.getLocation(), tool);
+                            .get(ORIENTATION_KEY, PersistentDataType.FLOAT))) {
+                        mechanic.getDrop().furnitureSpawns(frame, tool);
+                    }
                 });
             }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -356,4 +356,19 @@ public class FurnitureMechanic extends Mechanic {
         }
         return null;
     }
+
+    public ItemFrame getItemFrame(Location location) {
+        if (hasBarriers()) {
+            for (Location sideLocation : getLocations(location.getYaw(), location, getBarriers())) {
+                for (Entity entity : sideLocation.getWorld().getNearbyEntities(location, 1, 1, 1))
+                    if (entity instanceof ItemFrame frame
+                            && entity.getLocation().getBlockX() == location.getBlockX()
+                            && entity.getLocation().getBlockY() == location.getBlockY()
+                            && entity.getLocation().getBlockZ() == location.getBlockZ()
+                            && entity.getPersistentDataContainer().has(FURNITURE_KEY, PersistentDataType.STRING))
+                        return frame;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/io/th0rgal/oraxen/utils/drops/Drop.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/drops/Drop.java
@@ -117,12 +117,12 @@ public class Drop {
         if (!canDrop(itemInHand))
             return;
 
+        ItemStack drop = OraxenItems.getItemById(sourceID).build();
         if (frame.getItem().getItemMeta() instanceof LeatherArmorMeta) {
-            ItemStack drop = OraxenItems.getItemById(sourceID).build();
             ItemMeta meta = drop.getItemMeta().clone();
             ((LeatherArmorMeta)(meta)).setColor(((LeatherArmorMeta) frame.getItem().getItemMeta()).getColor());
             drop.setItemMeta(meta);
-            frame.getLocation().getWorld().dropItemNaturally(frame.getLocation(), drop);
         }
+        frame.getLocation().getWorld().dropItemNaturally(frame.getLocation(), drop);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/utils/drops/Drop.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/drops/Drop.java
@@ -3,9 +3,15 @@ package io.th0rgal.oraxen.utils.drops;
 import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.provided.misc.itemtype.ItemTypeMechanic;
 import io.th0rgal.oraxen.mechanics.provided.misc.itemtype.ItemTypeMechanicFactory;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.material.Colorable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -104,6 +110,19 @@ public class Drop {
 
         for (Loot loot : loots) {
             loot.dropNaturally(location, fortuneMultiplier);
+        }
+    }
+
+    public void furnitureSpawns(ItemFrame frame, ItemStack itemInHand) {
+        if (!canDrop(itemInHand))
+            return;
+
+        if (frame.getItem().getItemMeta() instanceof LeatherArmorMeta) {
+            ItemStack drop = OraxenItems.getItemById(sourceID).build();
+            ItemMeta meta = drop.getItemMeta().clone();
+            ((LeatherArmorMeta)(meta)).setColor(((LeatherArmorMeta) frame.getItem().getItemMeta()).getColor());
+            drop.setItemMeta(meta);
+            frame.getLocation().getWorld().dropItemNaturally(frame.getLocation(), drop);
         }
     }
 }


### PR DESCRIPTION
Closes #274 
Fixes #253 

**Fixes issue with projectiles destroying furniture items.**
Specifically checks ProjectileHitEvent as compared to EntityDamageByEntity event it cancels collision not damage, thus you can pick up the arrow again, like normal vanilla interaction


https://user-images.githubusercontent.com/62521371/163677912-f7db628c-d6b2-49aa-b6fa-a4ce30897ed7.mp4

**Fixes explosions dropping non-custom variant of a block.** 
Bases the drop as if player broke it with their hand, meaning ores will not drop

https://user-images.githubusercontent.com/62521371/163712398-5aac3ed9-bb0e-4bd7-887a-f11c8ee38f08.mp4


**Fixed recently found bug when breaking dyed furniture.**
Now it will drop the actual color that was on said furniture, and not base it on the config version of the item.


https://user-images.githubusercontent.com/62521371/163712430-91414bf3-fb12-4d54-a6fc-a950e3f1b1d4.mp4





