### PR TITLE
emote tabcompletion support

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -34,6 +34,7 @@ public class CommandsManager {
                 .withSubcommand((new RecipesCommand()).getRecipesCommand())
                 .withSubcommand((new ReloadCommand()).getReloadCommand())
                 .withSubcommand((new DebugCommand()).getDebugCommand())
+                .withSubcommand((new GlyphCommand()).getGlyphCommand())
                 .executes((sender, args) -> {
                     Message.COMMAND_HELP.send(sender);
                 })

--- a/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
@@ -1,0 +1,53 @@
+package io.th0rgal.oraxen.commands;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.ArgumentSuggestions;
+import dev.jorel.commandapi.arguments.TextArgument;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.font.Glyph;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.bukkit.inventory.meta.BookMeta.Generation.ORIGINAL;
+
+public class GlyphCommand {
+
+    public CommandAPICommand getGlyphCommand() {
+        return new CommandAPICommand("emoji")
+                .withPermission("oraxen.command.emoji")
+                .withArguments(new TextArgument("type").replaceSuggestions(
+                        ArgumentSuggestions.strings("list")))
+                .executes((sender, args) -> {
+                    Player player = ((Player) sender);
+                    List<Glyph> emojis = OraxenPlugin.get().getFontManager().getEmojis().stream().filter(glyph -> glyph.hasPermission(player)).toList();
+                    List<String> list = new ArrayList<>();
+
+                    ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
+                    BookMeta meta = (BookMeta) book.getItemMeta();
+                    if (meta == null || emojis.isEmpty()) return;
+
+                    meta.setTitle("Glyph Book");
+                    meta.setAuthor("Oraxen");
+                    meta.setGeneration(ORIGINAL);
+                    int s = 0;
+                    for (int p = 0; p < 50; p++) {
+                        for (int i = 0; i < 256; i++) {
+                            s = p * 256 + i + 1;
+                            if (emojis.size() < s) break;
+                            list.add(String.valueOf(emojis.get(p * 256 + i).getCharacter()));
+                        }
+                        meta.addPage(ChatColor.WHITE + list.toString().replace("[", "").replace("]", "").replace(",", ""));
+                        list.clear();
+                        if (emojis.size() < s) break;
+                    }
+                    book.setItemMeta(meta);
+                    player.openBook(book);
+                });
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
@@ -5,6 +5,10 @@ import dev.jorel.commandapi.arguments.ArgumentSuggestions;
 import dev.jorel.commandapi.arguments.TextArgument;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.font.Glyph;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -14,6 +18,8 @@ import org.bukkit.inventory.meta.BookMeta;
 import java.util.ArrayList;
 import java.util.List;
 
+import static net.md_5.bungee.api.chat.ClickEvent.Action.SUGGEST_COMMAND;
+import static net.md_5.bungee.api.chat.HoverEvent.Action.SHOW_TEXT;
 import static org.bukkit.inventory.meta.BookMeta.Generation.ORIGINAL;
 
 public class GlyphCommand {
@@ -26,7 +32,10 @@ public class GlyphCommand {
                 .executes((sender, args) -> {
                     Player player = ((Player) sender);
                     List<Glyph> emojis = OraxenPlugin.get().getFontManager().getEmojis().stream().filter(glyph -> glyph.hasPermission(player)).toList();
-                    List<String> list = new ArrayList<>();
+                    List<BaseComponent[]> list = new ArrayList<>();
+                    BaseComponent[] page;
+                    ComponentBuilder page2 = new ComponentBuilder("");
+                    int s;
 
                     ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
                     BookMeta meta = (BookMeta) book.getItemMeta();
@@ -35,17 +44,22 @@ public class GlyphCommand {
                     meta.setTitle("Glyph Book");
                     meta.setAuthor("Oraxen");
                     meta.setGeneration(ORIGINAL);
-                    int s = 0;
+                    pageLoop:
                     for (int p = 0; p < 50; p++) {
                         for (int i = 0; i < 256; i++) {
                             s = p * 256 + i + 1;
-                            if (emojis.size() < s) break;
-                            list.add(String.valueOf(emojis.get(p * 256 + i).getCharacter()));
+                            if (emojis.size() < s) break pageLoop;
+                            Glyph emoji = (emojis.get(p * 256 + i));
+                             page = new ComponentBuilder(ChatColor.WHITE + String.valueOf(emoji.getCharacter()))
+                                    .event(new ClickEvent(SUGGEST_COMMAND, String.valueOf(emoji.getCharacter())))
+                                    .event(new HoverEvent(SHOW_TEXT, new ComponentBuilder(":"+emoji.getName()+":").create()))
+                                    .create();
+                             list.add(page);
                         }
-                        meta.addPage(ChatColor.WHITE + list.toString().replace("[", "").replace("]", "").replace(",", ""));
-                        list.clear();
-                        if (emojis.size() < s) break;
                     }
+                    for (BaseComponent[] b : list)
+                        page2.append(b);
+                    meta.spigot().setPages(page2.create());
                     book.setItemMeta(meta);
                     player.openBook(book);
                 });

--- a/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
@@ -63,7 +63,7 @@ public class ReloadCommand {
                             OraxenPlugin.get().getInvManager().regen();
                         }
                     }
-                    //TODO Make this actually clear tablist
+                    // This does not clear the tablist and I am not sure how to do it otherwise
                     FontManager manager = new FontManager(OraxenPlugin.get().getConfigsManager());
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         manager.sendGlyphTabCompletion(player, false);

--- a/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
@@ -1,5 +1,7 @@
 package io.th0rgal.oraxen.commands;
 
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketContainer;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.ArgumentSuggestions;
 import dev.jorel.commandapi.arguments.TextArgument;
@@ -15,6 +17,9 @@ import net.kyori.adventure.text.minimessage.Template;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.UUID;
 
 public class ReloadCommand {
 
@@ -39,10 +44,6 @@ public class ReloadCommand {
                 .withArguments(new TextArgument("type").replaceSuggestions(
                         ArgumentSuggestions.strings("items", "pack", "recipes", "messages", "all")))
                 .executes((sender, args) -> {
-                    FontManager manager = new FontManager(OraxenPlugin.get().getConfigsManager());
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        manager.sendGlyphTabCompletion(player);
-                    }
                     switch (((String) args[0]).toUpperCase()) {
                         case "ITEMS" -> {
                             reloadItems(sender);
@@ -61,6 +62,11 @@ public class ReloadCommand {
                             RecipesManager.reload(oraxen);
                             OraxenPlugin.get().getInvManager().regen();
                         }
+                    }
+                    //TODO Make this actually clear tablist
+                    FontManager manager = new FontManager(OraxenPlugin.get().getConfigsManager());
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        manager.sendGlyphTabCompletion(player, false);
                     }
                 });
     }

--- a/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
@@ -4,6 +4,7 @@ import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.ArgumentSuggestions;
 import dev.jorel.commandapi.arguments.TextArgument;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.config.ConfigsManager;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.font.FontManager;
 import io.th0rgal.oraxen.items.OraxenItems;
@@ -11,7 +12,9 @@ import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.recipes.RecipesManager;
 import io.th0rgal.oraxen.sound.SoundManager;
 import net.kyori.adventure.text.minimessage.Template;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 public class ReloadCommand {
 
@@ -36,6 +39,10 @@ public class ReloadCommand {
                 .withArguments(new TextArgument("type").replaceSuggestions(
                         ArgumentSuggestions.strings("items", "pack", "recipes", "messages", "all")))
                 .executes((sender, args) -> {
+                    FontManager manager = new FontManager(OraxenPlugin.get().getConfigsManager());
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        manager.sendGlyphTabCompletion(player);
+                    }
                     switch (((String) args[0]).toUpperCase()) {
                         case "ITEMS" -> {
                             reloadItems(sender);

--- a/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -63,6 +63,6 @@ public class FontEvents implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        manager.sendGlyphTabCompletion(event.getPlayer());
+        manager.sendGlyphTabCompletion(event.getPlayer(), true);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -63,27 +63,6 @@ public class FontEvents implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-            if (entry.getValue().hasTabCompletion()) {
-                ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
-                PacketContainer packet = protocolManager.createPacket(PacketType.Play.Server.PLAYER_INFO);
-                packet.getPlayerInfoAction().write(0, EnumWrappers.PlayerInfoAction.ADD_PLAYER);
-
-                PlayerInfoData data = new PlayerInfoData( new WrappedGameProfile(
-                        entry.getValue().getTabIcon(), String.valueOf(entry.getValue().getCharacter()))
-                        , 0, EnumWrappers.NativeGameMode.SPECTATOR,
-                        WrappedChatComponent.fromText(""));
-
-                List<PlayerInfoData> dataList = new ArrayList<>();
-                dataList.add(data);
-                packet.getPlayerInfoDataLists().write(0, dataList);
-
-                try {
-                    protocolManager.sendServerPacket(event.getPlayer(), packet);
-                } catch (InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
+        manager.sendGlyphTabCompletion(event.getPlayer());
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -1,12 +1,22 @@
 package io.th0rgal.oraxen.font;
 
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.EnumWrappers;
+import com.comphenix.protocol.wrappers.PlayerInfoData;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
+import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.ConfigsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public class FontManager {
@@ -98,4 +108,28 @@ public class FontManager {
         return output.toString();
     }
 
+    public void sendGlyphTabCompletion(Player player) {
+        for (Map.Entry<String, Glyph> entry : getGlyphByPlaceholderMap().entrySet()) {
+            if (entry.getValue().hasTabCompletion()) {
+                ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
+                PacketContainer packet = protocolManager.createPacket(PacketType.Play.Server.PLAYER_INFO);
+                packet.getPlayerInfoAction().write(0, EnumWrappers.PlayerInfoAction.ADD_PLAYER);
+
+                PlayerInfoData data = new PlayerInfoData( new WrappedGameProfile(
+                        entry.getValue().getTabIcon(), " " + entry.getValue().getCharacter())
+                        , 0, EnumWrappers.NativeGameMode.SPECTATOR,
+                        WrappedChatComponent.fromText(""));
+
+                List<PlayerInfoData> dataList = new ArrayList<>();
+                dataList.add(data);
+                packet.getPlayerInfoDataLists().write(0, dataList);
+
+                try {
+                    protocolManager.sendServerPacket(player, packet);
+                } catch (InvocationTargetException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -8,7 +8,6 @@ import com.comphenix.protocol.wrappers.*;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.ConfigsManager;
 import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -73,6 +72,10 @@ public class FontManager {
 
     public final Collection<Glyph> getGlyphs() {
         return glyphMap.values();
+    }
+
+    public final Collection<Glyph> getEmojis() {
+        return glyphMap.values().stream().filter(Glyph::hasTabCompletion).toList();
     }
 
     public final Collection<Font> getFonts() {

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -4,13 +4,11 @@ import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.wrappers.EnumWrappers;
-import com.comphenix.protocol.wrappers.PlayerInfoData;
-import com.comphenix.protocol.wrappers.WrappedChatComponent;
-import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.*;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.ConfigsManager;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -108,15 +106,28 @@ public class FontManager {
         return output.toString();
     }
 
-    public void sendGlyphTabCompletion(Player player) {
+    public void sendGlyphTabCompletion(Player player, Boolean addPlayers) {
         for (Map.Entry<String, Glyph> entry : getGlyphByPlaceholderMap().entrySet()) {
             if (entry.getValue().hasTabCompletion()) {
                 ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
                 PacketContainer packet = protocolManager.createPacket(PacketType.Play.Server.PLAYER_INFO);
-                packet.getPlayerInfoAction().write(0, EnumWrappers.PlayerInfoAction.ADD_PLAYER);
 
-                PlayerInfoData data = new PlayerInfoData( new WrappedGameProfile(
-                        entry.getValue().getTabIcon(), " " + entry.getValue().getCharacter())
+                if (addPlayers) packet.getPlayerInfoAction().write(0, EnumWrappers.PlayerInfoAction.ADD_PLAYER);
+                else {
+                    packet.getPlayerInfoAction().write(0, EnumWrappers.PlayerInfoAction.REMOVE_PLAYER);
+                }
+
+                final WrappedGameProfile profile = new WrappedGameProfile(
+                        UUID.randomUUID(), " " + entry.getValue().getCharacter());
+
+                if (entry.getValue().getTabIconTexture() != null && entry.getValue().getTabIconSignature() != null)
+                    profile.getProperties().put("textures",
+                            new WrappedSignedProperty(
+                                    "textures",
+                                    entry.getValue().getTabIconTexture(),
+                                    entry.getValue().getTabIconSignature()));
+
+                PlayerInfoData data = new PlayerInfoData(profile
                         , 0, EnumWrappers.NativeGameMode.SPECTATOR,
                         WrappedChatComponent.fromText(""));
 

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -75,7 +75,7 @@ public class FontManager {
     }
 
     public final Collection<Glyph> getEmojis() {
-        return glyphMap.values().stream().filter(Glyph::hasTabCompletion).toList();
+        return glyphMap.values().stream().filter(Glyph::isEmoji).toList();
     }
 
     public final Collection<Font> getFonts() {

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -13,6 +13,7 @@ public class Glyph {
     private boolean fileChanged = false;
 
     private final String name;
+    private final boolean isEmoji;
     private boolean tabcomplete;
     private String tabIconTexture;
     private String tabIconSignature;
@@ -27,6 +28,7 @@ public class Glyph {
     public Glyph(final String glyphName, final ConfigurationSection glyphSection, int newCode) {
         name = glyphName;
         placeholders = new String[0];
+        isEmoji = glyphSection.getBoolean("is_emoji", false);
         if (glyphSection.isConfigurationSection("chat")) {
             final ConfigurationSection chatSection = glyphSection.getConfigurationSection("chat");
             placeholders = chatSection.getStringList("placeholders").toArray(new String[0]);
@@ -35,8 +37,8 @@ public class Glyph {
             if (chatSection.isBoolean("tabcomplete"))
                 tabcomplete = chatSection.getBoolean("tabcomplete");
             else tabcomplete = false;
-            tabIconTexture = chatSection.getString("tabIconTexture", "ewogICJ0aW1lc3RhbXAiIDogMTY0ODI4NzUzMTA4NywKICAicHJvZmlsZUlkIiA6ICJhYzM2YmVkZGQxNGQ0YjVmYmQyYzc5OThlMWMwOTg3ZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJtYWlzYWthIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU3ZGRlMGExN2MwNDY4MzI0MGIyNzJlYjJkODk1NWY4NzRiM2ExMTIyNTkxNjMwMGZlM2U4ODhkZjI4YjI4ZDciCiAgICB9CiAgfQp9");
-            tabIconSignature = chatSection.getString("tabIconSignature", "ScFX2rWxyhSyIn3YIke0ecNezt0bx+K8fRLQVPAzNli+X/dmod9ohujwwmDyog0exnlDAdEtXJY2XEUELpNLBHYZFyMsUChL4MObACzxGXExRBbyE8NzemmcRePKmglJfIHBxATlvG3VXeNn1dNA9g+GgLAB4KdqlDaYO5qAtdET7rckzLhSVeFz3yct3LuqZwzutdkJIbnR2Bu9kM4IpyowDbBEoASUp2ogNq4bQ+9O7cU7PtayknPGJaustHQR32jVcLYNqGweZKjZZUgER+6XrGAwyuWENQ00UpEWanHa2ahBugxzg1atcgc3spx3FxWLN0bVsUj4oXulPhxD4/44jALhHl7898qXwoRhqGaAuombJRH/bMoyoTZUDgcxmTbWFZcos9Ugg6eBlQo7ip35mW7fyd/8rk6RCGyf/wmqyDUnFNUHeQgJHHED+yr2oN/Y4jzCmG5Ikk1RExpi2Mbi7ouZx3bKzkTsEafGdnx8sMxenRCYFtcoQCcV4woQsk7xqqJyBVFiU4wXzHzMnbOhiRPJHlcqzJljFw2LuI97f8vlQGpW5KriFUWLSgKs1Zw4QOIdl5cv/oSZOvEAoi0s5EOB4rzVVE1XXLatYWOaRXy6Nbl8c9SH8UbkhcK5t+J54UIsvvuqq8AoDOX6yyw/wDORVlTaqy7pVXKZSQk=");
+            tabIconTexture = chatSection.getString("tab_icon_texture", "ewogICJ0aW1lc3RhbXAiIDogMTY0ODI4NzUzMTA4NywKICAicHJvZmlsZUlkIiA6ICJhYzM2YmVkZGQxNGQ0YjVmYmQyYzc5OThlMWMwOTg3ZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJtYWlzYWthIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU3ZGRlMGExN2MwNDY4MzI0MGIyNzJlYjJkODk1NWY4NzRiM2ExMTIyNTkxNjMwMGZlM2U4ODhkZjI4YjI4ZDciCiAgICB9CiAgfQp9");
+            tabIconSignature = chatSection.getString("tab_icon_signature", "ScFX2rWxyhSyIn3YIke0ecNezt0bx+K8fRLQVPAzNli+X/dmod9ohujwwmDyog0exnlDAdEtXJY2XEUELpNLBHYZFyMsUChL4MObACzxGXExRBbyE8NzemmcRePKmglJfIHBxATlvG3VXeNn1dNA9g+GgLAB4KdqlDaYO5qAtdET7rckzLhSVeFz3yct3LuqZwzutdkJIbnR2Bu9kM4IpyowDbBEoASUp2ogNq4bQ+9O7cU7PtayknPGJaustHQR32jVcLYNqGweZKjZZUgER+6XrGAwyuWENQ00UpEWanHa2ahBugxzg1atcgc3spx3FxWLN0bVsUj4oXulPhxD4/44jALhHl7898qXwoRhqGaAuombJRH/bMoyoTZUDgcxmTbWFZcos9Ugg6eBlQo7ip35mW7fyd/8rk6RCGyf/wmqyDUnFNUHeQgJHHED+yr2oN/Y4jzCmG5Ikk1RExpi2Mbi7ouZx3bKzkTsEafGdnx8sMxenRCYFtcoQCcV4woQsk7xqqJyBVFiU4wXzHzMnbOhiRPJHlcqzJljFw2LuI97f8vlQGpW5KriFUWLSgKs1Zw4QOIdl5cv/oSZOvEAoi0s5EOB4rzVVE1XXLatYWOaRXy6Nbl8c9SH8UbkhcK5t+J54UIsvvuqq8AoDOX6yyw/wDORVlTaqy7pVXKZSQk=");
         }
         texture = glyphSection.getString("texture");
         if (!texture.endsWith(".png"))
@@ -84,6 +86,8 @@ public class Glyph {
     public String[] getPlaceholders() {
         return placeholders;
     }
+
+    public boolean isEmoji() { return isEmoji; }
 
     public boolean hasTabCompletion() { return tabcomplete; }
 

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -4,9 +4,13 @@ package io.th0rgal.oraxen.font;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.config.Settings;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.bukkit.profile.PlayerProfile;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 
@@ -16,7 +20,8 @@ public class Glyph {
 
     private final String name;
     private boolean tabcomplete;
-    private String tabIcon;
+    private String tabIconTexture;
+    private String tabIconSignature;
     private final char character;
     private String texture;
     private final int ascent;
@@ -36,9 +41,12 @@ public class Glyph {
             if (chatSection.isBoolean("tabcomplete"))
                 tabcomplete = chatSection.getBoolean("tabcomplete");
             else tabcomplete = false;
-            if (chatSection.isString("tabIcon"))
-                tabIcon = chatSection.getString("tabIcon");
-            else tabIcon = String.valueOf(UUID.randomUUID());
+            if (chatSection.isString("tabIconTexture")) {
+                tabIconTexture = chatSection.getString("tabIconTexture");
+            } else tabIconTexture = null;
+            if (chatSection.isString("tabIconSignature")) {
+                tabIconSignature = chatSection.getString("tabIconSignature");
+            } else tabIconSignature = null;
         }
         texture = glyphSection.getString("texture");
         if (!texture.endsWith(".png"))
@@ -89,7 +97,13 @@ public class Glyph {
 
     public boolean hasTabCompletion() { return tabcomplete; }
 
-    public UUID getTabIcon() { return UUID.fromString(tabIcon); }
+    public String getTabIconTexture() {
+        return tabIconTexture;
+    }
+
+    public String getTabIconSignature() {
+        return tabIconSignature;
+    }
 
     public JsonObject toJson() {
         final JsonObject output = new JsonObject();

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -4,11 +4,10 @@ package io.th0rgal.oraxen.font;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.config.Settings;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
-import java.util.Map;
+import java.util.UUID;
 
 
 public class Glyph {
@@ -16,6 +15,8 @@ public class Glyph {
     private boolean fileChanged = false;
 
     private final String name;
+    private boolean tabcomplete;
+    private String tabIcon;
     private final char character;
     private String texture;
     private final int ascent;
@@ -32,6 +33,12 @@ public class Glyph {
             placeholders = chatSection.getStringList("placeholders").toArray(new String[0]);
             if (chatSection.isString("permission"))
                 permission = chatSection.getString("permission");
+            if (chatSection.isBoolean("tabcomplete"))
+                tabcomplete = chatSection.getBoolean("tabcomplete");
+            else tabcomplete = false;
+            if (chatSection.isString("tabIcon"))
+                tabIcon = chatSection.getString("tabIcon");
+            else tabIcon = String.valueOf(UUID.randomUUID());
         }
         texture = glyphSection.getString("texture");
         if (!texture.endsWith(".png"))
@@ -79,6 +86,10 @@ public class Glyph {
     public String[] getPlaceholders() {
         return placeholders;
     }
+
+    public boolean hasTabCompletion() { return tabcomplete; }
+
+    public UUID getTabIcon() { return UUID.fromString(tabIcon); }
 
     public JsonObject toJson() {
         final JsonObject output = new JsonObject();

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -4,14 +4,8 @@ package io.th0rgal.oraxen.font;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.config.Settings;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.profile.PlayerProfile;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 
 public class Glyph {
@@ -41,12 +35,8 @@ public class Glyph {
             if (chatSection.isBoolean("tabcomplete"))
                 tabcomplete = chatSection.getBoolean("tabcomplete");
             else tabcomplete = false;
-            if (chatSection.isString("tabIconTexture")) {
-                tabIconTexture = chatSection.getString("tabIconTexture");
-            } else tabIconTexture = null;
-            if (chatSection.isString("tabIconSignature")) {
-                tabIconSignature = chatSection.getString("tabIconSignature");
-            } else tabIconSignature = null;
+            tabIconTexture = chatSection.getString("tabIconTexture", "ewogICJ0aW1lc3RhbXAiIDogMTY0ODI4NzUzMTA4NywKICAicHJvZmlsZUlkIiA6ICJhYzM2YmVkZGQxNGQ0YjVmYmQyYzc5OThlMWMwOTg3ZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJtYWlzYWthIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU3ZGRlMGExN2MwNDY4MzI0MGIyNzJlYjJkODk1NWY4NzRiM2ExMTIyNTkxNjMwMGZlM2U4ODhkZjI4YjI4ZDciCiAgICB9CiAgfQp9");
+            tabIconSignature = chatSection.getString("tabIconSignature", "ScFX2rWxyhSyIn3YIke0ecNezt0bx+K8fRLQVPAzNli+X/dmod9ohujwwmDyog0exnlDAdEtXJY2XEUELpNLBHYZFyMsUChL4MObACzxGXExRBbyE8NzemmcRePKmglJfIHBxATlvG3VXeNn1dNA9g+GgLAB4KdqlDaYO5qAtdET7rckzLhSVeFz3yct3LuqZwzutdkJIbnR2Bu9kM4IpyowDbBEoASUp2ogNq4bQ+9O7cU7PtayknPGJaustHQR32jVcLYNqGweZKjZZUgER+6XrGAwyuWENQ00UpEWanHa2ahBugxzg1atcgc3spx3FxWLN0bVsUj4oXulPhxD4/44jALhHl7898qXwoRhqGaAuombJRH/bMoyoTZUDgcxmTbWFZcos9Ugg6eBlQo7ip35mW7fyd/8rk6RCGyf/wmqyDUnFNUHeQgJHHED+yr2oN/Y4jzCmG5Ikk1RExpi2Mbi7ouZx3bKzkTsEafGdnx8sMxenRCYFtcoQCcV4woQsk7xqqJyBVFiU4wXzHzMnbOhiRPJHlcqzJljFw2LuI97f8vlQGpW5KriFUWLSgKs1Zw4QOIdl5cv/oSZOvEAoi0s5EOB4rzVVE1XXLatYWOaRXy6Nbl8c9SH8UbkhcK5t+J54UIsvvuqq8AoDOX6yyw/wDORVlTaqy7pVXKZSQk=");
         }
         texture = glyphSection.getString("texture");
         if (!texture.endsWith(".png"))


### PR DESCRIPTION
To my knowledge this is the best we could do.
It is rather annoying that it requires a fake player that cant be removed from the tablist but
Added option to let people specify the playericon it should use to help abit

![image](https://user-images.githubusercontent.com/62521371/163696384-3d9ae2ba-6728-4ca5-b085-955114bf2c15.png)

![image](https://user-images.githubusercontent.com/62521371/163696387-63875389-837b-4866-ab98-57c9eff69a28.png)

Config example:
```yml
heart:
  texture: default/chat/heart
  ascent: 8
  height: 8
  chat:
    tabcomplete: true
    tabIcon: c6307390-acda-48f8-8584-42087ad918f4
    placeholders:
      - "<3"
    permission: "oraxen.emoji.heart"