### PR TITLE
Update mcv to 1.19 & Fixed server crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ compileJava {
 dependencies {
     def actionsVersion = '1.0.0-SNAPSHOT'
 
-    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.18-R0.1-SNAPSHOT'
-    compileOnly("io.papermc.paper:paper-api:1.18-R0.1-SNAPSHOT") { exclude group: 'net.kyori' }
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.19-R0.1-SNAPSHOT'
+    compileOnly("io.papermc.paper:paper-api:1.19-R0.1-SNAPSHOT") { exclude group: 'net.kyori' }
     compileOnly group: 'com.github.dmulloy2', name: 'ProtocolLib', version: '4.8.0'
     compileOnly group: 'com.github.Hazebyte', name: 'CrateReloadedAPI', version: 'd7ae2a14c6'
     compileOnly group: 'com.github.jojodmo', name: 'ItemBridge', version: '-SNAPSHOT'

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -24,6 +24,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.world.GenericGameEvent;
 import org.bukkit.inventory.ItemStack;
 
+import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
+
 public class BlockMechanicListener implements Listener {
 
     private final MechanicFactory factory;
@@ -129,6 +131,9 @@ public class BlockMechanicListener implements Listener {
     public void onStep(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
         Block below = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
         SoundGroup soundGroup = below.getBlockData().getSoundGroup();
 
@@ -145,6 +150,9 @@ public class BlockMechanicListener implements Listener {
     public void onFall(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
         Block below = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
         SoundGroup soundGroup = below.getBlockData().getSoundGroup();
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic.FARMBLOCK_KEY;
 import static io.th0rgal.oraxen.utils.BlockHelpers.getAnvilFacing;
+import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
 
 public class NoteBlockMechanicListener implements Listener {
     private final MechanicFactory factory;
@@ -80,6 +81,8 @@ public class NoteBlockMechanicListener implements Listener {
     public void onNoteblockPowered(final GenericGameEvent event) {
         Block block = event.getLocation().getBlock();
         NamespacedKey eventKey = NamespacedKey.minecraft("note_block_play");
+        Location eLoc = block.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
 
         // This GameEvent only exists in 1.19
         // If server is 1.18 check if its there and if not return
@@ -299,6 +302,9 @@ public class NoteBlockMechanicListener implements Listener {
     public void onStep(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
         Block below = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
         SoundGroup soundGroup = below.getBlockData().getSoundGroup();
         NoteBlockMechanic mechanic = getNoteBlockMechanic(below);
@@ -320,7 +326,10 @@ public class NoteBlockMechanicListener implements Listener {
     public void onFall(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
-        Block below = entity.getLocation().getBlock().getRelative(BlockFace.DOWN);
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
+        Block below = eLoc.getBlock().getRelative(BlockFace.DOWN);
         SoundGroup soundGroup = below.getBlockData().getSoundGroup();
         NoteBlockMechanic mechanic = getNoteBlockMechanic(below);
         if (mechanic != null && mechanic.isDirectional()) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.sapling.SaplingMechanic.SAPLING_KEY;
+import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
 
 public class StringBlockMechanicListener implements Listener {
 
@@ -245,6 +246,9 @@ public class StringBlockMechanicListener implements Listener {
     public void onStep(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
         Block block = entity.getLocation().getBlock();
         StringBlockMechanic mechanic = getStringMechanic(block);
         SoundGroup soundGroup = block.getBlockData().getSoundGroup();
@@ -258,6 +262,9 @@ public class StringBlockMechanicListener implements Listener {
     public void onFall(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
         Block block = entity.getLocation().getBlock();
         StringBlockMechanic mechanic = getStringMechanic(block);
 

--- a/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -1,6 +1,6 @@
 package io.th0rgal.oraxen.utils;
 
-import org.apache.commons.lang.math.IntRange;
+import org.apache.commons.lang3.Range;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.block.*;
@@ -285,19 +285,19 @@ public class BlockHelpers {
     private static BlockFace getRelativeFacing(Player player) {
         double yaw = player.getLocation().getYaw();
         BlockFace face = BlockFace.SELF;
-        if (new IntRange(0.0, 22.5).containsDouble(yaw) || yaw >= 337.5 || yaw >= -22.5 && yaw <= 0.0 || yaw <= -337.5)
+        if (Range.between(0.0, 22.5).contains(yaw) || yaw >= 337.5 || yaw >= -22.5 && yaw <= 0.0 || yaw <= -337.5)
             face = BlockFace.SOUTH;
-        else if (new IntRange(22.5, 67.5).containsDouble(yaw) || new IntRange(-337.5, -292.5).containsDouble(yaw))
+        else if (Range.between(22.5, 67.5).contains(yaw) || Range.between(-337.5, -292.5).contains(yaw))
             face = BlockFace.WEST;
-        else if (new IntRange(112.5, 157.5).containsDouble(yaw) || new IntRange(-292.5, -247.5).containsDouble(yaw))
+        else if (Range.between(112.5, 157.5).contains(yaw) || Range.between(-292.5, -247.5).contains(yaw))
             face = BlockFace.NORTH_WEST;
-        else if (new IntRange(157.5, 202.5).containsDouble(yaw) || new IntRange(-202.5, -157.5).containsDouble(yaw))
+        else if (Range.between(157.5, 202.5).contains(yaw) || Range.between(-202.5, -157.5).contains(yaw))
             face = BlockFace.NORTH;
-        else if (new IntRange(202.5, 247.5).containsDouble(yaw) || new IntRange(-157.5, -112.5).containsDouble(yaw))
+        else if (Range.between(202.5, 247.5).contains(yaw) || Range.between(-157.5, -112.5).contains(yaw))
             face = BlockFace.NORTH_EAST;
-        else if (new IntRange(247.5, 292.5).containsDouble(yaw) || new IntRange(-112.5, -67.5).containsDouble(yaw))
+        else if (Range.between(247.5, 292.5).contains(yaw) || Range.between(-112.5, -67.5).contains(yaw))
             face = BlockFace.EAST;
-        else if (new IntRange(292.5, 337.5).containsDouble(yaw) || new IntRange(-67.5, -22.5).containsDouble(yaw))
+        else if (Range.between(292.5, 337.5).contains(yaw) || Range.between(-67.5, -22.5).contains(yaw))
             face = BlockFace.SOUTH_EAST;
         return face;
     }

--- a/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -311,4 +311,17 @@ public class BlockHelpers {
             default -> BlockFace.NORTH;
         };
     }
+
+    /*
+    * Calling loc.getChunk() will crash a Paper 1.19 build 62-66 (possibly more) Server if the Chunk does not exist.
+    * Instead, get Chunk location and check with World.isChunkLoaded() if the Chunk is loaded.
+    */
+    public static boolean isLoaded(World world, Location loc) {
+        return world.isChunkLoaded(loc.getBlockX() >> 4, loc.getBlockZ() >> 4);
+    }
+
+    public static boolean isLoaded(Location loc) {
+        return loc.getWorld() != null && isLoaded(loc.getWorld(), loc);
+    }
+
 }


### PR DESCRIPTION
Updated mcv 1.19:
 > Only updated the version in build.gradle

Fixed server crash:
 > In Paper 1.19 build 62 - 66 (possibly more) the Server crashes when e.g. Location.getChunk() or similar Chunk related methods are called if the given Chunk does not yet exist.
 -> Added isLoaded() method to BlockHelper
 -> Added isLoaded() call to all GenericGameEvent methods that seem to be able to crash the Server (Provide not existent Chunk data).
 Side-note: All 'missing' Chunks seem to be in the nether.