### PR TITLE
More farming mechanics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ repositories {
     // CodeMc (bstats)
     maven { url 'https://repo.codemc.org/repository/maven-public' }
     // CustomBlockData
-    maven { url 'https://hub.jeff-media.com/nexus/repository/jeff-media-public' }
+    maven { url 'https://hub.jeff-media.com/nexus/repository/jeff-media-public/' }
     // actions-code, actions-spigot
     maven { url 'https://repo.triumphteam.dev/snapshots' }
     // MythicMobs
@@ -75,7 +75,7 @@ dependencies {
     implementation group: 'net.kyori', name: 'adventure-platform-bukkit', version: '4.0.0'
     implementation group: 'com.github.stefvanschie.inventoryframework', name: 'IF', version: '0.10.0'
     implementation group: 'dev.jorel', name: 'commandapi-shade', version: '7.0.0'
-    implementation group: 'de.jeff_media', name: 'CustomBlockData', version: '1.0.1'
+    implementation "com.jeff_media:CustomBlockData:1.0.5"
 
     implementation(group: 'me.gabytm.util', name: 'actions-spigot', version: actionsVersion) { exclude group: 'com.google.guava' }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -17,6 +17,7 @@ import io.th0rgal.oraxen.mechanics.provided.farming.bigmining.BigMiningMechanicF
 import io.th0rgal.oraxen.mechanics.provided.farming.bottledexp.BottledExpMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.farming.harvesting.HarvestingMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.farming.smelting.SmeltingMechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.farming.watering.WateringMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.durability.DurabilityMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
@@ -86,6 +87,7 @@ public class MechanicsManager {
         registerMechanicFactory("smelting", SmeltingMechanicFactory::new);
         registerMechanicFactory("bottledexp", BottledExpMechanicFactory::new);
         registerMechanicFactory("harvesting", HarvestingMechanicFactory::new);
+        registerMechanicFactory("watering", WateringMechanicFactory::new);
         if (CompatibilitiesManager.hasPlugin("ProtocolLib"))
             registerMechanicFactory("bedrockbreak", BedrockBreakMechanicFactory::new);
     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
@@ -6,20 +6,20 @@ import org.bukkit.configuration.ConfigurationSection;
 
 public class WateringMechanic extends Mechanic {
 
-    private final boolean isWateringCan;
-    private final int uses;
-    private final String remainingUsesGlyph;
+    private final String emptyCanItem;
+    private final String filledCanItem;
 
     public WateringMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
         super(mechanicFactory, section);
-        isWateringCan = section.getBoolean("isWaterCan", false);
-        uses = section.getInt("uses", 1);
-        remainingUsesGlyph = section.getString("remainingUsesGlyph");
+        emptyCanItem = section.getString("emptyCanItem");
+        filledCanItem = section.getString("filledCanItem");
     }
 
-    public boolean isWateringCan() { return this.isWateringCan; }
+    public boolean isEmpty() { return (emptyCanItem == null && filledCanItem != null); }
 
-    public int getUses() { return uses; }
+    public boolean isFilled() { return (filledCanItem == null && emptyCanItem != null); }
 
-    public String getRemainingUseGlyph() { return remainingUsesGlyph; }
+    public String getEmptyCanItem() { return this.emptyCanItem; }
+
+    public String getFilledCanItem() { return this.filledCanItem; }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
@@ -1,0 +1,17 @@
+package io.th0rgal.oraxen.mechanics.provided.farming.watering;
+
+import io.th0rgal.oraxen.mechanics.Mechanic;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import org.bukkit.configuration.ConfigurationSection;
+
+public class WateringMechanic extends Mechanic {
+
+    private final boolean isWateringCan;
+
+    public WateringMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
+        super(mechanicFactory, section);
+        isWateringCan = section.getBoolean("isWaterCan");
+    }
+
+    public boolean isWateringCan() { return this.isWateringCan; }
+}

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
@@ -10,7 +10,7 @@ public class WateringMechanic extends Mechanic {
 
     public WateringMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
         super(mechanicFactory, section);
-        isWateringCan = section.getBoolean("isWaterCan");
+        isWateringCan = section.getBoolean("isWaterCan", false);
     }
 
     public boolean isWateringCan() { return this.isWateringCan; }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanic.java
@@ -7,11 +7,19 @@ import org.bukkit.configuration.ConfigurationSection;
 public class WateringMechanic extends Mechanic {
 
     private final boolean isWateringCan;
+    private final int uses;
+    private final String remainingUsesGlyph;
 
     public WateringMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
         super(mechanicFactory, section);
         isWateringCan = section.getBoolean("isWaterCan", false);
+        uses = section.getInt("uses", 1);
+        remainingUsesGlyph = section.getString("remainingUsesGlyph");
     }
 
     public boolean isWateringCan() { return this.isWateringCan; }
+
+    public int getUses() { return uses; }
+
+    public String getRemainingUseGlyph() { return remainingUsesGlyph; }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicFactory.java
@@ -8,9 +8,12 @@ import org.bukkit.configuration.ConfigurationSection;
 
 public class WateringMechanicFactory extends MechanicFactory {
 
+    private static WateringMechanicFactory instance;
+
     public WateringMechanicFactory(ConfigurationSection section) {
         super(section);
         MechanicsManager.registerListeners(OraxenPlugin.get(), new WateringMechanicListener(this));
+        instance = this;
     }
 
     @Override
@@ -19,4 +22,6 @@ public class WateringMechanicFactory extends MechanicFactory {
         addToImplemented(mechanic);
         return mechanic;
     }
+
+    public static WateringMechanicFactory get() { return instance; }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicFactory.java
@@ -1,0 +1,22 @@
+package io.th0rgal.oraxen.mechanics.provided.farming.watering;
+
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.mechanics.Mechanic;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import org.bukkit.configuration.ConfigurationSection;
+
+public class WateringMechanicFactory extends MechanicFactory {
+
+    public WateringMechanicFactory(ConfigurationSection section) {
+        super(section);
+        MechanicsManager.registerListeners(OraxenPlugin.get(), new WateringMechanicListener(this));
+    }
+
+    @Override
+    public Mechanic parse(ConfigurationSection itemMechanicConfiguration) {
+        Mechanic mechanic = new WateringMechanic(this, itemMechanicConfiguration);
+        addToImplemented(mechanic);
+        return mechanic;
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
@@ -6,10 +6,9 @@ import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock.FarmBlockDryout;
-import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.block.Block;
+import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -32,6 +31,32 @@ public class WateringMechanicListener implements Listener {
         this.factory = factory;
     }
 
+    @EventHandler
+    public void onRefillCan(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        String itemId = OraxenItems.getIdByItem(item);
+        WateringMechanic mechanic = (WateringMechanic) factory.getMechanic(itemId);
+        Block block = event.getClickedBlock();
+        if (item.getType() == Material.AIR || factory.isNotImplementedIn(itemId) || !mechanic.isEmpty()) return;
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+
+        if (player.getTargetBlockExact(5, FluidCollisionMode.SOURCE_ONLY).getType() == Material.WATER) {
+            player.getInventory().setItemInMainHand(OraxenItems.getItemById(mechanic.getFilledCanItem()).build());
+            player.getWorld().playSound(player.getLocation(), Sound.ITEM_BUCKET_FILL, 1.0f, 1.0f);
+            Bukkit.broadcastMessage("test");
+        }
+
+        if (block.getType() == Material.WATER_CAULDRON) {
+            Levelled cauldron = (Levelled) block.getBlockData();
+            if (cauldron.getLevel() == 1) return;
+            cauldron.setLevel(cauldron.getLevel()-1);
+            block.setBlockData(cauldron);
+            player.getInventory().setItemInMainHand(OraxenItems.getItemById(mechanic.getFilledCanItem()).build());
+            player.getWorld().playSound(player.getLocation(), Sound.ITEM_BUCKET_FILL, 1.0f, 1.0f);
+        }
+    }
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void onWateringFarmBlock(PlayerInteractEvent event) {
         Player player = event.getPlayer();
@@ -39,7 +64,7 @@ public class WateringMechanicListener implements Listener {
         String itemId = OraxenItems.getIdByItem(item);
         WateringMechanic mechanic = (WateringMechanic) factory.getMechanic(itemId);
 
-        if (item.getType() == Material.AIR || factory.isNotImplementedIn(itemId) || !mechanic.isWateringCan()) return;
+        if (item.getType() == Material.AIR || factory.isNotImplementedIn(itemId) || !mechanic.isFilled()) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
         Block block = event.getClickedBlock();
@@ -50,15 +75,14 @@ public class WateringMechanicListener implements Listener {
 
             NoteBlockMechanicFactory.setBlockModel(block, farmMechanic.getMoistFarmBlock());
             farmBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, farmMechanic.getDryoutTime());
-        }
-
-        else if (block.getType() == Material.FARMLAND) {
+        } else if (block.getType() == Material.FARMLAND) {
             Farmland data = ((Farmland) block.getBlockData());
             if (data.getMoisture() == data.getMaximumMoisture()) return;
             data.setMoisture(data.getMaximumMoisture());
             block.setBlockData(data);
         } else return;
 
+        player.getInventory().setItemInMainHand(OraxenItems.getItemById(mechanic.getEmptyCanItem()).build());
         player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation().add(0.5, 1, 0.5), 40);
         player.getWorld().playSound(block.getLocation(), Sound.ITEM_BUCKET_EMPTY, 1.0f, 1.0f);
     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
@@ -20,7 +20,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
-import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.FARMBLOCK_KEY;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
 
 public class WateringMechanicListener implements Listener {
 
@@ -45,10 +45,10 @@ public class WateringMechanicListener implements Listener {
 
         if (!farmingBlockMechanic.isFarmBlock()) return;
         NoteBlockMechanicFactory.setBlockModel(block, farmingBlockMechanic.getMoistFarmBlock());
-        player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation(), 10);
-
         PersistentDataContainer farmBlockData = new CustomBlockData(block, OraxenPlugin.get());
         farmBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+
+        player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation(), 10);
     }
 
     private NoteBlockMechanic getNoteBlockMechanic(Block block) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
@@ -1,0 +1,52 @@
+package io.th0rgal.oraxen.mechanics.provided.farming.watering;
+
+import io.th0rgal.oraxen.items.OraxenItems;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
+import org.bukkit.Particle;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.type.NoteBlock;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class WateringMechanicListener implements Listener {
+
+    private final MechanicFactory factory;
+
+    public WateringMechanicListener(MechanicFactory factory) {
+        this.factory = factory;
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onWateringFarmBlock(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        String itemId = OraxenItems.getIdByItem(item);
+        WateringMechanic mechanic = (WateringMechanic) factory.getMechanic(itemId);
+
+        if (factory.isNotImplementedIn(itemId) || !mechanic.isWateringCan()) return;
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+
+        Block block = event.getClickedBlock();
+        NoteBlockMechanic farmingBlockMechanic = getNoteBlockMechanic(block);
+
+        if (!farmingBlockMechanic.isFarmBlock()) return;
+        NoteBlockMechanicFactory.setBlockModel(block, farmingBlockMechanic.getMoistFarmBlock());
+        player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation(), 10);
+
+    }
+
+    private NoteBlockMechanic getNoteBlockMechanic(Block block) {
+        final NoteBlock noteBlok = (NoteBlock) block.getBlockData();
+        return NoteBlockMechanicFactory
+                .getBlockMechanic((int) (noteBlok.getInstrument().getType()) * 25
+                        + (int) noteBlok.getNote().getId() + (noteBlok.isPowered() ? 400 : 0) - 26);
+    }
+
+}

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
@@ -1,9 +1,12 @@
 package io.th0rgal.oraxen.mechanics.provided.farming.watering;
 
+import de.jeff_media.customblockdata.CustomBlockData;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.NoteBlock;
@@ -14,6 +17,10 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.FARMBLOCK_KEY;
 
 public class WateringMechanicListener implements Listener {
 
@@ -30,7 +37,7 @@ public class WateringMechanicListener implements Listener {
         String itemId = OraxenItems.getIdByItem(item);
         WateringMechanic mechanic = (WateringMechanic) factory.getMechanic(itemId);
 
-        if (factory.isNotImplementedIn(itemId) || !mechanic.isWateringCan()) return;
+        if (item.getType() == Material.AIR || factory.isNotImplementedIn(itemId) || !mechanic.isWateringCan()) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
         Block block = event.getClickedBlock();
@@ -40,6 +47,8 @@ public class WateringMechanicListener implements Listener {
         NoteBlockMechanicFactory.setBlockModel(block, farmingBlockMechanic.getMoistFarmBlock());
         player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation(), 10);
 
+        PersistentDataContainer farmBlockData = new CustomBlockData(block, OraxenPlugin.get());
+        farmBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
     }
 
     private NoteBlockMechanic getNoteBlockMechanic(Block block) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
@@ -6,7 +6,10 @@ import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock.FarmBlockDryout;
-import org.bukkit.*;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.block.data.type.Farmland;
@@ -34,17 +37,17 @@ public class WateringMechanicListener implements Listener {
     @EventHandler
     public void onRefillCan(PlayerInteractEvent event) {
         Player player = event.getPlayer();
+        Block block = event.getClickedBlock();
         ItemStack item = player.getInventory().getItemInMainHand();
         String itemId = OraxenItems.getIdByItem(item);
         WateringMechanic mechanic = (WateringMechanic) factory.getMechanic(itemId);
-        Block block = event.getClickedBlock();
+
         if (item.getType() == Material.AIR || factory.isNotImplementedIn(itemId) || !mechanic.isEmpty()) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
         if (player.getTargetBlockExact(5, FluidCollisionMode.SOURCE_ONLY).getType() == Material.WATER) {
             player.getInventory().setItemInMainHand(OraxenItems.getItemById(mechanic.getFilledCanItem()).build());
             player.getWorld().playSound(player.getLocation(), Sound.ITEM_BUCKET_FILL, 1.0f, 1.0f);
-            Bukkit.broadcastMessage("test");
         }
 
         if (block.getType() == Material.WATER_CAULDRON) {
@@ -60,6 +63,7 @@ public class WateringMechanicListener implements Listener {
     @EventHandler(priority = EventPriority.NORMAL)
     public void onWateringFarmBlock(PlayerInteractEvent event) {
         Player player = event.getPlayer();
+        Block block = event.getClickedBlock();
         ItemStack item = player.getInventory().getItemInMainHand();
         String itemId = OraxenItems.getIdByItem(item);
         WateringMechanic mechanic = (WateringMechanic) factory.getMechanic(itemId);
@@ -67,9 +71,7 @@ public class WateringMechanicListener implements Listener {
         if (item.getType() == Material.AIR || factory.isNotImplementedIn(itemId) || !mechanic.isFilled()) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
-        Block block = event.getClickedBlock();
-
-        if (block.getType() == Material.NOTE_BLOCK && getNoteBlockMechanic(block).hasDryout()) {
+        if (block.getType() == Material.NOTE_BLOCK && getNoteBlockMechanic(block).hasDryout() && !getNoteBlockMechanic(block).getDryout().isMoistFarmBlock()) {
             FarmBlockDryout farmMechanic = getNoteBlockMechanic(block).getDryout();
             PersistentDataContainer farmBlockData = new CustomBlockData(block, OraxenPlugin.get());
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/watering/WateringMechanicListener.java
@@ -1,6 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.farming.watering;
 
-import de.jeff_media.customblockdata.CustomBlockData;
+import com.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
@@ -9,7 +9,6 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.type.NoteBlock;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -20,7 +19,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
+import java.util.Objects;
+
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
 
 public class WateringMechanicListener implements Listener {
 
@@ -41,21 +43,15 @@ public class WateringMechanicListener implements Listener {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
         Block block = event.getClickedBlock();
-        NoteBlockMechanic farmingBlockMechanic = getNoteBlockMechanic(block);
-
-        if (!farmingBlockMechanic.isFarmBlock()) return;
-        NoteBlockMechanicFactory.setBlockModel(block, farmingBlockMechanic.getMoistFarmBlock());
+        NoteBlockMechanic farmMechanic = getNoteBlockMechanic(block);
         PersistentDataContainer farmBlockData = new CustomBlockData(block, OraxenPlugin.get());
-        farmBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
 
-        player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation(), 10);
-    }
 
-    private NoteBlockMechanic getNoteBlockMechanic(Block block) {
-        final NoteBlock noteBlok = (NoteBlock) block.getBlockData();
-        return NoteBlockMechanicFactory
-                .getBlockMechanic((int) (noteBlok.getInstrument().getType()) * 25
-                        + (int) noteBlok.getNote().getId() + (noteBlok.isPowered() ? 400 : 0) - 26);
+        if (!farmMechanic.isFarmBlock() || Objects.equals(farmBlockData.get(FARMBLOCK_KEY, PersistentDataType.STRING), farmMechanic.getMoistFarmBlock())) return;
+        NoteBlockMechanicFactory.setBlockModel(block, farmMechanic.getMoistFarmBlock());
+        farmBlockData.set(FARMBLOCK_KEY, PersistentDataType.STRING, farmMechanic.getMoistFarmBlock());
+
+        player.getWorld().spawnParticle(Particle.WATER_SPLASH, block.getLocation().add(0.5, 1, 0.5), 40);
     }
 
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -101,8 +101,11 @@ public class FurnitureListener implements Listener {
 
         if (mechanic.farmlandRequired && farm.getType() != Material.FARMLAND) return;
 
-        if (mechanic.farmblockRequired && farm.getType() != Material.NOTE_BLOCK) return;
-        if (mechanic.farmblockRequired && !getNoteBlockMechanic(farm).getDryout().isFarmBlock()) return;
+        if (mechanic.farmblockRequired) {
+            if (farm.getType() != Material.NOTE_BLOCK) return;
+            if (!getNoteBlockMechanic(farm).hasDryout()) return;
+            if (!getNoteBlockMechanic(farm).getDryout().isFarmBlock()) return;
+        }
 
         target.setType(Material.AIR, false);
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(target, target.getState(), placedAgainst,

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -97,11 +97,11 @@ public class FurnitureListener implements Listener {
             return;
 
         Block farm = target.getLocation().clone().subtract(0, 1, 0).getBlock();
-        NoteBlockMechanic noteBlockMechanic = getNoteBlockMechanic(farm);
+
 
         if (mechanic.farmlandRequired && farm.getType() != Material.FARMLAND) return;
 
-        if (mechanic.farmblockRequired && !noteBlockMechanic.isFarmBlock()) return;
+        if (mechanic.farmblockRequired && (farm.getType() != Material.NOTE_BLOCK || !getNoteBlockMechanic(farm).isFarmBlock())) return;
 
         target.setType(Material.AIR, false);
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(target, target.getState(), placedAgainst,

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -1,6 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture;
 
-import de.jeff_media.customblockdata.CustomBlockData;
+import com.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.items.OraxenItems;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -4,9 +4,9 @@ import de.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.items.OraxenItems;
-import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
@@ -15,6 +15,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.NoteBlock;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -23,18 +24,15 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
-import java.util.List;
 import java.util.UUID;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.*;
@@ -98,10 +96,12 @@ public class FurnitureListener implements Listener {
         if (mechanic == null)
             return;
 
-        if (mechanic.farmlandRequired &&
-                target.getLocation().clone().subtract(0, 1, 0).getBlock().getType()
-                        != Material.FARMLAND)
-            return;
+        Block farm = target.getLocation().clone().subtract(0, 1, 0).getBlock();
+        NoteBlockMechanic noteBlockMechanic = getNoteBlockMechanic(farm);
+
+        if (mechanic.farmlandRequired && farm.getType() != Material.FARMLAND) return;
+
+        if (mechanic.farmblockRequired && !noteBlockMechanic.isFarmBlock()) return;
 
         target.setType(Material.AIR, false);
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(target, target.getState(), placedAgainst,
@@ -313,6 +313,13 @@ public class FurnitureListener implements Listener {
                 && (playerLocation.getBlockY() == blockLocation.getBlockY()
                 || playerLocation.getBlockY() + 1 == blockLocation.getBlockY())
                 && playerLocation.getBlockZ() == blockLocation.getBlockZ();
+    }
+
+    public NoteBlockMechanic getNoteBlockMechanic(Block block) {
+        final NoteBlock noteBlok = (NoteBlock) block.getBlockData();
+        return NoteBlockMechanicFactory
+                .getBlockMechanic((int) (noteBlok.getInstrument().getType()) * 25
+                        + (int) noteBlok.getNote().getId() + (noteBlok.isPowered() ? 400 : 0) - 26);
     }
 
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -101,7 +101,8 @@ public class FurnitureListener implements Listener {
 
         if (mechanic.farmlandRequired && farm.getType() != Material.FARMLAND) return;
 
-        if (mechanic.farmblockRequired && (farm.getType() != Material.NOTE_BLOCK || !getNoteBlockMechanic(farm).isFarmBlock())) return;
+        if (mechanic.farmblockRequired && farm.getType() != Material.NOTE_BLOCK) return;
+        if (mechanic.farmblockRequired && !getNoteBlockMechanic(farm).getDryout().isFarmBlock()) return;
 
         target.setType(Material.AIR, false);
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(target, target.getState(), placedAgainst,

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -96,7 +96,7 @@ public class FurnitureListener implements Listener {
         if (mechanic == null)
             return;
 
-        Block farm = target.getLocation().clone().subtract(0, 1, 0).getBlock();
+        Block farm = target.getRelative(BlockFace.DOWN);
 
 
         if (mechanic.farmlandRequired && farm.getType() != Material.FARMLAND) return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -11,17 +11,18 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.Evolvin
 import io.th0rgal.oraxen.utils.actions.ClickAction;
 import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.drops.Loot;
-import net.Indyuce.mmoitems.stat.Armor;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.*;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.checkerframework.checker.units.qual.C;
 
 import java.util.*;
 
@@ -33,6 +34,7 @@ public class FurnitureMechanic extends Mechanic {
     public static final NamespacedKey ORIENTATION_KEY = new NamespacedKey(OraxenPlugin.get(), "orientation");
     public static final NamespacedKey EVOLUTION_KEY = new NamespacedKey(OraxenPlugin.get(), "evolution");
     public final boolean farmlandRequired;
+    public final boolean farmblockRequired;
     private final List<BlockLocation> barriers;
     private final boolean hasRotation;
     private final boolean hasSeat;
@@ -84,6 +86,7 @@ public class FurnitureMechanic extends Mechanic {
         light = section.getInt("light", -1);
 
         farmlandRequired = section.getBoolean("farmland_required", false);
+        farmblockRequired = section.getBoolean("farmblock_required", false);
 
         facing = section.isString("facing")
                 ? BlockFace.valueOf(section.getString("facing").toUpperCase())

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -33,6 +33,7 @@ public class FurnitureMechanic extends Mechanic {
     public static final NamespacedKey ROOT_KEY = new NamespacedKey(OraxenPlugin.get(), "root");
     public static final NamespacedKey ORIENTATION_KEY = new NamespacedKey(OraxenPlugin.get(), "orientation");
     public static final NamespacedKey EVOLUTION_KEY = new NamespacedKey(OraxenPlugin.get(), "evolution");
+    public static final NamespacedKey FARMBLOCK_KEY = new NamespacedKey(OraxenPlugin.get(), "farmblock");
     public final boolean farmlandRequired;
     public final boolean farmblockRequired;
     private final List<BlockLocation> barriers;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -33,7 +33,6 @@ public class FurnitureMechanic extends Mechanic {
     public static final NamespacedKey ROOT_KEY = new NamespacedKey(OraxenPlugin.get(), "root");
     public static final NamespacedKey ORIENTATION_KEY = new NamespacedKey(OraxenPlugin.get(), "orientation");
     public static final NamespacedKey EVOLUTION_KEY = new NamespacedKey(OraxenPlugin.get(), "evolution");
-    public static final NamespacedKey FARMBLOCK_KEY = new NamespacedKey(OraxenPlugin.get(), "farmblock");
     public final boolean farmlandRequired;
     public final boolean farmblockRequired;
     private final List<BlockLocation> barriers;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -1,6 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture;
 
-import de.jeff_media.customblockdata.CustomBlockData;
+import com.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
 import io.th0rgal.oraxen.compatibilities.provided.lightapi.WrappedLightAPI;
@@ -178,7 +178,7 @@ public class FurnitureMechanic extends Mechanic {
         return evolvingFurniture;
     }
 
-    private void setPlacedItem() {
+    public void setPlacedItem() {
         if (placedItem == null) {
             placedItem = OraxenItems.getItemById(placedItemId != null ? placedItemId : getItemID()).build();
             ItemMeta meta = placedItem.getItemMeta();
@@ -254,10 +254,10 @@ public class FurnitureMechanic extends Mechanic {
                 WrappedLightAPI.removeBlockLight(location);
             if (hasSeat()) {
                 ArmorStand seat = getSeat(location);
-                 if(seat != null && seat.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
-                     seat.getPassengers().clear();
-                     seat.remove();
-                 }
+                if (seat != null && seat.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
+                    seat.getPassengers().clear();
+                    seat.remove();
+                }
             }
             location.getBlock().setType(Material.AIR);
         }
@@ -338,7 +338,7 @@ public class FurnitureMechanic extends Mechanic {
             }
         }
     }
-  
+
     private String spawnSeat(FurnitureMechanic mechanic, Block target, float yaw) {
         if (mechanic.hasSeat()) {
             final ArmorStand seat = target.getWorld().spawn(target.getLocation()

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
@@ -42,7 +42,7 @@ public class EvolutionTask extends BukkitRunnable {
                         continue;
                     }
 
-                    if (mechanic.farmblockRequired && !noteBlockMechanic.isFarmBlock()) {
+                    if (mechanic.farmblockRequired && !noteBlockMechanic.getDryout().isFarmBlock()) {
                         mechanic.remove(frame);
                         continue;
                     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
@@ -47,18 +47,23 @@ public class EvolutionTask extends BukkitRunnable {
                         continue;
                     }
 
+                    if (mechanic.farmblockRequired && !noteBlockMechanic.getDryout().isMoistFarmBlock()) {
+                        frame.getPersistentDataContainer().set(FurnitureMechanic.EVOLUTION_KEY,
+                                PersistentDataType.INTEGER, 0);
+                        continue;
+                    }
+
                     EvolvingFurniture evolution = mechanic.getEvolution();
                     int evolutionStep = frame.getPersistentDataContainer()
                             .get(EVOLUTION_KEY, PersistentDataType.INTEGER)
                             + delay * frame.getLocation().getBlock().getLightLevel();
 
                     if (evolutionStep > evolution.getDelay()) {
-                        if (!evolution.bernoulliTest())
-                            continue;
-                        mechanic.remove(frame);
                         FurnitureMechanic nextMechanic = (FurnitureMechanic) furnitureFactory.getMechanic(evolution.getNextStage());
-                        if (nextMechanic == null) return;
+                        if (nextMechanic == null) continue;
+                        if (!evolution.bernoulliTest()) continue;
 
+                        mechanic.remove(frame);
                         nextMechanic.place(
                                 frame.getRotation(),
                                 mechanic.getYaw(frame.getRotation()),

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution;
 
-import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.BlockLocation;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
@@ -60,8 +59,8 @@ public class EvolutionTask extends BukkitRunnable {
                             + delay * frame.getLocation().getBlock().getLightLevel();
 
                     if (evolutionStep > evolution.getDelay()) {
-                        if (!evolution.bernoulliTest())
-                            continue;
+                        if (evolution.getNextStage() == null) continue;
+                        if (!evolution.bernoulliTest()) continue;
                         mechanic.remove(frame);
                         FurnitureMechanic nextMechanic = (FurnitureMechanic)
                                 furnitureFactory.getMechanic(evolution.getNextStage());

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/evolution/EvolutionTask.java
@@ -1,12 +1,18 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution;
 
-import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.BlockLocation;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
-import org.bukkit.*;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
+
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.EVOLUTION_KEY;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
 
 public class EvolutionTask extends BukkitRunnable {
 
@@ -22,30 +28,39 @@ public class EvolutionTask extends BukkitRunnable {
     public void run() {
         for (World world : Bukkit.getWorlds())
             for (ItemFrame frame : world.getEntitiesByClass(ItemFrame.class))
-                if (frame.getPersistentDataContainer().has(FurnitureMechanic.EVOLUTION_KEY,
+                if (frame.getPersistentDataContainer().has(EVOLUTION_KEY,
                         PersistentDataType.INTEGER)) {
 
                     String itemID = frame.getPersistentDataContainer()
                             .get(FurnitureMechanic.FURNITURE_KEY, PersistentDataType.STRING);
+                    Block blockBelow = frame.getLocation().clone().subtract(0, 1, 0).getBlock();
                     FurnitureMechanic mechanic = (FurnitureMechanic) furnitureFactory.getMechanic(itemID);
+                    NoteBlockMechanic noteBlockMechanic = getNoteBlockMechanic(blockBelow);
 
-                    if (mechanic.farmlandRequired &&
-                            frame.getLocation().clone().subtract(0, 1, 0).getBlock().getType()
-                                    != Material.FARMLAND) {
+                    if (mechanic.farmlandRequired && blockBelow.getType() != Material.FARMLAND) {
                         mechanic.remove(frame);
                         continue;
                     }
+
+                    if (mechanic.farmblockRequired && !noteBlockMechanic.isFarmBlock()) {
+                        mechanic.remove(frame);
+                        continue;
+                    }
+
                     EvolvingFurniture evolution = mechanic.getEvolution();
                     int evolutionStep = frame.getPersistentDataContainer()
-                            .get(FurnitureMechanic.EVOLUTION_KEY, PersistentDataType.INTEGER)
+                            .get(EVOLUTION_KEY, PersistentDataType.INTEGER)
                             + delay * frame.getLocation().getBlock().getLightLevel();
+
                     if (evolutionStep > evolution.getDelay()) {
                         if (!evolution.bernoulliTest())
                             continue;
                         mechanic.remove(frame);
-                        FurnitureMechanic nextMechanic = (FurnitureMechanic)
-                                furnitureFactory.getMechanic(evolution.getNextStage());
-                        nextMechanic.place(frame.getRotation(),
+                        FurnitureMechanic nextMechanic = (FurnitureMechanic) furnitureFactory.getMechanic(evolution.getNextStage());
+                        if (nextMechanic == null) return;
+
+                        nextMechanic.place(
+                                frame.getRotation(),
                                 mechanic.getYaw(frame.getRotation()),
                                 frame.getFacing(),
                                 frame.getLocation(),

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
@@ -1,11 +1,13 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock;
 
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.utils.actions.ClickAction;
 import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.drops.Loot;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
@@ -15,6 +17,7 @@ import java.util.List;
 
 public class NoteBlockMechanic extends Mechanic {
 
+    public static final NamespacedKey FARMBLOCK_KEY = new NamespacedKey(OraxenPlugin.get(), "farmblock");
     protected final boolean hasHardness;
     private final int customVariation;
     private final Drop drop;
@@ -83,9 +86,9 @@ public class NoteBlockMechanic extends Mechanic {
 
         if (section.isConfigurationSection("farming")) {
             ConfigurationSection farming = section.getConfigurationSection("farming");
-            isFarmBlock = farming.getBoolean("isFarmBlock");
+            isFarmBlock = farming.getBoolean("isFarmBlock", false);
             moistFarmBlock = farming.getString("moistFarmBlock");
-            farmBlockDryoutTime = farming.getInt("farmBlockDryoutTime");
+            farmBlockDryoutTime = farming.getInt("farmBlockDryoutTime", 10000);
         }
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
@@ -25,6 +25,7 @@ public class NoteBlockMechanic extends Mechanic {
     private final int light;
     private boolean isFarmBlock;
     private String moistFarmBlock;
+    private int farmBlockDryoutTime;
     private final List<ClickAction> clickActions;
 
     @SuppressWarnings("unchecked")
@@ -84,6 +85,7 @@ public class NoteBlockMechanic extends Mechanic {
             ConfigurationSection farming = section.getConfigurationSection("farming");
             isFarmBlock = farming.getBoolean("isFarmBlock");
             moistFarmBlock = farming.getString("moistFarmBlock");
+            farmBlockDryoutTime = farming.getInt("farmBlockDryoutTime");
         }
     }
 
@@ -133,6 +135,8 @@ public class NoteBlockMechanic extends Mechanic {
     public String getMoistFarmBlock() {
         return moistFarmBlock;
     }
+
+    public int getFarmBlockDryoutTime() { return farmBlockDryoutTime; }
 
     public void runClickActions(final Player player) {
         for (final ClickAction action : clickActions) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
@@ -23,6 +23,8 @@ public class NoteBlockMechanic extends Mechanic {
     private String model;
     private int period;
     private final int light;
+    private boolean isFarmBlock;
+    private String moistFarmBlock;
     private final List<ClickAction> clickActions;
 
     @SuppressWarnings("unchecked")
@@ -77,6 +79,12 @@ public class NoteBlockMechanic extends Mechanic {
 
         light = section.getInt("light", -1);
         clickActions = ClickAction.parseList(section);
+
+        if (section.isConfigurationSection("farming")) {
+            ConfigurationSection farming = section.getConfigurationSection("farming");
+            isFarmBlock = farming.getBoolean("isFarmBlock");
+            moistFarmBlock = farming.getString("moistFarmBlock");
+        }
     }
 
     public String getModel(ConfigurationSection section) {
@@ -116,6 +124,14 @@ public class NoteBlockMechanic extends Mechanic {
 
     public int getLight() {
         return light;
+    }
+
+    public boolean isFarmBlock() {
+        return isFarmBlock;
+    }
+
+    public String getMoistFarmBlock() {
+        return moistFarmBlock;
     }
 
     public void runClickActions(final Player player) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
@@ -4,6 +4,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock.FarmBlockDryout;
 import io.th0rgal.oraxen.utils.actions.ClickAction;
 import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.drops.Loot;
@@ -26,9 +27,7 @@ public class NoteBlockMechanic extends Mechanic {
     private String model;
     private int period;
     private final int light;
-    private boolean isFarmBlock;
-    private String moistFarmBlock;
-    private int farmBlockDryoutTime;
+    private final FarmBlockDryout farmBlockDryout;
     private final List<ClickAction> clickActions;
 
     @SuppressWarnings("unchecked")
@@ -84,12 +83,18 @@ public class NoteBlockMechanic extends Mechanic {
         light = section.getInt("light", -1);
         clickActions = ClickAction.parseList(section);
 
-        if (section.isConfigurationSection("farming")) {
-            ConfigurationSection farming = section.getConfigurationSection("farming");
-            isFarmBlock = farming.getBoolean("isFarmBlock", false);
-            moistFarmBlock = farming.getString("moistFarmBlock");
-            farmBlockDryoutTime = farming.getInt("farmBlockDryoutTime", 10000);
-        }
+        if (section.isConfigurationSection("farmblock")) {
+            farmBlockDryout = new FarmBlockDryout(getItemID(), section.getConfigurationSection("farmblock"));
+            ((NoteBlockMechanicFactory) getFactory()).registerFarmBlock();
+        } else farmBlockDryout = null;
+    }
+
+    public boolean hasDryout() {
+        return farmBlockDryout != null;
+    }
+
+    public FarmBlockDryout getDryout() {
+        return farmBlockDryout;
     }
 
     public String getModel(ConfigurationSection section) {
@@ -130,16 +135,6 @@ public class NoteBlockMechanic extends Mechanic {
     public int getLight() {
         return light;
     }
-
-    public boolean isFarmBlock() {
-        return isFarmBlock;
-    }
-
-    public String getMoistFarmBlock() {
-        return moistFarmBlock;
-    }
-
-    public int getFarmBlockDryoutTime() { return farmBlockDryoutTime; }
 
     public void runClickActions(final Player player) {
         for (final ClickAction action : clickActions) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock.FarmBlockTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Instrument;
 import org.bukkit.Material;
@@ -23,6 +24,9 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
     private static JsonObject variants;
     private static NoteBlockMechanicFactory instance;
     public final List<String> toolTypes;
+    private boolean farmBlock;
+    private static FarmBlockTask farmBlockTask;
+    public final int farmBlockCheckDelay;
 
     public NoteBlockMechanicFactory(ConfigurationSection section) {
         super(section);
@@ -30,6 +34,8 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
         variants = new JsonObject();
         variants.add("instrument=harp,powered=false", getModelJson("required/note_block"));
         toolTypes = section.getStringList("tool_types");
+        farmBlockCheckDelay = section.getInt("farmblock_check_delay");
+        farmBlock = false;
 
         // this modifier should be executed when all the items have been parsed, just
         // before zipping the pack
@@ -146,6 +152,15 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
          * will be reserved for the vanilla behavior. We still have 800-25 = 775 variations
          */
         return createNoteBlockData(((NoteBlockMechanic) getInstance().getMechanic(itemID)).getCustomVariation());
+    }
+
+    public void registerFarmBlock() {
+        if (farmBlock) return;
+        if (farmBlockTask != null) farmBlockTask.cancel();
+
+        farmBlockTask = new FarmBlockTask(this, farmBlockCheckDelay);
+        farmBlockTask.runTaskTimer(OraxenPlugin.get(), 0, farmBlockCheckDelay);
+        farmBlock = true;
     }
 
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -275,5 +275,4 @@ public class NoteBlockMechanicListener implements Listener {
                 .getBlockMechanic((int) (noteBlok.getInstrument().getType()) * 25
                         + (int) noteBlok.getNote().getId() + (noteBlok.isPowered() ? 400 : 0) - 26);
     }
-
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -54,7 +54,7 @@ public class NoteBlockMechanicListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockPhysics(final BlockPhysicsEvent event) {
-        final Block aboveBlock = event.getBlock().getLocation().add(0, 1, 0).getBlock();
+        final Block aboveBlock = event.getBlock().getRelative(BlockFace.UP);
         if (aboveBlock.getType() == Material.NOTE_BLOCK) {
             updateAndCheck(event.getBlock().getLocation());
             event.setCancelled(true);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -190,7 +190,7 @@ public class NoteBlockMechanicListener implements Listener {
                 WrappedLightAPI.createBlockLight(placedBlock.getLocation(), mechanic.getLight());
             event.setCancelled(true);
 
-            if (mechanic.isFarmBlock()) {
+            if (mechanic.getDryout().isFarmBlock()) {
                 final PersistentDataContainer customBlockData = new CustomBlockData(placedBlock, OraxenPlugin.get());
                 customBlockData.set(FARMBLOCK_KEY, PersistentDataType.STRING, mechanic.getItemID());
             }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -1,5 +1,7 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock;
 
+import com.jeff_media.customblockdata.CustomBlockData;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.compatibilities.provided.lightapi.WrappedLightAPI;
 import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
@@ -22,8 +24,12 @@ import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.List;
+
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
 
 public class NoteBlockMechanicListener implements Listener {
 
@@ -183,6 +189,11 @@ public class NoteBlockMechanicListener implements Listener {
             if (mechanic.getLight() != -1)
                 WrappedLightAPI.createBlockLight(placedBlock.getLocation(), mechanic.getLight());
             event.setCancelled(true);
+
+            if (mechanic.isFarmBlock()) {
+                final PersistentDataContainer customBlockData = new CustomBlockData(placedBlock, OraxenPlugin.get());
+                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.STRING, mechanic.getItemID());
+            }
         }
     }
 
@@ -269,7 +280,7 @@ public class NoteBlockMechanicListener implements Listener {
         return target;
     }
 
-    public NoteBlockMechanic getNoteBlockMechanic(Block block) {
+    public static NoteBlockMechanic getNoteBlockMechanic(Block block) {
         final NoteBlock noteBlok = (NoteBlock) block.getBlockData();
         return NoteBlockMechanicFactory
                 .getBlockMechanic((int) (noteBlok.getInstrument().getType()) * 25

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
@@ -1,7 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock;
 
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -53,10 +52,8 @@ public class FarmBlockDryout {
 
     public boolean isConnectedToWaterSource(Block block, PersistentDataContainer customBlockData) {
         Location blockLoc = block.getLocation();
-        Bukkit.broadcastMessage(String.valueOf(block.getType()));
 
         if (blockLoc.clone().subtract(0, 1, 0).getBlock().getType() == Material.WATER) {
-            Bukkit.broadcastMessage("is water below");
             NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
             customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
             return true;
@@ -64,81 +61,17 @@ public class FarmBlockDryout {
 
         for (int i = 1; i <= 9; i++) {
             Block nextBlock = blockLoc.getBlock();
-            if (nextBlock.getType() == Material.WATER) {
-                Bukkit.broadcastMessage("is water");
-                NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
-                return true;
-            } else if (nextBlock.getType() == Material.FARMLAND) {
-                Farmland data = (Farmland) nextBlock.getBlockData();
-                if (data.getMoisture() > 0) {
-                    NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                    customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
-                    return true;
-                }
-            } else if (nextBlock.getType() == Material.NOTE_BLOCK &&
+            if (nextBlock.getType() == Material.WATER) return true;
+            else if (nextBlock.getType() == Material.FARMLAND && ((Farmland) nextBlock.getBlockData()).getMoisture() > 0) return true;
+            else if (nextBlock.getType() == Material.NOTE_BLOCK &&
                     getNoteBlockMechanic(nextBlock).hasDryout() &&
-                    getNoteBlockMechanic(nextBlock).getDryout().isMoistFarmBlock()) {
-                Bukkit.broadcastMessage("is moistfarmblock");
-                NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                    getNoteBlockMechanic(nextBlock).getDryout().isMoistFarmBlock())
                 return true;
-            }
+
             blockLoc = blockLoc.add(0, 0, -1);
         }
         return false;
     }
-
-    //Attempt at checking all blocks in a radius of 9 for water source
-    // Could find all waterblocks in radius and check if it is connected to farmblock via farmblocks/farmland
-
-        /*for (int i = 1; i <= 9; i++) {
-            for (int j = 1; j <= 9; j++) {
-                Block nextBlock = blockLoc.getBlock();
-                if (nextBlock.getType() == Material.WATER) {
-                    Bukkit.broadcastMessage("is water");
-                    NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                    customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
-                    return true;
-                } else if (nextBlock.getType() == Material.FARMLAND) {
-                    Farmland data = (Farmland) nextBlock.getBlockData();
-                    if (data.getMoisture() > 0) {
-                        NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                        customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
-                        return true;
-                    }
-                } else if (nextBlock.getType() == Material.NOTE_BLOCK &&
-                        getNoteBlockMechanic(nextBlock).hasDryout() &&
-                        getNoteBlockMechanic(nextBlock).getDryout().isMoistFarmBlock()) {
-
-                    NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                    customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
-                    return true;
-                }
-
-                else if (nextBlock.getType() == Material.FARMLAND ||
-                        (nextBlock.getType() == Material.NOTE_BLOCK && getNoteBlockMechanic(nextBlock).getDryout().isFarmBlock())) {
-                    Bukkit.broadcastMessage("is farmblock");
-                    Location nextLoc = nextBlock.getLocation().clone();
-                    for (int k = 1; k <= 9; k++) {
-                        if (nextBlock.getType() == Material.WATER) {
-                            Bukkit.broadcastMessage("is farmblock and water");
-                            NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
-                            customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
-                            return true;
-                        }
-                        nextLoc = nextLoc.add(0, 0, -1);
-                    }
-                }
-
-                blockLoc = blockLoc.add(0, 0, -1);
-            }
-
-            blockLoc = blockLoc.add(-1, 0, 9);
-        }
-        Bukkit.broadcastMessage("nothing");
-        return false;
-    }*/
 }
 
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
@@ -2,33 +2,41 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock;
 
 import org.bukkit.configuration.ConfigurationSection;
 
-import java.util.Random;
-
 public class FarmBlockDryout {
 
-    private final boolean lightBoost;
-    private final int probability;
-    private final int delay;
-    private final Random random = new Random();
-    private boolean isMoist;
+    private String farmBlock;
+    private String moistFarmBlock;
+    private int farmBlockDryoutTime;
+    private final String id;
 
-    public FarmBlockDryout(String itemId, ConfigurationSection farmblockSection) {
-        delay = farmblockSection.getInt("delay");
-        probability = (int) (1D / (double) farmblockSection.get("probability", 1));
-        lightBoost = farmblockSection.isBoolean("light_boost") && farmblockSection.getBoolean("light_boost");
+    public FarmBlockDryout(String itemID, ConfigurationSection farmblockSection) {
+        id = itemID;
+        farmBlock = farmblockSection.getString("farmBlockPath");
+        moistFarmBlock = farmblockSection.getString("moistFarmBlockPath");
+        farmBlockDryoutTime = farmblockSection.getInt("farmBlockDryOutTime", 50000);
     }
 
     public int getDelay() {
-        return delay;
+        return farmBlockDryoutTime;
     }
 
-    public boolean isLightBoosted() {
-        return lightBoost;
+    public boolean isFarmBlock() {
+        return (farmBlock != null || moistFarmBlock != null);
     }
 
-    public boolean bernoulliTest() {
-        return random.nextInt(probability) == 0;
+    public boolean isMoistFarmBlock() {
+        return ((moistFarmBlock == null || moistFarmBlock.equals(id)) && farmBlock != null);
     }
+
+    public String getFarmBlock() {
+        return farmBlock;
+    }
+
+    public String getMoistFarmBlock() {
+        return moistFarmBlock;
+    }
+
+    public int getDryoutTime() { return farmBlockDryoutTime; }
 }
 
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
@@ -1,6 +1,17 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock;
 
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.type.Farmland;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
 
 public class FarmBlockDryout {
 
@@ -36,7 +47,98 @@ public class FarmBlockDryout {
         return moistFarmBlock;
     }
 
-    public int getDryoutTime() { return farmBlockDryoutTime; }
+    public int getDryoutTime() {
+        return farmBlockDryoutTime;
+    }
+
+    public boolean isConnectedToWaterSource(Block block, PersistentDataContainer customBlockData) {
+        Location blockLoc = block.getLocation();
+        Bukkit.broadcastMessage(String.valueOf(block.getType()));
+
+        if (blockLoc.clone().subtract(0, 1, 0).getBlock().getType() == Material.WATER) {
+            Bukkit.broadcastMessage("is water below");
+            NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+            customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+            return true;
+        }
+
+        for (int i = 1; i <= 9; i++) {
+            Block nextBlock = blockLoc.getBlock();
+            if (nextBlock.getType() == Material.WATER) {
+                Bukkit.broadcastMessage("is water");
+                NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                return true;
+            } else if (nextBlock.getType() == Material.FARMLAND) {
+                Farmland data = (Farmland) nextBlock.getBlockData();
+                if (data.getMoisture() > 0) {
+                    NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                    customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                    return true;
+                }
+            } else if (nextBlock.getType() == Material.NOTE_BLOCK &&
+                    getNoteBlockMechanic(nextBlock).hasDryout() &&
+                    getNoteBlockMechanic(nextBlock).getDryout().isMoistFarmBlock()) {
+                Bukkit.broadcastMessage("is moistfarmblock");
+                NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                return true;
+            }
+            blockLoc = blockLoc.add(0, 0, -1);
+        }
+        return false;
+    }
+
+    //Attempt at checking all blocks in a radius of 9 for water source
+    // Could find all waterblocks in radius and check if it is connected to farmblock via farmblocks/farmland
+
+        /*for (int i = 1; i <= 9; i++) {
+            for (int j = 1; j <= 9; j++) {
+                Block nextBlock = blockLoc.getBlock();
+                if (nextBlock.getType() == Material.WATER) {
+                    Bukkit.broadcastMessage("is water");
+                    NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                    customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                    return true;
+                } else if (nextBlock.getType() == Material.FARMLAND) {
+                    Farmland data = (Farmland) nextBlock.getBlockData();
+                    if (data.getMoisture() > 0) {
+                        NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                        customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                        return true;
+                    }
+                } else if (nextBlock.getType() == Material.NOTE_BLOCK &&
+                        getNoteBlockMechanic(nextBlock).hasDryout() &&
+                        getNoteBlockMechanic(nextBlock).getDryout().isMoistFarmBlock()) {
+
+                    NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                    customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                    return true;
+                }
+
+                else if (nextBlock.getType() == Material.FARMLAND ||
+                        (nextBlock.getType() == Material.NOTE_BLOCK && getNoteBlockMechanic(nextBlock).getDryout().isFarmBlock())) {
+                    Bukkit.broadcastMessage("is farmblock");
+                    Location nextLoc = nextBlock.getLocation().clone();
+                    for (int k = 1; k <= 9; k++) {
+                        if (nextBlock.getType() == Material.WATER) {
+                            Bukkit.broadcastMessage("is farmblock and water");
+                            NoteBlockMechanicFactory.setBlockModel(block, getMoistFarmBlock());
+                            customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                            return true;
+                        }
+                        nextLoc = nextLoc.add(0, 0, -1);
+                    }
+                }
+
+                blockLoc = blockLoc.add(0, 0, -1);
+            }
+
+            blockLoc = blockLoc.add(-1, 0, 9);
+        }
+        Bukkit.broadcastMessage("nothing");
+        return false;
+    }*/
 }
 
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
@@ -19,9 +19,9 @@ import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockM
 
 public class FarmBlockDryout {
 
-    private String farmBlock;
-    private String moistFarmBlock;
-    private int farmBlockDryoutTime;
+    private final String farmBlock;
+    private final String moistFarmBlock;
+    private final int farmBlockDryoutTime;
     private final String id;
 
     public FarmBlockDryout(String itemID, ConfigurationSection farmblockSection) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockDryout.java
@@ -1,0 +1,34 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Random;
+
+public class FarmBlockDryout {
+
+    private final boolean lightBoost;
+    private final int probability;
+    private final int delay;
+    private final Random random = new Random();
+    private boolean isMoist;
+
+    public FarmBlockDryout(String itemId, ConfigurationSection farmblockSection) {
+        delay = farmblockSection.getInt("delay");
+        probability = (int) (1D / (double) farmblockSection.get("probability", 1));
+        lightBoost = farmblockSection.isBoolean("light_boost") && farmblockSection.getBoolean("light_boost");
+    }
+
+    public int getDelay() {
+        return delay;
+    }
+
+    public boolean isLightBoosted() {
+        return lightBoost;
+    }
+
+    public boolean bernoulliTest() {
+        return random.nextInt(probability) == 0;
+    }
+}
+
+

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
@@ -1,0 +1,30 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock;
+
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
+
+public class FarmBlockTask extends BukkitRunnable {
+
+    private final NoteBlockMechanicFactory factory;
+    private final int delay;
+
+    public FarmBlockTask(NoteBlockMechanicFactory factory, int delay) {
+        this.delay = delay;
+        this.factory = factory;
+    }
+
+    @Override
+    public void run() {
+        for (World world : Bukkit.getWorlds()) {
+            if (world.getPersistentDataContainer().has(FARMBLOCK_KEY, PersistentDataType.INTEGER)) {
+                String farmBlockId = world.getPersistentDataContainer().get(FARMBLOCK_KEY, PersistentDataType.STRING);
+                System.out.println("i have a farmblock pog");
+            }
+        }
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
@@ -1,8 +1,13 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock;
 
+import com.jeff_media.customblockdata.CustomBlockData;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -14,16 +19,20 @@ public class FarmBlockTask extends BukkitRunnable {
     private final int delay;
 
     public FarmBlockTask(NoteBlockMechanicFactory factory, int delay) {
-        this.delay = delay;
         this.factory = factory;
+        this.delay = delay;
     }
 
     @Override
     public void run() {
         for (World world : Bukkit.getWorlds()) {
-            if (world.getPersistentDataContainer().has(FARMBLOCK_KEY, PersistentDataType.INTEGER)) {
-                String farmBlockId = world.getPersistentDataContainer().get(FARMBLOCK_KEY, PersistentDataType.STRING);
-                System.out.println("i have a farmblock pog");
+            for (Chunk chunk : world.getLoadedChunks()) {
+                for (Block block : CustomBlockData.getBlocksWithCustomData(OraxenPlugin.get(),chunk)) {
+                    PersistentDataContainer customBlock = new CustomBlockData(block, OraxenPlugin.get());
+                    if (customBlock.has(FARMBLOCK_KEY, PersistentDataType.STRING)) {
+                        Bukkit.broadcastMessage("i has le farmblock key");
+                    } else Bukkit.broadcastMessage("no");
+                }
             }
         }
     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
@@ -47,9 +47,19 @@ public class FarmBlockTask extends BukkitRunnable {
                             if (farmMechanic.getDryoutTime() - moistTimerRemain <= 0) {
                                 NoteBlockMechanicFactory.setBlockModel(block, farmMechanic.getFarmBlock());
                                 customBlockData.remove(FARMBLOCK_KEY);
+                                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.STRING, farmMechanic.getFarmBlock());
                             } else customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, moistTimerRemain);
-                        } else if (farmMechanic.isConnectedToWaterSource(block, customBlockData)) {
-                            Bukkit.broadcastMessage("yep");
+                        }
+
+                        else {
+                            if (farmMechanic.isConnectedToWaterSource(block, customBlockData)) {
+                                NoteBlockMechanicFactory.setBlockModel(block, farmMechanic.getMoistFarmBlock());
+                                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                            }
+                            else if (world.hasStorm() && world.getHighestBlockAt(block.getLocation()) == block) {
+                                NoteBlockMechanicFactory.setBlockModel(block, farmMechanic.getMoistFarmBlock());
+                                customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, 0);
+                            }
                         }
                     }
                 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -12,6 +13,7 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
 
 public class FarmBlockTask extends BukkitRunnable {
 
@@ -27,11 +29,18 @@ public class FarmBlockTask extends BukkitRunnable {
     public void run() {
         for (World world : Bukkit.getWorlds()) {
             for (Chunk chunk : world.getLoadedChunks()) {
-                for (Block block : CustomBlockData.getBlocksWithCustomData(OraxenPlugin.get(),chunk)) {
-                    PersistentDataContainer customBlock = new CustomBlockData(block, OraxenPlugin.get());
-                    if (customBlock.has(FARMBLOCK_KEY, PersistentDataType.STRING)) {
-                        Bukkit.broadcastMessage("i has le farmblock key");
-                    } else Bukkit.broadcastMessage("no");
+                for (Block block : CustomBlockData.getBlocksWithCustomData(OraxenPlugin.get(), chunk)) {
+                    PersistentDataContainer customBlockData = new CustomBlockData(block, OraxenPlugin.get());
+                    if (customBlockData.has(FARMBLOCK_KEY, PersistentDataType.INTEGER) && block.getType() == Material.NOTE_BLOCK) {
+                        FarmBlockDryout farmMechanic = getNoteBlockMechanic(block).getDryout();
+
+                        int moistTimerRemain = customBlockData.get(FARMBLOCK_KEY, PersistentDataType.INTEGER) + delay;
+
+                        if (farmMechanic.getDryoutTime() - moistTimerRemain <= 0) {
+                            NoteBlockMechanicFactory.setBlockModel(block, farmMechanic.getFarmBlock());
+                            customBlockData.remove(FARMBLOCK_KEY);
+                        } else customBlockData.set(FARMBLOCK_KEY, PersistentDataType.INTEGER, moistTimerRemain);
+                    }
                 }
             }
         }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/farmblock/FarmBlockTask.java
@@ -8,6 +8,7 @@ import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -31,7 +32,7 @@ public class FarmBlockTask extends BukkitRunnable {
             for (Chunk chunk : world.getLoadedChunks()) {
                 for (Block block : CustomBlockData.getBlocksWithCustomData(OraxenPlugin.get(), chunk)) {
                     PersistentDataContainer customBlockData = new CustomBlockData(block, OraxenPlugin.get());
-                    Block blockBelow = block.getLocation().subtract(0, 1, 0).getBlock();
+                    Block blockBelow = block.getRelative(BlockFace.DOWN);
                     if (customBlockData.has(FARMBLOCK_KEY, PersistentDataType.STRING) && block.getType() == Material.NOTE_BLOCK) {
                         if (!getNoteBlockMechanic(block).hasDryout()) return;
                         FarmBlockDryout farmMechanic = getNoteBlockMechanic(block).getDryout();

--- a/src/main/resources/mechanics.yml
+++ b/src/main/resources/mechanics.yml
@@ -43,6 +43,8 @@ noteblock:
     - GOLDEN
     - DIAMOND
     - NETHERITE
+    - # ticks between each check for dryout
+  farmblock_check_delay: 1000
   enabled: true
 
 stringblock:

--- a/src/main/resources/mechanics.yml
+++ b/src/main/resources/mechanics.yml
@@ -134,3 +134,6 @@ bedrockbreak:
 
 harvesting:
   enabled: true
+
+watering:
+  enabled: true


### PR DESCRIPTION
Adds a "Farm Block" block. Essentially farmland for custom blocks, but will eventually have more interactions.
Includes mechanic for watering can aswell, tho I plan on merging all this into a Farming mechanic by the end of the PR.

Not sure on how it should split the "isFarmBlock" mechanic as they do kinda only exist for noteblocks, tho they could in theory be furniture aswell. thoughts?
First mechanic i add so it probably is badly formatted so please correct anything.