### PR TITLE
Minor features and bugfixes

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -9,6 +9,7 @@ import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.items.OraxenItems;
 import net.kyori.adventure.text.minimessage.Template;
 import org.bukkit.Color;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -21,6 +22,9 @@ import java.util.Map;
 public class CommandsManager {
 
     public void loadCommands() {
+        ConfigurationSection commandsSection =
+                OraxenPlugin.get().getConfigsManager().getSettings().getConfigurationSection("Plugin.commands");
+        if (commandsSection == null) return;
         new CommandAPICommand("oraxen")
                 .withAliases("o", "oxn")
                 .withPermission("oraxen.command")
@@ -35,7 +39,7 @@ public class CommandsManager {
                 .withSubcommand((new ReloadCommand()).getReloadCommand())
                 .withSubcommand((new DebugCommand()).getDebugCommand())
                 .withSubcommand((new ModelDataCommand()).getHighestModelDataCommand())
-                .withSubcommand((new GlyphCommand()).getGlyphCommand())
+                .withSubcommand((new GlyphCommand()).getGlyphCommand(commandsSection))
                 .withSubcommand((new PrintGlyphCommand()).getPrintGlyphCommand())
                 .executes((sender, args) -> {
                     Message.COMMAND_HELP.send(sender);

--- a/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
@@ -1,9 +1,8 @@
 package io.th0rgal.oraxen.commands;
 
 import dev.jorel.commandapi.CommandAPICommand;
-import dev.jorel.commandapi.arguments.ArgumentSuggestions;
-import dev.jorel.commandapi.arguments.TextArgument;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.font.Glyph;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -11,6 +10,7 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -25,14 +25,19 @@ import static org.bukkit.inventory.meta.BookMeta.Generation.ORIGINAL;
 
 public class GlyphCommand {
 
-    public CommandAPICommand getGlyphCommand() {
-        return new CommandAPICommand("emoji")
-                .withPermission("oraxen.command.emoji")
-                .withArguments(new TextArgument("type").replaceSuggestions(
-                        ArgumentSuggestions.strings("list")))
+    public CommandAPICommand getGlyphCommand(ConfigurationSection commandsSection) {
+        ConfigurationSection emojiSection = commandsSection.getConfigurationSection("emoji_list");
+        List<Glyph> emojiList = OraxenPlugin.get().getFontManager().getEmojis().stream().toList();
+
+        return new CommandAPICommand("emojis")
+                .withPermission("oraxen.command.emojis").withPermission("oraxen.command.emoji")
                 .executes((sender, args) -> {
                     Player player = ((Player) sender);
-                    List<Glyph> emojis = OraxenPlugin.get().getFontManager().getEmojis().stream().filter(glyph -> glyph.hasPermission(player)).toList();
+                    if (emojiSection == null) return;
+                    boolean onlyShowPermissable = emojiSection.getBoolean("only_show_emojis_with_permission");
+
+                    List<Glyph> emojis = !onlyShowPermissable
+                            ? emojiList : emojiList.stream().filter(glyph -> glyph.hasPermission(player)).toList();
                     List<BaseComponent[]> list = new ArrayList<>();
                     BaseComponent[] page;
                     ComponentBuilder page2 = new ComponentBuilder("");
@@ -40,7 +45,11 @@ public class GlyphCommand {
 
                     ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
                     BookMeta meta = (BookMeta) book.getItemMeta();
-                    if (meta == null || emojis.isEmpty()) return;
+
+                    if (meta == null || emojis.isEmpty()) {
+                        Message.NO_EMOJIS.send(player);
+                        return;
+                    }
 
                     meta.setTitle("Glyph Book");
                     meta.setAuthor("Oraxen");
@@ -53,16 +62,21 @@ public class GlyphCommand {
                             Glyph emoji = (emojis.get(p * 256 + i));
                             String[] placeholders = emoji.getPlaceholders();
                             String finalString = "";
+                            String permissionMessage = "";
                             for (String placeholder : placeholders) {
                                 if (Arrays.toString(placeholders).replace("]", "").endsWith(placeholder)) {
                                     finalString += placeholder;
                                 } else {
                                     finalString += (placeholder + "\n");
                                 }
+
+                                if (!onlyShowPermissable)
+                                    permissionMessage += emoji.hasPermission(player) ?
+                                            ("\n" + ChatColor.GREEN + "Permitted") : ("\n" + ChatColor.RED +"No Permission");
                             }
                             page = new ComponentBuilder(ChatColor.WHITE + String.valueOf(emoji.getCharacter()))
                                     .event(new ClickEvent(SUGGEST_COMMAND, String.valueOf(emoji.getCharacter())))
-                                    .event(new HoverEvent(SHOW_TEXT, new ComponentBuilder(finalString).create()))
+                                    .event(new HoverEvent(SHOW_TEXT, new ComponentBuilder(finalString + permissionMessage).create()))
                                     .create();
                              list.add(page);
                         }

--- a/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -9,6 +9,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum Message {
 
     // general
@@ -83,9 +86,11 @@ public enum Message {
 
     public void send(final CommandSender sender, final Template... placeholders) {
         String lang = OraxenPlugin.get().getConfigsManager().getLanguage().getString(path);
+        ArrayList<Template> templates = new ArrayList<>(List.of(placeholders));
+        templates.add(Template.template("prefix", Message.PREFIX.toComponent()));
         if (lang == null) return;
         OraxenPlugin.get().getAudience().sender(sender).sendMessage(
-                Utils.MINI_MESSAGE.deserialize(lang, TemplateResolver.templates(placeholders))
+                Utils.MINI_MESSAGE.deserialize(lang, TemplateResolver.templates(templates))
         );
     }
 

--- a/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -4,7 +4,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.Utils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.Template;
-import org.apache.commons.lang3.ArrayUtils;
+import net.kyori.adventure.text.minimessage.template.TemplateResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
@@ -82,11 +82,10 @@ public enum Message {
     }
 
     public void send(final CommandSender sender, final Template... placeholders) {
+        String lang = OraxenPlugin.get().getConfigsManager().getLanguage().getString(path);
+        if (lang == null) return;
         OraxenPlugin.get().getAudience().sender(sender).sendMessage(
-                Utils.MINI_MESSAGE.parse(OraxenPlugin.get().getConfigsManager().getLanguage().getString(path),
-                        ArrayUtils.addAll(new Template[]{
-                                        Template.template("prefix", Message.PREFIX.toComponent())},
-                                placeholders))
+                Utils.MINI_MESSAGE.deserialize(lang, TemplateResolver.templates(placeholders))
         );
     }
 

--- a/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -36,6 +36,7 @@ public enum Message {
     NOT_ENOUGH_EXP("general.not_enough_exp"),
     NOT_ENOUGH_SPACE("general.not_enough_space"),
     EXIT_MENU("general.exit_menu"),
+    NO_EMOJIS("general.no_emojis"),
 
     // logs
     PLUGIN_LOADED("logs.loaded"),

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.*;
 
 public class FontManager {
@@ -101,7 +102,8 @@ public class FontManager {
 
     public String getShift(int length) {
         // Ensure shifts.yml exists as it is required
-        OraxenPlugin.get().saveResource("glyphs/shifts.yml", false);
+        if (!Path.of(OraxenPlugin.get().getDataFolder() + "/glyphs/shifts.yml").toFile().exists())
+            OraxenPlugin.get().saveResource("glyphs/shifts.yml", false);
         StringBuilder output = new StringBuilder();
         while (length > 0) {
             int biggestPower = Integer.highestOneBit(length);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -243,7 +243,7 @@ public class FurnitureListener implements Listener {
 
                     mechanic.removeAirFurniture(frame);
                     if (player.getGameMode() != GameMode.CREATIVE)
-                        mechanic.getDrop().spawns(frame.getLocation(), player.getInventory().getItemInMainHand());
+                        mechanic.getDrop().furnitureSpawns(frame, player.getInventory().getItemInMainHand());
                 }
             }
     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -2,8 +2,6 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock;
 
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.items.ItemBuilder;
-import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
@@ -18,7 +16,10 @@ import org.bukkit.block.Block;
 import org.bukkit.block.data.type.NoteBlock;
 import org.bukkit.configuration.ConfigurationSection;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class NoteBlockMechanicFactory extends MechanicFactory {
 
@@ -188,15 +189,15 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
         if (farmBlock) return;
         if (farmBlockTask != null) farmBlockTask.cancel();
 
-        // Dont register if there is no farmblocks in configs
-        List<String> farmblockList = new ArrayList<>();
-        for (ItemBuilder itemBuilder : OraxenItems.getItems()) {
-            String id = OraxenItems.getIdByItem(itemBuilder.build());
-            NoteBlockMechanic mechanic = (NoteBlockMechanic) NoteBlockMechanicFactory.getInstance().getMechanic(id);
-            if (mechanic == null || !mechanic.hasDryout()) continue;
-            farmblockList.add(id);
-        }
-        if (farmblockList.isEmpty()) return;
+//        // Dont register if there is no farmblocks in configs
+//        List<String> farmblockList = new ArrayList<>();
+//        for (ItemBuilder itemBuilder : OraxenItems.getItems()) {
+//            String id = OraxenItems.getIdByItem(itemBuilder.build());
+//            NoteBlockMechanic mechanic = (NoteBlockMechanic) NoteBlockMechanicFactory.getInstance().getMechanic(id);
+//            if (mechanic == null || !mechanic.hasDryout()) continue;
+//            farmblockList.add(id);
+//        }
+//        if (farmblockList.isEmpty()) return;
 
         farmBlockTask = new FarmBlockTask(farmBlockCheckDelay);
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
@@ -2,8 +2,6 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock;
 
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.items.ItemBuilder;
-import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
@@ -17,7 +15,10 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Tripwire;
 import org.bukkit.configuration.ConfigurationSection;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class StringBlockMechanicFactory extends MechanicFactory {
 
@@ -152,15 +153,16 @@ public class StringBlockMechanicFactory extends MechanicFactory {
         if (sapling) return;
         if (saplingTask != null) saplingTask.cancel();
 
+        // Disabled for abit as OraxenItems.getItems() here
         // Dont register if there is no sapling in configs
-        List<String> saplingList = new ArrayList<>();
-        for (ItemBuilder itemBuilder : OraxenItems.getItems()) {
-            String id = OraxenItems.getIdByItem(itemBuilder.build());
-            StringBlockMechanic mechanic = (StringBlockMechanic) StringBlockMechanicFactory.getInstance().getMechanic(id);
-            if (mechanic == null || !mechanic.isSapling()) continue;
-            saplingList.add(id);
-        }
-        if (saplingList.isEmpty()) return;
+//        List<String> saplingList = new ArrayList<>();
+//        for (ItemBuilder itemBuilder : OraxenItems.getItems()) {
+//            String id = OraxenItems.getIdByItem(itemBuilder.build());
+//            StringBlockMechanic mechanic = (StringBlockMechanic) StringBlockMechanicFactory.getInstance().getMechanic(id);
+//            if (mechanic == null || !mechanic.isSapling()) continue;
+//            saplingList.add(id);
+//        }
+//        if (saplingList.isEmpty()) return;
 
         saplingTask = new SaplingTask(saplingGrowthCheckDelay);
         saplingTask.runTaskTimer(OraxenPlugin.get(), 0, saplingGrowthCheckDelay);

--- a/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
+++ b/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
@@ -18,6 +18,7 @@ public class CustomSound {
         this.name = name;
         List<String> temp = new ArrayList<>();
         for (String sound : sounds) {
+            if (sound == null) continue;
             temp.add(sound.replace(".ogg", ""));
         }
         this.sounds.addAll(temp);

--- a/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
+++ b/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
@@ -3,9 +3,7 @@ package io.th0rgal.oraxen.sound;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Objects;
+import java.util.*;
 
 public class SoundManager {
 
@@ -25,8 +23,10 @@ public class SoundManager {
         for (String soundName : section.getKeys(true)) {
             ConfigurationSection sound = section.getConfigurationSection(soundName);
             if (sound == null) continue;
+            List<String> sounds = !sound.getStringList("sounds").isEmpty() ?
+                    sound.getStringList("sounds") : Collections.singletonList(sound.getString("sound"));
             output.add(new CustomSound(
-                    soundName, sound.getStringList("sounds"), sound.getString("category"),
+                    soundName, sounds, sound.getString("category"),
                     sound.getBoolean("replace"), sound.getString("subtitle"))
             );
         }

--- a/src/main/resources/languages/czech.yml
+++ b/src/main/resources/languages/czech.yml
@@ -23,6 +23,7 @@ general:
   not_enough_exp: "<prefix><#fa4943>Na tohle potřebuješ více zkušeností"
   not_enough_space: "<prefix><#fa4943>Potřebuješ více místa pro položení tohoto nábytku"
   exit_menu: "<gradient:#FA7CBB:#F14658>Odejít"
+  no_emojis: "<prefix><#fa4943>No emojis found"
 
 logs:
   loaded: "<prefix><#55ffa4>Úspěšně načten na <os>"

--- a/src/main/resources/languages/english.yml
+++ b/src/main/resources/languages/english.yml
@@ -23,6 +23,7 @@ general:
   not_enough_exp: "<prefix><#fa4943>You need more experience to do this"
   not_enough_space: "<prefix><#fa4943>You need more space to place this furniture"
   exit_menu: "<gradient:#FA7CBB:#F14658>Exit"
+  no_emojis: "<prefix><#fa4943>No emojis found"
 
 logs:
   loaded: "<prefix><#55ffa4>Successfully loaded on <os>"

--- a/src/main/resources/languages/english.yml
+++ b/src/main/resources/languages/english.yml
@@ -49,15 +49,11 @@ command:
           <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> open recipes builder
         \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
           <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> save recipe"
-  join: "
-        <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> Resource Pack </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
-
-        <gray><bold>To see the new items you need to use a special resourcepack (but don't worry, this doesn't prevent you from using yours at the same time).</bold>
-
-        <dark_gray>»<gray> To try to load it directly from the game, <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ loading the resourcepack from the game can cause lags\"><red><bold>CLICK HERE</bold></hover></click>
-
-        <dark_gray>»<gray> To download it from the internet, <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ install it from Options/ResourcePacks in your game\"><green><bold>CLICK HERE</bold></hover></click>
-        "
+  join: |-
+    <dark_gray><st>                           </st><dark_gray>{<aqua><bold>Resource Pack</bold><dark_gray>}<dark_gray><st>                        </st>
+    <gray><bold>To see the new items you need to use a special resourcepack (but don't worry, this doesn't prevent you from using yours at the same time).</bold>
+    <dark_gray>»<gray> To try to load it directly from the game, <click:run_command:oraxen pack send @p><hover:show_text:"<red>! loading the resourcepack from the game can cause lags"><red><bold>CLICK HERE</bold></hover></click>
+    <dark_gray>»<gray> To download it from the internet, <hover:show_text:" <green>! install it from Options/ResourcePacks in your game"><green><bold><click:OPEN_URL:'<pack_url>'>CLICK HERE</click></bold></hover>
 
   recipe:
     no_builder: "<prefix><#fa4943>Please create a recipe first!"

--- a/src/main/resources/languages/english.yml
+++ b/src/main/resources/languages/english.yml
@@ -49,11 +49,12 @@ command:
           <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> open recipes builder
         \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
           <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> save recipe"
+
   join: |-
     <dark_gray><st>                           </st><dark_gray>{<aqua><bold>Resource Pack</bold><dark_gray>}<dark_gray><st>                        </st>
     <gray><bold>To see the new items you need to use a special resourcepack (but don't worry, this doesn't prevent you from using yours at the same time).</bold>
     <dark_gray>»<gray> To try to load it directly from the game, <click:run_command:oraxen pack send @p><hover:show_text:"<red>! loading the resourcepack from the game can cause lags"><red><bold>CLICK HERE</bold></hover></click>
-    <dark_gray>»<gray> To download it from the internet, <hover:show_text:" <green>! install it from Options/ResourcePacks in your game"><green><bold><click:OPEN_URL:'<pack_url>'>CLICK HERE</click></bold></hover>
+    <dark_gray>»<gray> To download it from the internet, <hover:show_text:'<pack_url>' <green>! install it from Options/ResourcePacks in your game"><green><bold><click:OPEN_URL:'<pack_url>'>CLICK HERE</click></bold></hover>
 
   recipe:
     no_builder: "<prefix><#fa4943>Please create a recipe first!"

--- a/src/main/resources/languages/french.yml
+++ b/src/main/resources/languages/french.yml
@@ -23,6 +23,7 @@ general:
   not_enough_exp: "<prefix><#fa4943>Vous avez besoin de plus d'expérience pour faire ceci"
   not_enough_space: "<prefix><#fa4943>Vous avez besoin de plus de place pour placer cet équipement"
   exit_menu: "<gradient:#FA7CBB:#F14658>Quitter"
+  no_emojis: "<prefix><#fa4943>No emojis found"
 
 logs:
   loaded: "<prefix><#55ffa4>Chargé avec succès sur <os>"

--- a/src/main/resources/languages/german.yml
+++ b/src/main/resources/languages/german.yml
@@ -23,6 +23,7 @@ general:
   not_enough_exp: "<prefix><#fa4943>Sie brauchen mehr Erfahrung, um dies zu tun"
   not_enough_space: "<prefix><#fa4943>Sie brauchen mehr Platz, um diese Möbel zu platzieren"
   exit_menu: "<gradient:#FA7CBB:#F14658>Beenden"
+  no_emojis: "<prefix><#fa4943>No emojis found"
 
 logs:
   loaded: "<prefix><#55ffa4>Erfolgreich geladen auf <os>"

--- a/src/main/resources/languages/zh-CN.yml
+++ b/src/main/resources/languages/zh-CN.yml
@@ -23,6 +23,7 @@ general:
   not_enough_exp: "<prefix><#fa4943>经验值好像不够欸"
   not_enough_space: "<prefix><#fa4943>你需要更多的空间来放置这个家具"
   exit_menu: "<gradient:#FA7CBB:#F14658>退出"
+  no_emojis: "<prefix><#fa4943>No emojis found"
 
 logs:
   loaded: "<prefix><#55ffa4>已成功在 <os> 载入"

--- a/src/main/resources/languages/zh-TW.yml
+++ b/src/main/resources/languages/zh-TW.yml
@@ -23,6 +23,7 @@ general:
   not_enough_exp: "<prefix><#fa4943>經驗值好像不夠欸"
   not_enough_space: "<prefix><#fa4943>你需要更多的空間來放置這個傢俱"
   exit_menu: "<gradient:#FA7CBB:#F14658>退出"
+  no_emojis: "<prefix><#fa4943>No emojis found"
 
 logs:
   loaded: "<prefix><#55ffa4>已成功在 <os> 載入"

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -3,6 +3,8 @@ Plugin:
   commands:
     repair:
       oraxen_durability_only: false # will not repair vanilla items if set to true
+    emoji_list:
+      only_show_emojis_with_permission: true # will only show emojis player has permission to use if set to true
 
 Pack:
   generation:


### PR DESCRIPTION
Some old sounds didnt work as forgot to change `sound` to `sounds`.
This adds option to either specify 1 sound with `sound` or a list with `sounds`.
Also fixes some issues with CB sounds

Adds option to emoji list (now `/oraxen emoji`) to display all emojis, not on permission basis via settings.yml (adds hovermsg to showcase those you dont have perm for)
add check for shifts.yml to prevent console warning (harmless but annoying)

update MiniMessage parse method as scheduled to be removed someday

Fix bug with non-barrier furniture dropping dyed furniture incorrectly