### PR TITLE
add sounds to furniture

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanic.java
@@ -79,24 +79,31 @@ public class BlockMechanic extends Mechanic {
         return breakSound != null;
     }
     public String getBreakSound() {
-        return breakSound;
+        return validateReplacedSounds(breakSound);
     }
 
     public boolean hasPlaceSound() {
         return placeSound != null;
     }
     public String getPlaceSound() {
-        return placeSound;
+        return validateReplacedSounds(placeSound);
     }
 
     public boolean hasStepSound() { return stepSound != null; }
-    public String getStepSound() { return stepSound; }
+    public String getStepSound() { return validateReplacedSounds(stepSound); }
 
     public boolean hasHitSound() { return hitSound != null; }
-    public String getHitSound() { return hitSound; }
+    public String getHitSound() { return validateReplacedSounds(hitSound); }
 
     public boolean hasFallSound() { return fallSound != null; }
-    public String getFallSound() { return fallSound; }
+    public String getFallSound() { return validateReplacedSounds(fallSound); }
+    private String validateReplacedSounds(String sound) {
+        if (sound.startsWith("block.wood"))
+            return sound.replace("block.wood", "required.wood.");
+        else if (sound.startsWith("block.stone"))
+            return sound.replace("block.stone", "required.stone.");
+        else return sound;
+    }
 
     public static int getCode(final MultipleFacing blockData) {
         final List<BlockFace> properties = Arrays

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -67,9 +67,13 @@ public class BlockMechanicListener implements Listener {
             return;
 
         final Block block = event.getBlock();
-        final BlockData blockData = block.getBlockData();
-        BlockMechanic.setBlockFacing((MultipleFacing) blockData, 15);
+        final MultipleFacing blockData = (MultipleFacing) block.getBlockData();
+        BlockMechanic.setBlockFacing(blockData, 15);
         block.setBlockData(blockData, false);
+
+        final BlockMechanic mechanic = BlockMechanicFactory.getBlockMechanic(BlockMechanic.getCode(blockData));
+        if (mechanic != null && mechanic.hasPlaceSound())
+            BlockHelpers.playCustomBlockSound(block, mechanic.getPlaceSound());
     }
 
     // not static here because only instanciated once I think

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -8,7 +8,6 @@ import io.th0rgal.oraxen.events.OraxenFurnitureInteractEvent;
 import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
@@ -18,7 +17,6 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.type.NoteBlock;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -34,6 +32,7 @@ import org.bukkit.event.inventory.InventoryCreativeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.world.GenericGameEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -44,6 +43,8 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.*;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
+import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
 
 public class FurnitureListener implements Listener {
 
@@ -126,8 +127,9 @@ public class FurnitureListener implements Listener {
 
         if (mechanic.farmblockRequired) {
             if (farm.getType() != Material.NOTE_BLOCK) return;
-            if (!getNoteBlockMechanic(farm).hasDryout()) return;
-            if (!getNoteBlockMechanic(farm).getDryout().isFarmBlock()) return;
+            NoteBlockMechanic farmMechanic = getNoteBlockMechanic(farm);
+            if (farmMechanic == null || !farmMechanic.hasDryout()) return;
+            if (!farmMechanic.getDryout().isFarmBlock()) return;
         }
 
         target.setType(Material.AIR, false);
@@ -220,7 +222,6 @@ public class FurnitureListener implements Listener {
             mechanic.removeAirFurniture(frame);
             mechanic.getDrop().spawns(frame.getLocation(), new ItemStack(Material.AIR));
         }
-
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -293,8 +294,8 @@ public class FurnitureListener implements Listener {
             return;
         final String mechanicID = customBlockData.get(FURNITURE_KEY, PersistentDataType.STRING);
         final FurnitureMechanic mechanic = (FurnitureMechanic) factory.getMechanic(mechanicID);
-        final BlockLocation rootBlockLocation = new BlockLocation(customBlockData.get(ROOT_KEY,
-                PersistentDataType.STRING));
+        final BlockLocation rootBlockLocation =
+                new BlockLocation(customBlockData.get(ROOT_KEY, PersistentDataType.STRING));
 
         OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, event.getPlayer(), block);
         OraxenPlugin.get().getServer().getPluginManager().callEvent(furnitureBreakEvent);
@@ -303,8 +304,7 @@ public class FurnitureListener implements Listener {
             return;
         }
 
-        mechanic.removeSolid(block.getWorld(), rootBlockLocation, customBlockData
-                .get(ORIENTATION_KEY, PersistentDataType.FLOAT));
+        mechanic.removeSolid(block.getWorld(), rootBlockLocation, customBlockData.get(ORIENTATION_KEY, PersistentDataType.FLOAT));
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -404,6 +404,30 @@ public class FurnitureListener implements Listener {
         }
     }
 
+    @EventHandler
+    public void onStepFall(final GenericGameEvent event) {
+        Entity entity = event.getEntity();
+        if (entity == null) return;
+        Location eLoc = entity.getLocation();
+        if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
+
+        GameEvent gameEvent = event.getEvent();
+        Block currentBlock = entity.getLocation().getBlock();
+        Block blockBelow = currentBlock.getRelative(BlockFace.DOWN);
+
+        if (!BlockHelpers.REPLACEABLE_BLOCKS.contains(currentBlock.getType()) || currentBlock.getType() == Material.TRIPWIRE) return;
+        if (blockBelow.getType() != Material.BARRIER) return;
+        FurnitureMechanic mechanic = getFurnitureMechanic(blockBelow);
+        if (mechanic == null) return;
+
+        String sound;
+        if (gameEvent == GameEvent.STEP && mechanic.hasStepSound()) sound = mechanic.getStepSound();
+        else if (gameEvent == GameEvent.HIT_GROUND && mechanic.hasFallSound()) sound = mechanic.getFallSound();
+        else return;
+
+        BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);
+    }
+
     private boolean isStandingInside(final Player player, final Block block) {
         final Location playerLocation = player.getLocation();
         final Location blockLocation = block.getLocation();
@@ -419,13 +443,4 @@ public class FurnitureListener implements Listener {
         final String mechanicID = customBlockData.get(FURNITURE_KEY, PersistentDataType.STRING);
         return (FurnitureMechanic) factory.getMechanic(mechanicID);
     }
-
-    public NoteBlockMechanic getNoteBlockMechanic(Block block) {
-        if (block.getType() != Material.NOTE_BLOCK) return null;
-        final NoteBlock noteBlock = (NoteBlock) block.getBlockData();
-        return NoteBlockMechanicFactory
-                .getBlockMechanic((noteBlock.getInstrument().getType()) * 25
-                        + noteBlock.getNote().getId() + (noteBlock.isPowered() ? 400 : 0) - 26);
-    }
-
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -415,15 +415,19 @@ public class FurnitureListener implements Listener {
         Block currentBlock = entity.getLocation().getBlock();
         Block blockBelow = currentBlock.getRelative(BlockFace.DOWN);
 
+        if (blockBelow.getBlockData().getSoundGroup().getStepSound() != Sound.BLOCK_STONE_STEP) return;
         if (!BlockHelpers.REPLACEABLE_BLOCKS.contains(currentBlock.getType()) || currentBlock.getType() == Material.TRIPWIRE) return;
-        if (blockBelow.getType() != Material.BARRIER) return;
         FurnitureMechanic mechanic = getFurnitureMechanic(blockBelow);
         if (mechanic == null) return;
 
         String sound;
-        if (gameEvent == GameEvent.STEP && mechanic.hasStepSound()) sound = mechanic.getStepSound();
-        else if (gameEvent == GameEvent.HIT_GROUND && mechanic.hasFallSound()) sound = mechanic.getFallSound();
-        else return;
+        if (gameEvent == GameEvent.STEP && mechanic.hasStepSound()) {
+            if (blockBelow.getType() == Material.BARRIER) sound = mechanic.getStepSound();
+            else sound = "required.stone.step";
+        } else if (gameEvent == GameEvent.HIT_GROUND && mechanic.hasFallSound()) {
+            if (blockBelow.getType() == Material.BARRIER) sound = mechanic.getFallSound();
+            else sound = "required.stone.fall";
+        } else return;
 
         BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);
     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -152,22 +152,31 @@ public class FurnitureMechanic extends Mechanic {
         return breakSound != null;
     }
     public String getBreakSound() {
-        return breakSound;
+        return validateReplacedSounds(breakSound);
     }
 
-    public boolean hasPlaceSound() {return placeSound != null;}
+    public boolean hasPlaceSound() {
+        return placeSound != null;
+    }
     public String getPlaceSound() {
-        return placeSound;
+        return validateReplacedSounds(placeSound);
     }
 
     public boolean hasStepSound() { return stepSound != null; }
-    public String getStepSound() { return stepSound; }
+    public String getStepSound() { return validateReplacedSounds(stepSound); }
 
     public boolean hasHitSound() { return hitSound != null; }
-    public String getHitSound() { return hitSound; }
+    public String getHitSound() { return validateReplacedSounds(hitSound); }
 
     public boolean hasFallSound() { return fallSound != null; }
-    public String getFallSound() { return fallSound; }
+    public String getFallSound() { return validateReplacedSounds(fallSound); }
+    private String validateReplacedSounds(String sound) {
+        if (sound.startsWith("block.wood"))
+            return sound.replace("block.wood", "required.wood.");
+        else if (sound.startsWith("block.stone"))
+            return sound.replace("block.stone", "required.stone.");
+        else return sound;
+    }
 
     public boolean hasBarriers() {
         return !barriers.isEmpty();

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -155,9 +155,7 @@ public class FurnitureMechanic extends Mechanic {
         return breakSound;
     }
 
-    public boolean hasPlaceSound() {
-        return placeSound != null;
-    }
+    public boolean hasPlaceSound() {return placeSound != null;}
     public String getPlaceSound() {
         return placeSound;
     }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -8,6 +8,7 @@ import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolvingFurniture;
+import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.actions.ClickAction;
 import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.drops.Loot;
@@ -35,6 +36,11 @@ public class FurnitureMechanic extends Mechanic {
     public static final NamespacedKey EVOLUTION_KEY = new NamespacedKey(OraxenPlugin.get(), "evolution");
     public final boolean farmlandRequired;
     public final boolean farmblockRequired;
+    private final String breakSound;
+    private final String placeSound;
+    private final String stepSound;
+    private final String hitSound;
+    private final String fallSound;
     private final List<BlockLocation> barriers;
     private final boolean hasRotation;
     private final boolean hasSeat;
@@ -54,6 +60,12 @@ public class FurnitureMechanic extends Mechanic {
     public FurnitureMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
         super(mechanicFactory, section, itemBuilder -> itemBuilder.setCustomTag(FURNITURE_KEY,
                 PersistentDataType.BYTE, (byte) 1));
+
+        placeSound = section.getString("place_sound", null);
+        breakSound = section.getString("break_sound", null);
+        stepSound = section.getString("step_sound", null);
+        hitSound = section.getString("hit_sound", null);
+        fallSound = section.getString("fall_sound", null);
 
         if (section.isString("item"))
             placedItemId = section.getString("item");
@@ -135,6 +147,29 @@ public class FurnitureMechanic extends Mechanic {
         }
         return null;
     }
+
+    public boolean hasBreakSound() {
+        return breakSound != null;
+    }
+    public String getBreakSound() {
+        return breakSound;
+    }
+
+    public boolean hasPlaceSound() {
+        return placeSound != null;
+    }
+    public String getPlaceSound() {
+        return placeSound;
+    }
+
+    public boolean hasStepSound() { return stepSound != null; }
+    public String getStepSound() { return stepSound; }
+
+    public boolean hasHitSound() { return hitSound != null; }
+    public String getHitSound() { return hitSound; }
+
+    public boolean hasFallSound() { return fallSound != null; }
+    public String getFallSound() { return fallSound; }
 
     public boolean hasBarriers() {
         return !barriers.isEmpty();
@@ -240,6 +275,8 @@ public class FurnitureMechanic extends Mechanic {
             }
         else if (light != -1)
             WrappedLightAPI.createBlockLight(location, light);
+        if (hasPlaceSound())
+            BlockHelpers.playCustomBlockSound(location.getBlock(), getPlaceSound());
         return output;
     }
 
@@ -284,7 +321,8 @@ public class FurnitureMechanic extends Mechanic {
                 removed = true;
                 break;
             }
-
+        if (hasBreakSound())
+            BlockHelpers.playCustomBlockSound(rootLocation.getBlock(), getBreakSound());
         return removed;
     }
 
@@ -303,6 +341,8 @@ public class FurnitureMechanic extends Mechanic {
             WrappedLightAPI.removeBlockLight(location);
         }
         frame.remove();
+        if (hasBreakSound())
+            BlockHelpers.playCustomBlockSound(location.getBlock(), getBreakSound());
     }
 
     public void remove(ItemFrame frame) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
@@ -136,24 +136,31 @@ public class NoteBlockMechanic extends Mechanic {
         return breakSound != null;
     }
     public String getBreakSound() {
-        return breakSound;
+        return validateReplacedSounds(breakSound);
     }
 
     public boolean hasPlaceSound() {
         return placeSound != null;
     }
     public String getPlaceSound() {
-        return placeSound;
+        return validateReplacedSounds(placeSound);
     }
 
     public boolean hasStepSound() { return stepSound != null; }
-    public String getStepSound() { return stepSound; }
+    public String getStepSound() { return validateReplacedSounds(stepSound); }
 
     public boolean hasHitSound() { return hitSound != null; }
-    public String getHitSound() { return hitSound; }
+    public String getHitSound() { return validateReplacedSounds(hitSound); }
 
     public boolean hasFallSound() { return fallSound != null; }
-    public String getFallSound() { return fallSound; }
+    public String getFallSound() { return validateReplacedSounds(fallSound); }
+    private String validateReplacedSounds(String sound) {
+        if (sound.startsWith("block.wood"))
+            return sound.replace("block.wood", "required.wood.");
+        else if (sound.startsWith("block.stone"))
+            return sound.replace("block.stone", "required.stone.");
+        else return sound;
+    }
 
     public int getPeriod() {
         return period;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanic.java
@@ -103,24 +103,31 @@ public class StringBlockMechanic extends Mechanic {
         return breakSound != null;
     }
     public String getBreakSound() {
-        return breakSound;
+        return validateReplacedSounds(breakSound);
     }
 
     public boolean hasPlaceSound() {
         return placeSound != null;
     }
     public String getPlaceSound() {
-        return placeSound;
+        return validateReplacedSounds(placeSound);
     }
 
     public boolean hasStepSound() { return stepSound != null; }
-    public String getStepSound() { return stepSound; }
+    public String getStepSound() { return validateReplacedSounds(stepSound); }
 
     public boolean hasHitSound() { return hitSound != null; }
-    public String getHitSound() { return hitSound; }
+    public String getHitSound() { return validateReplacedSounds(hitSound); }
 
     public boolean hasFallSound() { return fallSound != null; }
-    public String getFallSound() { return fallSound; }
+    public String getFallSound() { return validateReplacedSounds(fallSound); }
+    private String validateReplacedSounds(String sound) {
+        if (sound.startsWith("block.wood"))
+            return sound.replace("block.wood", "required.wood.");
+        else if (sound.startsWith("block.stone"))
+            return sound.replace("block.stone", "required.stone.");
+        else return sound;
+    }
 
     public int getPeriod() {
         return period;

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -10,16 +10,16 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.wrappers.BlockPosition;
 import com.comphenix.protocol.wrappers.EnumWrappers;
+import com.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanicFactory;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.protectionlib.ProtectionLib;
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.Location;
-import org.bukkit.World;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.MultipleFacing;
 import org.bukkit.block.data.type.Tripwire;
@@ -28,6 +28,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -37,6 +39,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.function.Consumer;
 
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.FURNITURE_KEY;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
 
 public class BreakerSystem {
@@ -176,7 +179,15 @@ public class BreakerSystem {
             case NOTE_BLOCK -> Objects.requireNonNull(getNoteBlockMechanic(block)).getHitSound();
             case MUSHROOM_STEM -> BlockMechanicFactory.getBlockMechanic(BlockMechanic.getCode((MultipleFacing) block.getBlockData())).getHitSound();
             case TRIPWIRE -> StringBlockMechanicFactory.getBlockMechanic(StringBlockMechanicFactory.getCode((Tripwire) block.getBlockData())).getHitSound();
+            case BARRIER -> getFurnitureMechanic(block).getHitSound();
             default -> null;
         };
+    }
+
+    private FurnitureMechanic getFurnitureMechanic(Block block) {
+        if (block.getType() != Material.BARRIER) return null;
+        final PersistentDataContainer customBlockData = new CustomBlockData(block, OraxenPlugin.get());
+        final String mechanicID = customBlockData.get(FURNITURE_KEY, PersistentDataType.STRING);
+        return (FurnitureMechanic) FurnitureFactory.getInstance().getMechanic(mechanicID);
     }
 }

--- a/src/main/resources/sound.yml
+++ b/src/main/resources/sound.yml
@@ -61,3 +61,53 @@ sounds:
       - step/wood4
       - step/wood5
       - step/wood6
+  block.stone.step: # Required for custom furniture sounds
+    replace: true
+  block.stone.place:
+    replace: true
+  block.stone.break:
+    replace: true
+  block.stone.fall:
+    replace: true
+  block.stone.hit:
+    replace: true
+  required.stone.hit: # Required for custom furniture sounds
+    subtitle: "subtitles.block.generic.hit"
+    sounds:
+      - step/stone1
+      - step/stone2
+      - step/stone3
+      - step/stone4
+      - step/stone5
+      - step/stone6
+  required.stone.place:
+    subtitle: "subtitles.block.generic.place"
+    sounds:
+      - dig/stone1
+      - dig/stone2
+      - dig/stone3
+      - dig/stone4
+  required.stone.break:
+    subtitle: "subtitles.block.generic.break"
+    sounds:
+      - dig/stone1
+      - dig/stone2
+      - dig/stone3
+      - dig/stone4
+  required.stone.step:
+    subtitle: "subtitles.block.generic.footsteps"
+    sounds:
+      - step/stone1
+      - step/stone2
+      - step/stone3
+      - step/stone4
+      - step/stone5
+      - step/stone6
+  required.stone.fall:
+    sounds:
+      - step/stone1
+      - step/stone2
+      - step/stone3
+      - step/stone4
+      - step/stone5
+      - step/stone6


### PR DESCRIPTION
This adds new entries to sound.yml for  `block.stone.x` same as for noteblocks as barriers inherit stone sound.
Also makes it so if a config entry wants to use `block.stone.x` it is repathed to the custom version automatically