### PR TITLE
1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ repositories {
     maven { url 'https://repo.triumphteam.dev/snapshots' }
     // MythicMobs
     maven { url 'https://mvn.lumine.io/repository/maven-public/' }
+    // commandAPI snapshots
+    maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
 }
 
 compileJava {
@@ -55,13 +57,13 @@ compileJava {
 dependencies {
     def actionsVersion = '1.0.0-SNAPSHOT'
 
-    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.18.2-R0.1-SNAPSHOT'
-    compileOnly("io.papermc.paper:paper-api:1.18.2-R0.1-SNAPSHOT") { exclude group: 'net.kyori' }
-    compileOnly group: 'com.github.dmulloy2', name: 'ProtocolLib', version: '4.7.0'
-    compileOnly group: 'com.github.Hazebyte', name: 'CrateReloadedAPI', version: '5318abfccc'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.18-R0.1-SNAPSHOT'
+    compileOnly("io.papermc.paper:paper-api:1.18-R0.1-SNAPSHOT") { exclude group: 'net.kyori' }
+    compileOnly group: 'com.github.dmulloy2', name: 'ProtocolLib', version: '4.8.0'
+    compileOnly group: 'com.github.Hazebyte', name: 'CrateReloadedAPI', version: 'd7ae2a14c6'
     compileOnly group: 'com.github.jojodmo', name: 'ItemBridge', version: '-SNAPSHOT'
-    compileOnly group: 'me.clip', name: 'placeholderapi', version: '2.10.10'
-    compileOnly group: 'com.github.BeYkeRYkt', name: 'LightAPI', version: '5.1.0-Bukkit'
+    compileOnly group: 'me.clip', name: 'placeholderapi', version: '2.11.1'
+    compileOnly group: 'com.github.BeYkeRYkt', name: 'LightAPI', version: '5.2.0-Bukkit'
     compileOnly group: 'me.gabytm.util', name: 'actions-core', version: actionsVersion
     compileOnly group: 'org.springframework', name: 'spring-expression', version: '5.3.16'
     compileOnly group: 'com.github.rockswang', name: 'java-curl', version: '1.2.2.2'
@@ -74,8 +76,8 @@ dependencies {
     implementation group: 'net.kyori', name: 'adventure-text-minimessage', version: '4.2.0-SNAPSHOT'
     implementation group: 'net.kyori', name: 'adventure-platform-bukkit', version: '4.0.0'
     implementation group: 'com.github.stefvanschie.inventoryframework', name: 'IF', version: '0.10.0'
-    implementation group: 'dev.jorel', name: 'commandapi-shade', version: '8.1.0'
-    implementation "com.jeff_media:CustomBlockData:1.0.5"
+    implementation group: 'dev.jorel', name: 'commandapi-shade', version: '8.4.0-SNAPSHOT'
+    implementation "com.jeff_media:CustomBlockData:2.0.0"
 
     implementation(group: 'me.gabytm.util', name: 'actions-spigot', version: actionsVersion) { exclude group: 'com.google.guava' }
 }

--- a/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -82,7 +82,7 @@ public class CommandsManager {
                 .withArguments(new TextArgument("action")
                         .replaceSuggestions(ArgumentSuggestions.strings("send", "msg")))
                 .withArguments(new EntitySelectorArgument("targets",
-                        EntitySelectorArgument.EntitySelector.MANY_PLAYERS))
+                        EntitySelector.MANY_PLAYERS))
                 .executes((sender, args) -> {
                     final Collection<Player> targets = (Collection<Player>) args[1];
                     if (args[0].equals("msg"))
@@ -111,7 +111,7 @@ public class CommandsManager {
         return new CommandAPICommand("give")
                 .withPermission("oraxen.command.give")
                 .withArguments(new EntitySelectorArgument("targets",
-                                EntitySelectorArgument.EntitySelector.MANY_PLAYERS),
+                                EntitySelector.MANY_PLAYERS),
                         new TextArgument("item")
                                 .replaceSuggestions(ArgumentSuggestions.strings(OraxenItems.getItemNames())),
                         new IntegerArgument("amount"))
@@ -148,7 +148,7 @@ public class CommandsManager {
         return new CommandAPICommand("give")
                 .withPermission("oraxen.command.give")
                 .withArguments(new EntitySelectorArgument("targets",
-                                EntitySelectorArgument.EntitySelector.MANY_PLAYERS),
+                                EntitySelector.MANY_PLAYERS),
                         new TextArgument("item")
                                 .replaceSuggestions(ArgumentSuggestions.strings(info -> OraxenItems.getItemNames())))
                 .executes((sender, args) -> {
@@ -176,7 +176,7 @@ public class CommandsManager {
         return new CommandAPICommand("update")
                 .withPermission("oraxen.command.update")
                 .withArguments(new EntitySelectorArgument("targets",
-                        EntitySelectorArgument.EntitySelector.MANY_PLAYERS))
+                        EntitySelector.MANY_PLAYERS))
                 .withArguments(new TextArgument("type")
                         .replaceSuggestions(ArgumentSuggestions.strings("hand", "all")))
                 .executes((sender, args) -> {

--- a/src/main/java/io/th0rgal/oraxen/commands/RecipesCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/RecipesCommand.java
@@ -14,7 +14,7 @@ import io.th0rgal.oraxen.recipes.builders.ShapedBuilder;
 import io.th0rgal.oraxen.recipes.builders.ShapelessBuilder;
 import io.th0rgal.oraxen.recipes.listeners.RecipesEventsManager;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.entity.Player;
 
 import java.util.List;

--- a/src/main/java/io/th0rgal/oraxen/commands/RepairCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/RepairCommand.java
@@ -9,7 +9,7 @@ import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.durability.DurabilityMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.durability.DurabilityMechanicFactory;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -4,7 +4,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.Utils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -87,9 +87,8 @@ public class NoteBlockMechanicListener implements Listener {
         Player player = event.getPlayer();
         ItemStack item = event.getItem();
 
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || block == null || block.getType() != Material.NOTE_BLOCK)
-            return;
-        if (block.getType().isInteractable()) return;
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK || block == null || block.getType() != Material.NOTE_BLOCK) return;
+        if (block.getType().isInteractable() && block.getType() != Material.NOTE_BLOCK) return;
 
         NoteBlockMechanic noteBlockMechanic = getNoteBlockMechanic(block);
 
@@ -145,6 +144,7 @@ public class NoteBlockMechanicListener implements Listener {
             }
         }
 
+        if (type == null) return;
         if (type.hasGravity() && relative.getRelative(BlockFace.DOWN).getType() == Material.AIR) {
             block.getWorld().spawnFallingBlock(relative.getLocation().add(0.5,0,0.5), Bukkit.createBlockData(type));
             return;

--- a/src/main/resources/pack/pack.mcmeta
+++ b/src/main/resources/pack/pack.mcmeta
@@ -1,1 +1,1 @@
-{"pack":{"pack_format":8,"description":"§9§lOraxen §8| §7Extend the Game §7www§8.§7oraxen§8.§7com"}}
+{"pack":{"pack_format":9,"description":"§9§lOraxen §8| §7Extend the Game §7www§8.§7oraxen§8.§7com"}}


### PR DESCRIPTION
Keeps Spigot-api at 1.18 as no reason to bump this right now.
Compatibility should be kept as long as possible.

Currently shift-glyphs are broken and still not sure how the new system Mojang added works.
When that is sorted it should be good to go