### PR TITLE
Pack sender related fixes and changes.

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/pack/dispatch/AdvancedPackSender.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/dispatch/AdvancedPackSender.java
@@ -14,6 +14,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
@@ -35,12 +36,12 @@ public class AdvancedPackSender extends PackSender implements Listener {
 
     @Override
     public void register() {
-        if (Settings.SEND_PACK.toBool())
-            Bukkit.getPluginManager().registerEvents(this, OraxenPlugin.get());
+        Bukkit.getPluginManager().registerEvents(this, OraxenPlugin.get());
     }
 
     @Override
     public void unregister() {
+        HandlerList.unregisterAll(this);
     }
 
     @Override

--- a/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
@@ -12,6 +12,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 public class BukkitPackSender extends PackSender implements Listener {
+
     public BukkitPackSender(HostingProvider hostingProvider) {
         super(hostingProvider);
     }


### PR DESCRIPTION
Made some changes that fix the problem with the pack being loaded multiple times when a player joins the server.

Made the reload command to be able to un-register the join event if the user decides to disable both the send-pack and send-join-message options.