### PR TITLE
Fix 1.19.2 Startup Issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ compileJava {
 dependencies {
     def actionsVersion = '1.0.0-SNAPSHOT'
 
-    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.19.1-R0.1-SNAPSHOT'
-    compileOnly("io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT") { exclude group: 'net.kyori' }
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.19.2-R0.1-SNAPSHOT'
+    compileOnly("io.papermc.paper:paper-api:1.19.2-R0.1-SNAPSHOT") { exclude group: 'net.kyori' }
     compileOnly group: 'com.comphenix.protocol', name: 'ProtocolLib', version: '5.0.0-SNAPSHOT'
     compileOnly group: 'com.github.Hazebyte', name: 'CrateReloadedAPI', version: 'd7ae2a14c6'
     compileOnly group: 'com.github.jojodmo', name: 'ItemBridge', version: '-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation group: 'net.kyori', name: 'adventure-text-minimessage', version: '4.2.0-SNAPSHOT'
     implementation group: 'net.kyori', name: 'adventure-platform-bukkit', version: '4.0.0'
     implementation group: 'com.github.stefvanschie.inventoryframework', name: 'IF', version: '0.10.0'
-    implementation group: 'dev.jorel', name: 'commandapi-shade', version: '8.5.0-SNAPSHOT'
+    implementation group: 'dev.jorel', name: 'commandapi-shade', version: '8.5.1-SNAPSHOT'
     implementation "com.jeff_media:CustomBlockData:2.0.0"
     implementation "com.jeff_media:MorePersistentDataTypes:2.3.1"
 


### PR DESCRIPTION
This should fix the startup error that CommandAPI does not support the server version when loading the plugin on 1.19.2.