### PR TITLE
add check for schedulers

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock;
 
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
@@ -188,6 +189,11 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
     public void registerFarmBlock() {
         if (farmBlock) return;
         if (farmBlockTask != null) farmBlockTask.cancel();
+
+        // Dont register if there is no farmblocks in configs
+        if (OraxenItems.getItems().stream().filter(item ->
+                ((NoteBlockMechanic)NoteBlockMechanicFactory.getInstance()
+                        .getMechanic(OraxenItems.getIdByItem(item.build()))).hasDryout()).toList().isEmpty()) return;
 
         farmBlockTask = new FarmBlockTask(this, farmBlockCheckDelay);
         farmBlockTask.runTaskTimer(OraxenPlugin.get(), 0, farmBlockCheckDelay);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock;
 
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
@@ -151,6 +152,11 @@ public class StringBlockMechanicFactory extends MechanicFactory {
     public void registerSaplingMechanic() {
         if (sapling) return;
         if (saplingTask != null) saplingTask.cancel();
+
+        // Dont register if there is no sapling in configs
+        if (OraxenItems.getItems().stream().filter(item ->
+                ((StringBlockMechanic) StringBlockMechanicFactory.getInstance()
+                        .getMechanic(OraxenItems.getIdByItem(item.build()))).isSapling()).toList().isEmpty()) return;
 
         saplingTask = new SaplingTask(this, saplingGrowthCheckDelay);
         saplingTask.runTaskTimer(OraxenPlugin.get(), 0, saplingGrowthCheckDelay);


### PR DESCRIPTION
Idea is that they wont run unless theres an item configured with it
Could simply add more options in mechanics.yml but this feels abit more dynamic and more supporting of backwards compat

not the prettiest but easiest way i could find to loop through itemconfigs and look for mechanic X