### PR TITLE
More Bugfixes

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -155,7 +155,7 @@ public class ConfigsManager {
                 Glyph glyph = new Glyph(key, configuration.getConfigurationSection(key), code);
                 if (glyph.isFileChanged())
                     fileChanged = true;
-                glyph.verifyGlyph();
+                glyph.verifyGlyph(output);
                 output.add(glyph);
             }
             if (fileChanged && Settings.AUTOMATICALLY_SET_GLYPH_CODE.toBool())

--- a/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -155,6 +155,7 @@ public class ConfigsManager {
                 Glyph glyph = new Glyph(key, configuration.getConfigurationSection(key), code);
                 if (glyph.isFileChanged())
                     fileChanged = true;
+                glyph.verifyGlyph();
                 output.add(glyph);
             }
             if (fileChanged && Settings.AUTOMATICALLY_SET_GLYPH_CODE.toBool())

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -3,9 +3,16 @@ package io.th0rgal.oraxen.font;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
 
 
 public class Glyph {
@@ -71,6 +78,10 @@ public class Glyph {
         return texture;
     }
 
+    public void setTexture(String texture) {
+        this.texture = (texture.endsWith(".png")) ? texture : texture + ".png";
+    }
+
     public int getAscent() {
         return ascent;
     }
@@ -87,9 +98,13 @@ public class Glyph {
         return placeholders;
     }
 
-    public boolean isEmoji() { return isEmoji; }
+    public boolean isEmoji() {
+        return isEmoji;
+    }
 
-    public boolean hasTabCompletion() { return tabcomplete; }
+    public boolean hasTabCompletion() {
+        return tabcomplete;
+    }
 
     public String getTabIconTexture() {
         return tabIconTexture;
@@ -121,5 +136,38 @@ public class Glyph {
 
     public int getCode() {
         return code;
+    }
+
+    public void verifyGlyph() {
+        final File texture = new File(OraxenPlugin.get().getDataFolder().getAbsolutePath() + "/pack/textures", getTexture());
+        boolean hasUpperCase = false;
+        BufferedImage image = null;
+        for (char c : getTexture().toCharArray()) if (Character.isUpperCase(c)) hasUpperCase = true;
+        try { image = ImageIO.read(texture); } catch (IOException ignored) {}
+
+        if (height < ascent) {
+            this.setTexture("required/exit_icon");
+            Logs.logError("The ascent is bigger than the height for " + name + ". This will break all your glyphs.");
+            Logs.logWarning("It has been temporarily set to a placeholder image. You should edit this in the glyph config.");
+        } else if (!texture.exists()) {
+            this.setTexture("required/exit_icon");
+            Logs.logError("The texture specified for " + name + " does not exist. This will break all your glyphs.");
+            Logs.logWarning("It has been temporarily set to a placeholder image. You should edit this in the glyph config.");
+        } else if (hasUpperCase) {
+            this.setTexture("required/exit_icon");
+            Logs.logError("The filename specified for " + name + " contains capital letters.");
+            Logs.logWarning("This will break all your glyphs. It has been temporarily set to a placeholder image.");
+            Logs.logWarning("You should edit this in the glyph config and your textures filename.");
+        } else if (texture.getName().contains(" ")) {
+            this.setTexture("required/exit_icon");
+            Logs.logError("The filename specified for " + name + " contains spaces.");
+            Logs.logWarning("This will break all your glyphs. It has been temporarily set to a placeholder image.");
+            Logs.logWarning("You should replace spaces with _ in your filename and glyph config.");
+        } else if (image.getHeight() > 256 || image.getWidth() > 256) {
+            this.setTexture("required/exit_icon");
+            Logs.logError("The texture specified for " + name + " is larger than the supported size.");
+            Logs.logWarning("The maximum image size is 256x256. Anything bigger will break all your glyphs.");
+            Logs.logWarning("It has been temporarily set to a placeholder-image. You should edit this in the glyph config.");
+        }
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -13,6 +13,9 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public class Glyph {
@@ -138,8 +141,9 @@ public class Glyph {
         return code;
     }
 
-    public void verifyGlyph() {
+    public void verifyGlyph(List<Glyph> glyphs) {
         final File texture = new File(OraxenPlugin.get().getDataFolder().getAbsolutePath() + "/pack/textures", getTexture());
+        Map<Glyph, Boolean> sameCodeMap = glyphs.stream().filter(g -> g != this && g.getCode() == this.getCode()).collect(Collectors.toMap(g -> g, g -> true));
         boolean hasUpperCase = false;
         BufferedImage image = null;
         for (char c : getTexture().toCharArray()) if (Character.isUpperCase(c)) hasUpperCase = true;
@@ -149,7 +153,7 @@ public class Glyph {
             this.setTexture("required/exit_icon");
             Logs.logError("The ascent is bigger than the height for " + name + ". This will break all your glyphs.");
             Logs.logWarning("It has been temporarily set to a placeholder image. You should edit this in the glyph config.");
-        } else if (!texture.exists()) {
+        } else if (!texture.exists() || image == null) {
             this.setTexture("required/exit_icon");
             Logs.logError("The texture specified for " + name + " does not exist. This will break all your glyphs.");
             Logs.logWarning("It has been temporarily set to a placeholder image. You should edit this in the glyph config.");
@@ -168,6 +172,11 @@ public class Glyph {
             Logs.logError("The texture specified for " + name + " is larger than the supported size.");
             Logs.logWarning("The maximum image size is 256x256. Anything bigger will break all your glyphs.");
             Logs.logWarning("It has been temporarily set to a placeholder-image. You should edit this in the glyph config.");
+        } else if (!sameCodeMap.isEmpty()) {
+            this.setTexture("required/exit_icon");
+            Logs.logError(name + " code is the same as " + sameCodeMap.keySet().stream().map(Glyph::getName).collect(Collectors.joining(", ")) + ".");
+            Logs.logWarning("This will break all your glyphs. It has been temporarily set to a placeholder image.");
+            Logs.logWarning("You should edit the code of all these glyphs to be unique.");
         }
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanic.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.drops.Loot;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.MultipleFacing;
@@ -113,12 +114,15 @@ public class BlockMechanic extends Mechanic {
     }
 
     public static int getCode(final Block block) {
-        final MultipleFacing blockData = (MultipleFacing) block.getBlockData();
-        final List<BlockFace> properties = Arrays
-                .asList(BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.DOWN, BlockFace.UP);
         int sum = 0;
-        for (final BlockFace blockFace : blockData.getFaces())
-            sum += (int) Math.pow(2, properties.indexOf(blockFace));
+        if (block.getType() == Material.MUSHROOM_STEM) {
+            final MultipleFacing blockData = (MultipleFacing) block.getBlockData();
+            final List<BlockFace> properties = Arrays
+                    .asList(BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.DOWN, BlockFace.UP);
+            for (final BlockFace blockFace : blockData.getFaces())
+                sum += (int) Math.pow(2, properties.indexOf(blockFace));
+        }
+
         return sum;
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicFactory.java
@@ -72,7 +72,8 @@ public class BlockMechanicFactory extends MechanicFactory {
     }
 
     public static BlockMechanic getBlockMechanic(Block block) {
-        return BLOCK_PER_VARIATION.get(BlockMechanic.getCode(block));
+        return (block.getType() == Material.MUSHROOM_STEM)
+                ? BLOCK_PER_VARIATION.get(BlockMechanic.getCode(block)) : null;
     }
 
     /**

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -49,7 +49,7 @@ public class BlockMechanicListener implements Listener {
         final BlockMechanic blockMechanic = getBlockMechanic(block);
         if (blockMechanic == null) return;
 
-        BlockHelpers.playCustomBlockSound(block, blockMechanic.hasBreakSound() ? blockMechanic.getBreakSound() : VANILLA_WOOD_BREAK);
+        BlockHelpers.playCustomBlockSound(block.getLocation(), blockMechanic.hasBreakSound() ? blockMechanic.getBreakSound() : VANILLA_WOOD_BREAK);
         blockMechanic.getDrop().spawns(block.getLocation(), event.getPlayer().getInventory().getItemInMainHand());
         event.setDropItems(false);
     }
@@ -114,7 +114,7 @@ public class BlockMechanicListener implements Listener {
             return;
         }
 
-        BlockHelpers.playCustomBlockSound(target, mechanic.hasPlaceSound() ? mechanic.getPlaceSound() : VANILLA_WOOD_PLACE);
+        BlockHelpers.playCustomBlockSound(target.getLocation(), mechanic.hasPlaceSound() ? mechanic.getPlaceSound() : VANILLA_WOOD_PLACE);
         event.setCancelled(true);
         if (player.getGameMode() != GameMode.CREATIVE)
             item.setAmount(item.getAmount() - 1);
@@ -167,7 +167,7 @@ public class BlockMechanicListener implements Listener {
         else if (gameEvent == GameEvent.HIT_GROUND) sound = mechanic.hasFallSound() ? mechanic.getFallSound() : VANILLA_WOOD_FALL;
         else return;
 
-        BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);
+        BlockHelpers.playCustomBlockSound(entity.getLocation(), sound, SoundCategory.PLAYERS);
     }
 
     private boolean isStandingInside(final Player player, final Block block) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -22,7 +22,7 @@ import org.bukkit.event.world.GenericGameEvent;
 import org.bukkit.inventory.ItemStack;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanicFactory.getBlockMechanic;
-import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
+import static io.th0rgal.oraxen.utils.BlockHelpers.*;
 
 public class BlockMechanicListener implements Listener {
 
@@ -44,20 +44,18 @@ public class BlockMechanicListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBreakingCustomBlock(final BlockBreakEvent event) {
         final Block block = event.getBlock();
-        if (block.getType() != Material.MUSHROOM_STEM || !event.isDropItems())
-            return;
+        if (block.getType() != Material.MUSHROOM_STEM || !event.isDropItems()) return;
 
         final BlockMechanic blockMechanic = getBlockMechanic(block);
         if (blockMechanic == null) return;
-        if (blockMechanic.hasBreakSound())
-            BlockHelpers.playCustomBlockSound(block, blockMechanic.getBreakSound());
+
+        BlockHelpers.playCustomBlockSound(block, blockMechanic.hasBreakSound() ? blockMechanic.getBreakSound() : VANILLA_WOOD_BREAK);
         blockMechanic.getDrop().spawns(block.getLocation(), event.getPlayer().getInventory().getItemInMainHand());
         event.setDropItems(false);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlacingMushroomBlock(final BlockPlaceEvent event) {
-
         if (event.getBlockPlaced().getType() != Material.MUSHROOM_STEM
                 || OraxenItems.exists(OraxenItems.getIdByItem(event.getItemInHand())))
             return;
@@ -66,10 +64,6 @@ public class BlockMechanicListener implements Listener {
         final MultipleFacing blockData = (MultipleFacing) block.getBlockData();
         BlockMechanic.setBlockFacing(blockData, 15);
         block.setBlockData(blockData, false);
-
-        final BlockMechanic mechanic = getBlockMechanic(block);
-        if (mechanic != null && mechanic.hasPlaceSound())
-            BlockHelpers.playCustomBlockSound(block, mechanic.getPlaceSound());
     }
 
     // not static here because only instanciated once I think
@@ -119,10 +113,10 @@ public class BlockMechanicListener implements Listener {
             target.setBlockData(curentBlockData, false); // false to cancel physic
             return;
         }
-        if (mechanic.hasPlaceSound())
-            BlockHelpers.playCustomBlockSound(target, mechanic.getPlaceSound());
+
+        BlockHelpers.playCustomBlockSound(target, mechanic.hasPlaceSound() ? mechanic.getPlaceSound() : VANILLA_WOOD_PLACE);
         event.setCancelled(true);
-        if (!player.getGameMode().equals(GameMode.CREATIVE))
+        if (player.getGameMode() != GameMode.CREATIVE)
             item.setAmount(item.getAmount() - 1);
     }
 
@@ -169,8 +163,8 @@ public class BlockMechanicListener implements Listener {
         final BlockMechanic mechanic = getBlockMechanic(blockBelow);
         if (mechanic == null) return;
 
-        if (gameEvent == GameEvent.STEP && mechanic.hasStepSound()) sound = mechanic.getStepSound();
-        else if (gameEvent == GameEvent.HIT_GROUND && mechanic.hasFallSound()) sound = mechanic.getFallSound();
+        if (gameEvent == GameEvent.STEP) sound = mechanic.hasStepSound() ? mechanic.getStepSound() : VANILLA_WOOD_STEP;
+        else if (gameEvent == GameEvent.HIT_GROUND) sound = mechanic.hasFallSound() ? mechanic.getFallSound() : VANILLA_WOOD_FALL;
         else return;
 
         BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -124,7 +124,7 @@ public class BlockMechanicListener implements Listener {
     public void onSetFire(final PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
         ItemStack item = event.getItem();
-        if (block == null || block.getType() != Material.NOTE_BLOCK) return;
+        if (block == null || block.getType() != Material.MUSHROOM_STEM) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getBlockFace() != BlockFace.UP) return;
         if (item == null) return;
 
@@ -139,7 +139,7 @@ public class BlockMechanicListener implements Listener {
     public void onCatchFire(final BlockIgniteEvent event) {
         Block block = event.getBlock();
         BlockMechanic mechanic = getBlockMechanic(block);
-        if (block.getType() != Material.NOTE_BLOCK || mechanic == null) return;
+        if (block.getType() != Material.MUSHROOM_STEM || mechanic == null) return;
         if (!mechanic.canIgnite()) event.setCancelled(true);
 
         block.getWorld().playSound(block.getLocation(), Sound.ITEM_FLINTANDSTEEL_USE, 1, 1);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -104,7 +104,7 @@ public class FurnitureListener implements Listener {
 
         if (block.getType() == Material.BARRIER || block.getType() == Material.TRIPWIRE) return;
         if (block.getBlockData().getSoundGroup().getPlaceSound() != Sound.BLOCK_STONE_PLACE) return;
-        BlockHelpers.playCustomBlockSound(event.getBlock(), VANILLA_STONE_PLACE);
+        BlockHelpers.playCustomBlockSound(event.getBlock().getLocation(), VANILLA_STONE_PLACE);
     }
 
     // Play sound due to furniture/barrier custom sound replacing stone
@@ -118,7 +118,7 @@ public class FurnitureListener implements Listener {
             breakerPlaySound.get(block).cancel();
             breakerPlaySound.remove(block);
         }
-        BlockHelpers.playCustomBlockSound(event.getBlock(), VANILLA_STONE_BREAK);
+        BlockHelpers.playCustomBlockSound(event.getBlock().getLocation(), VANILLA_STONE_BREAK);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -131,7 +131,7 @@ public class FurnitureListener implements Listener {
         if (breakerPlaySound.containsKey(block)) return;
 
         BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
-                BlockHelpers.playCustomBlockSound(block, VANILLA_STONE_HIT), 3L, 3L);
+                BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_STONE_HIT), 3L, 3L);
         breakerPlaySound.put(block, task);
     }
 
@@ -465,7 +465,7 @@ public class FurnitureListener implements Listener {
                     ? mechanic.getFallSound() : VANILLA_STONE_FALL;
         } else return;
 
-        BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);
+        BlockHelpers.playCustomBlockSound(entity.getLocation(), sound, SoundCategory.PLAYERS);
     }
 
     private boolean isStandingInside(final Player player, final Block block) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -21,9 +21,7 @@ import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.Action;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
@@ -37,18 +35,22 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.RayTraceResult;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.*;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
-import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
+import static io.th0rgal.oraxen.utils.BlockHelpers.*;
 
 public class FurnitureListener implements Listener {
 
     private final MechanicFactory factory;
+    private final Map<Block, BukkitTask> breakerPlaySound = new HashMap<>();
 
     public FurnitureListener(final MechanicFactory factory) {
         this.factory = factory;
@@ -92,6 +94,54 @@ public class FurnitureListener implements Listener {
                 return 1;
             }
         };
+    }
+
+
+    // Play sound due to furniture/barrier custom sound replacing stone
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlacingStone(final BlockPlaceEvent event) {
+        Block block = event.getBlock();
+        SoundGroup soundGroup = block.getBlockData().getSoundGroup();
+
+        if (block.getType() == Material.BARRIER || soundGroup.getPlaceSound() != Sound.BLOCK_STONE_PLACE) return;
+        BlockHelpers.playCustomBlockSound(event.getBlock(), VANILLA_STONE_PLACE);
+    }
+
+    // Play sound due to furniture/barrier custom sound replacing stone
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBreakingStone(final BlockBreakEvent event) {
+        Block block = event.getBlock();
+        SoundGroup soundGroup = block.getBlockData().getSoundGroup();
+
+        if (block.getType() == Material.BARRIER || soundGroup.getBreakSound() != Sound.BLOCK_STONE_BREAK) return;
+        if (breakerPlaySound.containsKey(block)) {
+            breakerPlaySound.get(block).cancel();
+            breakerPlaySound.remove(block);
+        }
+        BlockHelpers.playCustomBlockSound(event.getBlock(), VANILLA_STONE_BREAK);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onHitStone(final BlockDamageEvent event) {
+        Block block = event.getBlock();
+        SoundGroup soundGroup = block.getBlockData().getSoundGroup();
+
+        if (event.getInstaBreak()) return;
+        if (block.getType() == Material.BARRIER || soundGroup.getHitSound() != Sound.BLOCK_STONE_HIT) return;
+        if (breakerPlaySound.containsKey(block)) return;
+
+        BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
+                BlockHelpers.playCustomBlockSound(block, VANILLA_STONE_HIT), 3L, 3L);
+        breakerPlaySound.put(block, task);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onStopHittingStone(final BlockDamageAbortEvent event) {
+        Block block = event.getBlock();
+        if (breakerPlaySound.containsKey(block)) {
+            breakerPlaySound.get(block).cancel();
+            breakerPlaySound.remove(block);
+        }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
@@ -404,7 +454,7 @@ public class FurnitureListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onStepFall(final GenericGameEvent event) {
         Entity entity = event.getEntity();
         if (entity == null) return;
@@ -412,23 +462,21 @@ public class FurnitureListener implements Listener {
         if (!isLoaded(event.getLocation()) || !isLoaded(eLoc)) return;
 
         GameEvent gameEvent = event.getEvent();
-        Block currentBlock = entity.getLocation().getBlock();
-        Block blockBelow = currentBlock.getRelative(BlockFace.DOWN);
-        Material currentType = currentBlock.getType();
+        Block block = entity.getLocation().getBlock();
+        Block blockBelow = block.getRelative(BlockFace.DOWN);
+        SoundGroup soundGroup = blockBelow.getBlockData().getSoundGroup();
 
-        if (blockBelow.getBlockData().getSoundGroup().getStepSound() != Sound.BLOCK_STONE_STEP) return;
-        if (!BlockHelpers.REPLACEABLE_BLOCKS.contains(currentType) || currentType == Material.TRIPWIRE) return;
+        if (soundGroup.getStepSound() != Sound.BLOCK_STONE_STEP) return;
+        if (!BlockHelpers.REPLACEABLE_BLOCKS.contains(block.getType()) || block.getType() == Material.TRIPWIRE) return;
         FurnitureMechanic mechanic = getFurnitureMechanic(blockBelow);
 
         String sound;
         if (gameEvent == GameEvent.STEP) {
-            if (mechanic != null && mechanic.hasStepSound() && blockBelow.getType() == Material.BARRIER)
-                sound = mechanic.getStepSound();
-            else sound = "required.stone.step";
+            sound = (blockBelow.getType() == Material.BARRIER && mechanic != null && mechanic.hasStepSound())
+                    ? mechanic.getStepSound() : VANILLA_STONE_STEP;
         } else if (gameEvent == GameEvent.HIT_GROUND) {
-            if (mechanic != null && mechanic.hasFallSound() && blockBelow.getType() == Material.BARRIER)
-                sound = mechanic.getFallSound();
-            else sound = "required.stone.fall";
+            sound = (blockBelow.getType() == Material.BARRIER && mechanic != null && mechanic.hasFallSound())
+                    ? mechanic.getFallSound() : VANILLA_STONE_FALL;
         } else return;
 
         BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -286,7 +286,7 @@ public class FurnitureMechanic extends Mechanic {
         else if (light != -1)
             WrappedLightAPI.createBlockLight(location, light);
 
-        BlockHelpers.playCustomBlockSound(location.getBlock(), hasPlaceSound() ? getPlaceSound() : VANILLA_STONE_PLACE);
+        BlockHelpers.playCustomBlockSound(location, hasPlaceSound() ? getPlaceSound() : VANILLA_STONE_PLACE);
         return output;
     }
 
@@ -332,7 +332,7 @@ public class FurnitureMechanic extends Mechanic {
                 break;
             }
 
-        BlockHelpers.playCustomBlockSound(rootLocation.getBlock(), hasBreakSound() ? getBreakSound() : VANILLA_STONE_BREAK);
+        BlockHelpers.playCustomBlockSound(rootLocation, hasBreakSound() ? getBreakSound() : VANILLA_STONE_BREAK);
         return removed;
     }
 
@@ -352,7 +352,7 @@ public class FurnitureMechanic extends Mechanic {
         }
         frame.remove();
         if (hasBreakSound())
-            BlockHelpers.playCustomBlockSound(location.getBlock(), getBreakSound());
+            BlockHelpers.playCustomBlockSound(location, getBreakSound());
     }
 
     public void remove(ItemFrame frame) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -27,6 +27,8 @@ import org.bukkit.persistence.PersistentDataType;
 
 import java.util.*;
 
+import static io.th0rgal.oraxen.utils.BlockHelpers.VANILLA_STONE_BREAK;
+
 public class FurnitureMechanic extends Mechanic {
 
     public static final NamespacedKey FURNITURE_KEY = new NamespacedKey(OraxenPlugin.get(), "furniture");
@@ -328,8 +330,8 @@ public class FurnitureMechanic extends Mechanic {
                 removed = true;
                 break;
             }
-        if (hasBreakSound())
-            BlockHelpers.playCustomBlockSound(rootLocation.getBlock(), getBreakSound());
+
+        BlockHelpers.playCustomBlockSound(rootLocation.getBlock(), hasBreakSound() ? getBreakSound() : VANILLA_STONE_BREAK);
         return removed;
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -28,6 +28,7 @@ import org.bukkit.persistence.PersistentDataType;
 import java.util.*;
 
 import static io.th0rgal.oraxen.utils.BlockHelpers.VANILLA_STONE_BREAK;
+import static io.th0rgal.oraxen.utils.BlockHelpers.VANILLA_STONE_PLACE;
 
 public class FurnitureMechanic extends Mechanic {
 
@@ -284,8 +285,8 @@ public class FurnitureMechanic extends Mechanic {
             }
         else if (light != -1)
             WrappedLightAPI.createBlockLight(location, light);
-        if (hasPlaceSound())
-            BlockHelpers.playCustomBlockSound(location.getBlock(), getPlaceSound());
+
+        BlockHelpers.playCustomBlockSound(location.getBlock(), hasPlaceSound() ? getPlaceSound() : VANILLA_STONE_PLACE);
         return output;
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanic.java
@@ -158,9 +158,9 @@ public class NoteBlockMechanic extends Mechanic {
     public String getFallSound() { return validateReplacedSounds(fallSound); }
     private String validateReplacedSounds(String sound) {
         if (sound.startsWith("block.wood"))
-            return sound.replace("block.wood", "required.wood.");
+            return sound.replaceFirst("block.wood", "required.wood");
         else if (sound.startsWith("block.stone"))
-            return sound.replace("block.stone", "required.stone.");
+            return sound.replaceFirst("block.stone", "required.stone");
         else return sound;
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -193,7 +193,7 @@ public class NoteBlockMechanicListener implements Listener {
         final Block block = event.getBlock();
         if (block.getBlockData().getSoundGroup().getHitSound() != Sound.BLOCK_WOOD_HIT) return;
         if (getNoteBlockMechanic(block) != null || block.getType() == Material.MUSHROOM_STEM) return;
-        BlockHelpers.playCustomBlockSound(block, VANILLA_WOOD_HIT);
+        BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_HIT);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -207,7 +207,7 @@ public class NoteBlockMechanicListener implements Listener {
             breakerPlaySound.remove(block);
         }
 
-        BlockHelpers.playCustomBlockSound(block, VANILLA_WOOD_BREAK);
+        BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_BREAK);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -229,7 +229,7 @@ public class NoteBlockMechanicListener implements Listener {
             return;
         }
 
-        BlockHelpers.playCustomBlockSound(block, mechanic.hasBreakSound() ? mechanic.getBreakSound() : VANILLA_WOOD_BREAK);
+        BlockHelpers.playCustomBlockSound(block.getLocation(), mechanic.hasBreakSound() ? mechanic.getBreakSound() : VANILLA_WOOD_BREAK);
         if (mechanic.getLight() != -1)
             WrappedLightAPI.removeBlockLight(block.getLocation());
         if (player.getGameMode() != GameMode.CREATIVE)
@@ -258,7 +258,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (getNoteBlockMechanic(placed) != null || placed.getType() == Material.MUSHROOM_STEM) return;
 
         // Play sound for wood
-        BlockHelpers.playCustomBlockSound(placed, VANILLA_WOOD_PLACE);
+        BlockHelpers.playCustomBlockSound(placed.getLocation(), VANILLA_WOOD_PLACE);
         if (placed.getType() == Material.NOTE_BLOCK && !OraxenItems.exists(event.getItemInHand()))
             placed.setBlockData(Bukkit.createBlockData(Material.NOTE_BLOCK), false);
     }
@@ -300,7 +300,7 @@ public class NoteBlockMechanicListener implements Listener {
                 customBlockData.set(FARMBLOCK_KEY, PersistentDataType.STRING, mechanic.getItemID());
             }
 
-            BlockHelpers.playCustomBlockSound(placedBlock, mechanic.hasPlaceSound() ? mechanic.getPlaceSound() : VANILLA_WOOD_PLACE);
+            BlockHelpers.playCustomBlockSound(placedBlock.getLocation(), mechanic.hasPlaceSound() ? mechanic.getPlaceSound() : VANILLA_WOOD_PLACE);
         }
     }
 
@@ -344,7 +344,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (breakerPlaySound.containsKey(block)) return;
 
         BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
-                BlockHelpers.playCustomBlockSound(block, VANILLA_WOOD_HIT), 3L, 3L);
+                BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_HIT), 3L, 3L);
         breakerPlaySound.put(block, task);
     }
 
@@ -385,7 +385,7 @@ public class NoteBlockMechanicListener implements Listener {
                     ? mechanic.getFallSound() : VANILLA_WOOD_FALL;
         } else return;
 
-        BlockHelpers.playCustomBlockSound(blockBelow, sound, SoundCategory.PLAYERS);
+        BlockHelpers.playCustomBlockSound(entity.getLocation(), sound, SoundCategory.PLAYERS);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -509,7 +509,7 @@ public class NoteBlockMechanicListener implements Listener {
             else item.setAmount(item.getAmount() - 1);
         }
 
-        BlockHelpers.playCustomBlockSound(target, sound, SoundCategory.BLOCKS);
+        BlockHelpers.playCustomBlockSound(target.getLocation(), sound, SoundCategory.BLOCKS);
         Utils.sendAnimation(player, hand);
 
         return target;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -56,13 +56,13 @@ public class NoteBlockMechanicListener implements Listener {
         BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPistonPush(BlockPistonExtendEvent event) {
         if (event.getBlocks().stream().anyMatch(block -> block.getType().equals(Material.NOTE_BLOCK)))
             event.setCancelled(true);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPistonPull(BlockPistonRetractEvent event) {
         if (event.getBlocks().stream().anyMatch(block -> block.getType().equals(Material.NOTE_BLOCK)))
             event.setCancelled(true);
@@ -188,27 +188,13 @@ public class NoteBlockMechanicListener implements Listener {
             event.setCancelled(true);
     }
 
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    /*@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHitBlock(final BlockDamageEvent event) {
         final Block block = event.getBlock();
         if (block.getBlockData().getSoundGroup().getHitSound() != Sound.BLOCK_WOOD_HIT) return;
         if (getNoteBlockMechanic(block) != null || block.getType() == Material.MUSHROOM_STEM) return;
         BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_HIT);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onBreakingBlock(final BlockBreakEvent event) {
-        final Block block = event.getBlock();
-        if (block.getBlockData().getSoundGroup().getBreakSound() != Sound.BLOCK_WOOD_BREAK) return;
-        if (getNoteBlockMechanic(block) != null || block.getType() == Material.MUSHROOM_STEM) return;
-
-        if (breakerPlaySound.containsKey(block)) {
-            breakerPlaySound.get(block).cancel();
-            breakerPlaySound.remove(block);
-        }
-
-        BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_BREAK);
-    }
+    }*/
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBreakingCustomBlock(final BlockBreakEvent event) {
@@ -249,18 +235,6 @@ public class NoteBlockMechanicListener implements Listener {
             noteBlockMechanic.getDrop().spawns(block.getLocation(), new ItemStack(Material.AIR));
             block.setType(Material.AIR, false);
         });
-    }
-
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public void onPlacingBlock(final BlockPlaceEvent event) {
-        Block placed = event.getBlockPlaced();
-        if (placed.getBlockData().getSoundGroup().getPlaceSound() != Sound.BLOCK_WOOD_PLACE) return;
-        if (getNoteBlockMechanic(placed) != null || placed.getType() == Material.MUSHROOM_STEM) return;
-
-        // Play sound for wood
-        BlockHelpers.playCustomBlockSound(placed.getLocation(), VANILLA_WOOD_PLACE);
-        if (placed.getType() == Material.NOTE_BLOCK && !OraxenItems.exists(event.getItemInHand()))
-            placed.setBlockData(Bukkit.createBlockData(Material.NOTE_BLOCK), false);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -339,12 +313,12 @@ public class NoteBlockMechanicListener implements Listener {
         Block block = event.getBlock();
         SoundGroup soundGroup = block.getBlockData().getSoundGroup();
 
-        if (event.getInstaBreak()) return;
-        if (block.getType() == Material.NOTE_BLOCK || soundGroup.getHitSound() != Sound.BLOCK_WOOD_HIT) return;
+        if (block.getType() == Material.NOTE_BLOCK || block.getType() == Material.MUSHROOM_STEM)return;
+        if (event.getInstaBreak() || soundGroup.getHitSound() != Sound.BLOCK_WOOD_HIT) return;
         if (breakerPlaySound.containsKey(block)) return;
 
         BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
-                BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_HIT), 3L, 3L);
+                BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_HIT), 3L, 6L);
         breakerPlaySound.put(block, task);
     }
 
@@ -355,6 +329,32 @@ public class NoteBlockMechanicListener implements Listener {
             breakerPlaySound.get(block).cancel();
             breakerPlaySound.remove(block);
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlacingBlock(final BlockPlaceEvent event) {
+        Block placed = event.getBlockPlaced();
+        if (placed.getBlockData().getSoundGroup().getPlaceSound() != Sound.BLOCK_WOOD_PLACE) return;
+        if (getNoteBlockMechanic(placed) != null || placed.getType() == Material.MUSHROOM_STEM) return;
+
+        // Play sound for wood
+        BlockHelpers.playCustomBlockSound(placed.getLocation(), VANILLA_WOOD_PLACE);
+        if (placed.getType() == Material.NOTE_BLOCK && !OraxenItems.exists(event.getItemInHand()))
+            placed.setBlockData(Bukkit.createBlockData(Material.NOTE_BLOCK), false);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onBreakingBlock(final BlockBreakEvent event) {
+        final Block block = event.getBlock();
+        if (block.getBlockData().getSoundGroup().getBreakSound() != Sound.BLOCK_WOOD_BREAK) return;
+        if (getNoteBlockMechanic(block) != null || block.getType() == Material.MUSHROOM_STEM) return;
+
+        if (breakerPlaySound.containsKey(block)) {
+            breakerPlaySound.get(block).cancel();
+            breakerPlaySound.remove(block);
+        }
+
+        BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_WOOD_BREAK);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -97,7 +97,7 @@ public class StringBlockMechanicListener implements Listener {
 
             if (stringBlockMechanic == null) return;
             if (stringBlockMechanic.hasBreakSound())
-                BlockHelpers.playCustomBlockSound(block, stringBlockMechanic.getBreakSound());
+                BlockHelpers.playCustomBlockSound(block.getLocation(), stringBlockMechanic.getBreakSound());
             if (stringBlockMechanic.getLight() != -1)
                 WrappedLightAPI.removeBlockLight(block.getLocation());
             stringBlockMechanic.getDrop().spawns(block.getLocation(), new ItemStack(Material.AIR));
@@ -218,7 +218,7 @@ public class StringBlockMechanicListener implements Listener {
         if (placedBlock == null)
             return;
         if (mechanic.hasPlaceSound())
-            BlockHelpers.playCustomBlockSound(placedBlock, mechanic.getPlaceSound());
+            BlockHelpers.playCustomBlockSound(placedBlock.getLocation(), mechanic.getPlaceSound());
         if (mechanic.getLight() != -1)
             WrappedLightAPI.createBlockLight(placedBlock.getLocation(), mechanic.getLight());
         if (mechanic.isSapling()) {
@@ -257,7 +257,7 @@ public class StringBlockMechanicListener implements Listener {
         if (gameEvent == GameEvent.STEP && mechanic.hasStepSound()) sound = mechanic.getStepSound();
         else if (gameEvent == GameEvent.HIT_GROUND && mechanic.hasStepSound()) sound = mechanic.getFallSound();
         else return;
-        BlockHelpers.playCustomBlockSound(block, sound, SoundCategory.PLAYERS);
+        BlockHelpers.playCustomBlockSound(entity.getLocation(), sound, SoundCategory.PLAYERS);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -371,7 +371,7 @@ public class StringBlockMechanicListener implements Listener {
     private void breakStringBlock(Block block, StringBlockMechanic mechanic, ItemStack item) {
         if (mechanic == null) return;
         if (mechanic.hasBreakSound())
-            BlockHelpers.playCustomBlockSound(block, mechanic.getBreakSound());
+            BlockHelpers.playCustomBlockSound(block.getLocation(), mechanic.getBreakSound());
         if (mechanic.getLight() != -1)
             WrappedLightAPI.removeBlockLight(block.getLocation());
         mechanic.getDrop().spawns(block.getLocation(), item);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingListener.java
@@ -4,10 +4,7 @@ import com.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.compatibilities.provided.worldedit.WrappedWorldEdit;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.Material;
-import org.bukkit.Particle;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -30,10 +27,12 @@ public class SaplingListener implements Listener {
         Block block = event.getClickedBlock();
         Player player = event.getPlayer();
         ItemStack item = event.getItem();
+
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getHand() != EquipmentSlot.HAND) return;
         if (block == null  || block.getType() != Material.TRIPWIRE) return;
         if (item == null || item.getType() != Material.BONE_MEAL) return;
 
+        Location loc = block.getLocation();
         StringBlockMechanic mechanic = getStringMechanic(block);
         if (mechanic == null || !mechanic.isSapling()) return;
 
@@ -43,18 +42,18 @@ public class SaplingListener implements Listener {
         if (sapling.requiresWaterSource() && sapling.isInWater(block)) return;
         if (!sapling.canGrowFromBoneMeal()) return;
         if (!Bukkit.getPluginManager().isPluginEnabled("WorldEdit")) return;
-        if (!sapling.replaceBlocks() && !WrappedWorldEdit.getBlocksInSchematic(block.getLocation(), sapling.getSchematic()).isEmpty()) return;
+        if (!sapling.replaceBlocks() && !WrappedWorldEdit.getBlocksInSchematic(loc, sapling.getSchematic()).isEmpty()) return;
 
         if (player.getGameMode() != GameMode.CREATIVE) item.setAmount(item.getAmount() - 1);
-        block.getWorld().spawnParticle(Particle.COMPOSTER, block.getLocation().add(0.5, 0.2, 0.5), 10);
+        block.getWorld().playEffect(loc, Effect.BONE_MEAL_USE, 3);
 
         PersistentDataContainer pdc = new CustomBlockData(block, OraxenPlugin.get());
         int growthTimeRemains = pdc.get(SAPLING_KEY, PersistentDataType.INTEGER) - sapling.getBoneMealGrowthSpeedup();
         if (growthTimeRemains <= 0) {
             block.setType(Material.AIR, false);
             if (sapling.hasGrowSound())
-                player.playSound(block.getLocation(), sapling.getGrowSound(), 1.0f, 0.8f);
-            WrappedWorldEdit.pasteSchematic(block.getLocation(), sapling.getSchematic(), sapling.replaceBlocks(), sapling.copyBiomes(), sapling.copyEntities());
+                player.playSound(loc, sapling.getGrowSound(), 1.0f, 0.8f);
+            WrappedWorldEdit.pasteSchematic(loc, sapling.getSchematic(), sapling.replaceBlocks(), sapling.copyBiomes(), sapling.copyEntities());
         } else pdc.set(SAPLING_KEY, PersistentDataType.INTEGER, growthTimeRemains);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/BreakListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/BreakListener.java
@@ -1,0 +1,23 @@
+package io.th0rgal.oraxen.mechanics.provided.misc.custom.listeners;
+
+import io.th0rgal.oraxen.items.OraxenItems;
+import io.th0rgal.oraxen.mechanics.provided.misc.custom.fields.CustomEvent;
+import io.th0rgal.oraxen.utils.actions.ClickAction;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class BreakListener extends CustomListener {
+
+    public BreakListener(String itemID, long cooldown, CustomEvent event, ClickAction clickAction) {
+        super(itemID, cooldown, event, clickAction);
+    }
+
+    @EventHandler
+    public void onBroken(PlayerItemBreakEvent event) {
+        ItemStack item = event.getBrokenItem();
+        if (!itemID.equals(OraxenItems.getIdByItem(item)))
+            return;
+        perform(event.getPlayer(), item);
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -37,14 +37,13 @@ public class BlockHelpers {
     public static String VANILLA_WOOD_STEP = "minecraft:required.wood.step";
     public static String VANILLA_WOOD_FALL = "minecraft:required.wood.fall";
 
-    public static void playCustomBlockSound(Block block, String sound) {
-        playCustomBlockSound(block, sound, SoundCategory.BLOCKS);
+    public static void playCustomBlockSound(Location location, String sound) {
+        playCustomBlockSound(toCenterLocation(location), sound, SoundCategory.BLOCKS);
     }
 
-    public static void playCustomBlockSound(Block block, String sound, SoundCategory category) {
-        if (sound == null || block == null || category == null) return;
-        SoundGroup soundGroup = block.getBlockData().getSoundGroup();
-        block.getWorld().playSound(block.getLocation(), sound, category, 1f, 0.8f);
+    public static void playCustomBlockSound(Location location, String sound, SoundCategory category) {
+        if (sound == null || location == null || location.getWorld() == null || category == null) return;
+        location.getWorld().playSound(location, sound, category, 1f, 0.8f);
     }
 
     public static Location toBlockLocation(Location location) {

--- a/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -25,6 +25,18 @@ import static org.bukkit.block.data.FaceAttachable.AttachedFace.FLOOR;
 
 public class BlockHelpers {
 
+    public static String VANILLA_STONE_PLACE = "minecraft:required.stone.place";
+    public static String VANILLA_STONE_BREAK = "minecraft:required.stone.break";
+    public static String VANILLA_STONE_HIT = "minecraft:required.stone.hit";
+    public static String VANILLA_STONE_STEP = "minecraft:required.stone.step";
+    public static String VANILLA_STONE_FALL = "minecraft:required.stone.fall";
+
+    public static String VANILLA_WOOD_PLACE = "minecraft:required.wood.place";
+    public static String VANILLA_WOOD_BREAK = "minecraft:required.wood.break";
+    public static String VANILLA_WOOD_HIT = "minecraft:required.wood.hit";
+    public static String VANILLA_WOOD_STEP = "minecraft:required.wood.step";
+    public static String VANILLA_WOOD_FALL = "minecraft:required.wood.fall";
+
     public static void playCustomBlockSound(Block block, String sound) {
         playCustomBlockSound(block, sound, SoundCategory.BLOCKS);
     }

--- a/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -44,7 +44,7 @@ public class BlockHelpers {
     public static void playCustomBlockSound(Block block, String sound, SoundCategory category) {
         if (sound == null || block == null || category == null) return;
         SoundGroup soundGroup = block.getBlockData().getSoundGroup();
-        block.getWorld().playSound(block.getLocation(), sound, category, soundGroup.getVolume(), soundGroup.getPitch());
+        block.getWorld().playSound(block.getLocation(), sound, category, 1f, 0.8f);
     }
 
     public static Location toBlockLocation(Location location) {

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -79,8 +79,7 @@ public class BreakerSystem {
                     triggeredModifier = modifier;
                     break;
                 }
-            if (triggeredModifier == null || triggeredModifier.getPeriod(player, block, item) == 0)
-                return;
+            if (triggeredModifier == null || triggeredModifier.getPeriod(player, block, item) == 0) return;
             event.setCancelled(true);
 
             final Location location = block.getLocation();
@@ -113,7 +112,10 @@ public class BreakerSystem {
                                 sendBlockBreak(viewer, location, value);
 
                         if (value++ < 10) return;
-                        if (!ProtectionLib.canBreak(player, block.getLocation())) return;
+                        if (!ProtectionLib.canBreak(player, block.getLocation())) {
+                            breakerPlaySound.remove(block);
+                            return;
+                        }
 
                         final BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, player);
                         Bukkit.getPluginManager().callEvent(blockBreakEvent);
@@ -122,7 +124,7 @@ public class BreakerSystem {
                             modifier.breakBlock(player, block, item);
                             PlayerItemDamageEvent playerItemDamageEvent = new PlayerItemDamageEvent(player, item, 1);
                             Bukkit.getPluginManager().callEvent(playerItemDamageEvent);
-                        }
+                        } else breakerPlaySound.remove(block);
 
                         Bukkit.getScheduler().runTask(OraxenPlugin.get(), () ->
                                 player.removePotionEffect(PotionEffectType.SLOW_DIGGING));

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -112,19 +112,18 @@ public class BreakerSystem {
                             if (entity instanceof Player viewer)
                                 sendBlockBreak(viewer, location, value);
 
-                        if (value++ < 10)
-                            return;
+                        if (value++ < 10) return;
+                        if (!ProtectionLib.canBreak(player, block.getLocation())) return;
 
-                        if (!ProtectionLib.canBreak(player, block.getLocation()))
-                            return;
                         final BlockBreakEvent blockBreakEvent = new BlockBreakEvent(block, player);
                         Bukkit.getPluginManager().callEvent(blockBreakEvent);
+
                         if (!blockBreakEvent.isCancelled()) {
                             modifier.breakBlock(player, block, item);
-                            PlayerItemDamageEvent playerItemDamageEvent = new PlayerItemDamageEvent(player,
-                                    item, 1);
+                            PlayerItemDamageEvent playerItemDamageEvent = new PlayerItemDamageEvent(player, item, 1);
                             Bukkit.getPluginManager().callEvent(playerItemDamageEvent);
                         }
+
                         Bukkit.getScheduler().runTask(OraxenPlugin.get(), () ->
                                 player.removePotionEffect(PotionEffectType.SLOW_DIGGING));
                         breakerPerLocation.remove(location);

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -12,15 +12,15 @@ import com.comphenix.protocol.wrappers.BlockPosition;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import com.jeff_media.customblockdata.CustomBlockData;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.type.Tripwire;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -33,11 +33,16 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanicFactory.getBlockMechanic;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.FURNITURE_KEY;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener.getNoteBlockMechanic;
+import static io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanicListener.getStringMechanic;
 
 public class BreakerSystem {
 
@@ -168,18 +173,31 @@ public class BreakerSystem {
     }
 
     private String getSound(Block block) {
-        return switch (block.getType()) {
-            case NOTE_BLOCK -> Objects.requireNonNull(getNoteBlockMechanic(block)).getHitSound();
-            case MUSHROOM_STEM -> BlockMechanicFactory.getBlockMechanic(block).getHitSound();
-            case TRIPWIRE -> StringBlockMechanicFactory.getBlockMechanic(StringBlockMechanicFactory.getCode((Tripwire) block.getBlockData())).getHitSound();
-            case BARRIER -> getFurnitureMechanic(block).getHitSound();
-            default -> null;
-        };
+        switch (block.getType()) {
+            case NOTE_BLOCK -> {
+                NoteBlockMechanic mechanic = getNoteBlockMechanic(block);
+                return (mechanic != null && mechanic.hasHitSound()) ? mechanic.getHitSound() : "required.wood.hit";
+            }
+            case MUSHROOM_STEM -> {
+                BlockMechanic mechanic = getBlockMechanic(block);
+                return (mechanic != null && mechanic.hasHitSound()) ? mechanic.getHitSound() : "required.wood.hit";
+            }
+            case TRIPWIRE -> {
+                StringBlockMechanic mechanic = getStringMechanic(block);
+                return (mechanic != null && mechanic.hasHitSound()) ? mechanic.getHitSound() : "block.tripwire.detach";
+            }
+            case BARRIER -> {
+                FurnitureMechanic mechanic = getFurnitureMechanic(block);
+                return (mechanic != null && mechanic.hasHitSound()) ? mechanic.getHitSound() : "required.stone.hit";
+            }
+            default -> { return block.getBlockData().getSoundGroup().getHitSound().toString(); }
+        }
     }
 
     private FurnitureMechanic getFurnitureMechanic(Block block) {
         if (block.getType() != Material.BARRIER) return null;
         final PersistentDataContainer customBlockData = new CustomBlockData(block, OraxenPlugin.get());
+        if (!customBlockData.has(FURNITURE_KEY, PersistentDataType.STRING)) return null;
         final String mechanicID = customBlockData.get(FURNITURE_KEY, PersistentDataType.STRING);
         return (FurnitureMechanic) FurnitureFactory.getInstance().getMechanic(mechanicID);
     }

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -159,7 +159,7 @@ public class BreakerSystem {
         fakeAnimation.getBlockPositionModifier().write(0, new BlockPosition(location.toVector()));
         if (!breakerPlaySound.contains(block)) {
             breakerPlaySound.add(block);
-            BlockHelpers.playCustomBlockSound(block, getSound(block));
+            BlockHelpers.playCustomBlockSound(block.getLocation(), getSound(block));
             Bukkit.getScheduler().runTaskLater(OraxenPlugin.get(), () ->
                     breakerPlaySound.remove(block), 3);
         }

--- a/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.utils.drops;
 
+import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.items.OraxenItems;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -34,21 +35,19 @@ public class Loot {
     }
 
     private ItemStack getItemStack() {
-        if (itemStack != null) {
-            return itemStack;
-        }
+        if (itemStack != null) return itemStack;
+
         if (config.containsKey("oraxen_item")) {
-            String itemId = (String) config.get("oraxen_item");
+            String itemId = config.get("oraxen_item").toString();
             itemStack = OraxenItems.getItemById(itemId).build();
-            return itemStack;
-        }
-        if (config.containsKey("minecraft_type")) {
-            String itemType = (String) config.get("minecraft_type");
+        } else if (config.containsKey("crucible_item")) {
+            String crucibleID = config.get("crucible_item").toString();
+            itemStack = MythicCrucible.core().getItemManager().getItemStack(crucibleID);
+        } else if (config.containsKey("minecraft_type")) {
+            String itemType = config.get("minecraft_type").toString();
             Material material = Material.getMaterial(itemType);
             itemStack = new ItemStack(material);
-            return itemStack;
-        }
-        itemStack = (ItemStack) config.get("minecraft_item");
+        } else itemStack = (ItemStack) config.get("minecraft_item");
         return itemStack;
     }
 

--- a/src/main/resources/items/armors.yml
+++ b/src/main/resources/items/armors.yml
@@ -27,6 +27,7 @@ emerald_helmet:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: 3a25f0b5-dbda-4e38-b097-9e75e37ae464, slot: HEAD }
   Pack:
+    custom_model_data: 1
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -50,6 +51,7 @@ emerald_chestplate:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: e06fc6c9-f06a-4b58-b1e2-10d6b282ac04, slot: CHEST }
   Pack:
+    custom_model_data: 1
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -73,11 +75,13 @@ emerald_leggings:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: 389ad53a-76be-4101-9ed1-e8da4845d5d2, slot: LEGS }
   Pack:
+    custom_model_data: 1
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
       - default/armors/emerald_leggings
       - default/armors/emerald_leggings
+
 emerald_boots:
   displayname: "<gradient:#89E59D:#37C6BA>Emerald Boots"
   material: LEATHER_BOOTS
@@ -95,6 +99,7 @@ emerald_boots:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: 7bfcf804-b75a-40a5-97f5-f23282703d0e, slot: FEET }
   Pack:
+    custom_model_data: 1
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -114,6 +119,7 @@ obsidian_helmet:
     - { name: "oraxen", attribute: GENERIC_ARMOR, amount: 2, operation: 0,
         uuid: 3a25f0b5-dbda-4e38-b097-9e75e37ae464, slot: HEAD }
   Pack:
+    custom_model_data: 2
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -121,6 +127,7 @@ obsidian_helmet:
       - default/armors/obsidian_helmet
 
 obsidian_chestplate:
+  custom_model_data: 2
   displayname: "<gradient:#4B36B1:#6699FF>Obsidian Chestplate"
   material: LEATHER_CHESTPLATE
   color: 28, 22, 46
@@ -152,6 +159,7 @@ obsidian_leggings:
     - { name: "oraxen", attribute: GENERIC_ARMOR, amount: 5, operation: 0,
         uuid: 389ad53a-76be-4101-9ed1-e8da4845d5d2, slot: LEGS }
   Pack:
+    custom_model_data: 2
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -171,6 +179,7 @@ obsidian_boots:
     - { name: "oraxen", attribute: GENERIC_ARMOR, amount: 2, operation: 0,
         uuid: 7bfcf804-b75a-40a5-97f5-f23282703d0e, slot: FEET }
   Pack:
+    custom_model_data: 2
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -190,6 +199,7 @@ ruby_helmet:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: 3a25f0b5-dbda-4e38-b097-9e75e37ae464, slot: HEAD }
   Pack:
+    custom_model_data: 3
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -209,6 +219,7 @@ ruby_chestplate:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: e06fc6c9-f06a-4b58-b1e2-10d6b282ac04, slot: CHEST }
   Pack:
+    custom_model_data: 3
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -228,6 +239,7 @@ ruby_leggings:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: 389ad53a-76be-4101-9ed1-e8da4845d5d2, slot: LEGS }
   Pack:
+    custom_model_data: 3
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor
@@ -247,6 +259,7 @@ ruby_boots:
     - { name: "oraxen", attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
         uuid: 7bfcf804-b75a-40a5-97f5-f23282703d0e, slot: FEET }
   Pack:
+    custom_model_data: 3
     generate_model: true
     parent_model: "item/generated"
     textures: # duplicate because we use the overlay of the leather armor


### PR DESCRIPTION
Fixes some sound-related nullpointers
Tweak playEffect for sapling mechanic
Make Drop/Loot mechanic support `crucible_item` as item option
Validate all glyphs and find which ones are misconfigured, also replaces to prevent entire font from breaking, Closes #394 
![image](https://user-images.githubusercontent.com/62521371/185404681-e0c1a881-e30b-446a-9f33-20dd88bae27c.png)
Automatically translate glyphs on signs and books and color correct

https://user-images.githubusercontent.com/62521371/185723430-aab3a7d3-4e13-4007-992d-b10663c25eb3.mp4

Add ItemBreak as CustomListener, Closes #257 
