### PR TITLE
Fixes for the furniture, string and noteblock mechanics.

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen;
 
+import com.jeff_media.customblockdata.CustomBlockData;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIConfig;
 import io.th0rgal.oraxen.commands.CommandsManager;
@@ -66,6 +67,7 @@ public class OraxenPlugin extends JavaPlugin {
         final PluginManager pluginManager = Bukkit.getPluginManager();
         resourcePack = new ResourcePack(this);
         MechanicsManager.registerNativeMechanics();
+        CustomBlockData.registerListener(this);
         fontManager = new FontManager(configsManager);
         soundManager = new SoundManager(configsManager.getSound());
         OraxenItems.loadItems(configsManager);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -38,6 +38,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.RayTraceResult;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -362,7 +363,9 @@ public class FurnitureListener implements Listener {
         final Player player = (Player) event.getInventory().getHolder();
         if (player == null) return;
         if (event.getCursor().getType() == Material.BARRIER) {
-            final Block block = player.rayTraceBlocks(6.0).getHitBlock();
+            final RayTraceResult rayTraceResult = player.rayTraceBlocks(6.0);
+            if (rayTraceResult == null) return;
+            final Block block = rayTraceResult.getHitBlock();
             if (block == null) return;
             FurnitureMechanic furnitureMechanic = getFurnitureMechanic(block);
             if (furnitureMechanic == null) return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -36,6 +36,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.RayTraceResult;
 
 import java.util.List;
 import java.util.Objects;
@@ -341,7 +342,9 @@ public class NoteBlockMechanicListener implements Listener {
         final Player player = (Player) event.getInventory().getHolder();
         if (player == null) return;
         if (event.getCursor().getType() == Material.NOTE_BLOCK) {
-            final Block block = Objects.requireNonNull(player.rayTraceBlocks(6.0)).getHitBlock();
+            final RayTraceResult rayTraceResult = player.rayTraceBlocks(6.0);
+            if (rayTraceResult == null) return;
+            final Block block = rayTraceResult.getHitBlock();
             if (block == null) return;
             NoteBlockMechanic noteBlockMechanic = getNoteBlockMechanic(block);
             if (noteBlockMechanic == null) return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -34,6 +34,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.RayTraceResult;
 
 import java.util.List;
 import java.util.Objects;
@@ -272,7 +273,9 @@ public class StringBlockMechanicListener implements Listener {
         final Player player = (Player) event.getInventory().getHolder();
         if (player == null) return;
         if (event.getCursor().getType() == Material.STRING) {
-            final Block block = Objects.requireNonNull(player.rayTraceBlocks(6.0)).getHitBlock();
+            final RayTraceResult rayTraceResult = player.rayTraceBlocks(6.0);
+            if (rayTraceResult == null) return;
+            final Block block = rayTraceResult.getHitBlock();
             if (block == null) return;
             StringBlockMechanic stringBlockMechanic = getStringMechanic(block);
             if (stringBlockMechanic == null) return;


### PR DESCRIPTION
This PR fixes an error that could happen if someone was in creative mode and was moving a barrier block in their inventory while targeting a furniture block from 6+ blocks afar(This is also present to the string mechanic and noteblock mechanic). [furniture mechanic error](https://youtu.be/HRG7y83hK3s), [string mechanic error](https://youtu.be/hUA4caWPhE4), [noteblock mechanic error](https://youtu.be/I9MtJmJWp9A)

This PR also fixes an issue with the furniture mechanic not clearing the added block data. This could result in the following [problem](https://youtu.be/2P2dMWjeqs8) when you were middle-clicking a barrier block that was added at a location where previously was a furniture block.