### PR TITLE
Fixed an error related to the oraxen pack command and also fixed two issues with the sitting ability of the furniture mechanic.

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -33,6 +33,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryCreativeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -140,7 +141,7 @@ public class FurnitureListener implements Listener {
                 mechanic.hasBarriers()
                         && mechanic.getBarriers().size() > 1);
 
-        final float yaw = mechanic.getYaw(rotation) + mechanic.getSeatYaw();
+        final float yaw = mechanic.getYaw(rotation);
 
         if (!mechanic.isEnoughSpace(yaw, target.getLocation())) {
             blockPlaceEvent.setCancelled(true);
@@ -386,6 +387,17 @@ public class FurnitureListener implements Listener {
                 }
             }
             event.setCursor(OraxenItems.getItemById(id).build());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuitEvent(final PlayerQuitEvent event) {
+        final Player player = event.getPlayer();
+        final Entity vehicle = player.getVehicle();
+        if (vehicle instanceof final ArmorStand armorStand) {
+            if (armorStand.getPersistentDataContainer().has(SEAT_KEY, PersistentDataType.STRING)) {
+                player.leaveVehicle();
+            }
         }
     }
 

--- a/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
@@ -70,19 +70,17 @@ public class UploadManager {
                     Template.template("url", hostingProvider.getPackURL()),
                     Template.template("delay", String.valueOf(System.currentTimeMillis() - time)));
 
+            if (packSender == null) {
+                packSender = (CompatibilitiesManager.hasPlugin("ProtocolLib") && Settings.SEND_PACK_ADVANCED.toBool())
+                        ? new AdvancedPackSender(hostingProvider) : new BukkitPackSender(hostingProvider);
+            } else if (updatePackSender) {
+                packSender.unregister();
+                packSender = (CompatibilitiesManager.hasPlugin("ProtocolLib") && Settings.SEND_PACK_ADVANCED.toBool())
+                        ? new AdvancedPackSender(hostingProvider) : new BukkitPackSender(hostingProvider);
+            }
+
             if (Settings.SEND_PACK.toBool() || Settings.SEND_JOIN_MESSAGE.toBool()) {
-                if (packSender == null) {
-                    packSender = (CompatibilitiesManager.hasPlugin("ProtocolLib") && Settings.SEND_PACK_ADVANCED.toBool())
-                            ? new AdvancedPackSender(hostingProvider) : new BukkitPackSender(hostingProvider);
-                    packSender.register();
-                } else {
-                    if (updatePackSender) {
-                        packSender.unregister();
-                        packSender = (CompatibilitiesManager.hasPlugin("ProtocolLib") && Settings.SEND_PACK_ADVANCED.toBool())
-                                ? new AdvancedPackSender(hostingProvider) : new BukkitPackSender(hostingProvider);
-                        packSender.register();
-                    }
-                }
+                packSender.register();
                 if (!hostingProvider.getPackURL().equals(url))
                     for (Player player : Bukkit.getOnlinePlayers())
                         packSender.sendPack(player);
@@ -90,7 +88,6 @@ public class UploadManager {
             } else {
                 if (packSender != null) {
                     packSender.unregister();
-                    packSender = null;
                 }
             }
         });


### PR DESCRIPTION
This PR fixes one error produced by the oraxen pack command if someone had both the send_pack and the send_join_message options set to false. The PR  also fixes two problems with the sitting ability of the furniture mechanic. The first problem is the rotation of the player when they are sitting on furniture, and the second problem is the ability of the player to seat on furniture if another player was sitting there and then left the server.

For the first problem, I kept the ability for someone to set the yaw of the seat manually through the config like this:

```
seat:
  height: 0
  yaw: 0
```

But now you can just remove the yaw option and the plugin will set the yaw based on the rotation of the furniture. Example:
```
seat:
  height: 0
```

For the second problem, I added a PlayerQuitListener that checks if the player was sitting on an armor stand(placed by the plugin). If this is the case it makes the player to stand up from the furniture.

Here are some videos demonstrating the two problems with the sitting ability of the furniture mechanic and their fixes:
1. [The first problem](https://www.youtube.com/watch?v=ksems7x32mI) | [The fix](https://www.youtube.com/watch?v=Lt0A5mfoNWU)
2. [The second problem](https://www.youtube.com/watch?v=GOjWVt3kxQg) | [The fix](https://www.youtube.com/watch?v=M4sMNtAB6xw)