### PR TITLE
add option to blacklist cmd values

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -14,6 +14,7 @@ public enum Settings {
     UPDATE_CONFIGS("ConfigsTools.enable_configs_updater"),
     AUTOMATICALLY_SET_GLYPH_CODE("ConfigsTools.automatically_set_glyph_code"),
     AUTOMATICALLY_SET_MODEL_DATA("ConfigsTools.automatically_set_model_data"),
+    SKIPPED_MODEL_DATA_NUMBERS("ConfigsTools.skipped_model_data_numbers"),
     ERROR_ITEM("ConfigsTools.error_item"),
 
     RESET_RECIPES("Misc.reset_recipes"),

--- a/src/main/java/io/th0rgal/oraxen/items/ModelData.java
+++ b/src/main/java/io/th0rgal/oraxen/items/ModelData.java
@@ -1,10 +1,9 @@
 package io.th0rgal.oraxen.items;
 
+import io.th0rgal.oraxen.config.Settings;
 import org.bukkit.Material;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class ModelData {
 
@@ -30,30 +29,56 @@ public class ModelData {
 
     public static int generateId(String model, Material type) {
         Map<String, Integer> usedDurabilities;
-        if (!DATAS.containsKey(type)) {
+        if (!DATAS.containsKey(type) && !getSkippedCustomModelData().contains(1)) {
             usedDurabilities = new HashMap<>();
             usedDurabilities.put(model, 1);
             DATAS.put(type, usedDurabilities);
             return 1;
-        } else
-            usedDurabilities = DATAS.get(type);
+        } else usedDurabilities = DATAS.get(type);
 
-        if (usedDurabilities.containsKey(model))
+        if (usedDurabilities.containsKey(model)) {
             return usedDurabilities.get(model);
+        }
+
         int currentMaxDurability = Collections.max(usedDurabilities.values());
         for (int i = 1; i < currentMaxDurability; i++) {
             if (!usedDurabilities.containsValue(i)) { // if the id is available
+                if (getSkippedCustomModelData().contains(i)) // if the id should be skipped
+                    continue;
                 usedDurabilities.put(model, i);
                 DATAS.put(type, usedDurabilities);
                 return i;
             }
         }
-        // if no durability was available between the choosed, let's create a new one
+        // if no durability was available between the chosen, let's create a new one
         // bigger
         int newMaxDurability = currentMaxDurability + 1;
+        if (getSkippedCustomModelData().contains(newMaxDurability)) { // if the id should be skipped
+            newMaxDurability = getNextNotSkippedCustomModelData(newMaxDurability);
+        }
+
         usedDurabilities.put(model, newMaxDurability);
         DATAS.put(type, usedDurabilities);
         return newMaxDurability;
     }
 
+    private static int getNextNotSkippedCustomModelData(int i) {
+        List<Integer> sorted = new ArrayList<>(getSkippedCustomModelData());
+        sorted.sort(Comparator.naturalOrder());
+        return sorted.stream().filter(index -> index > i).toList().get(0);
+    }
+
+    private static Set<Integer> getSkippedCustomModelData() {
+        Set<Integer> skippedCustomModelData = new HashSet<>();
+        for (String s : Settings.SKIPPED_MODEL_DATA_NUMBERS.toStringList()) {
+            if (s.contains("-")) {
+                String[] s2 = s.split("-");
+                int min = Integer.parseInt(s2[0]);
+                int max = Integer.parseInt(s2[1]);
+                for (int i = min; i <= max; i++)
+                    skippedCustomModelData.add(i);
+            } else skippedCustomModelData.add(Integer.parseInt(s));
+        }
+        return skippedCustomModelData;
+    }
 }

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -109,6 +109,9 @@ ConfigsTools:
   # Nice for production servers, automatically set model data in settings so
   # that you can add new items without breaking existing ones
   automatically_set_model_data: false
+  # list of model data numbers the automatic system will skip
+  # List can take ranges like 1-4 as well as normal singular numbers
+  skipped_model_data_numbers: [ ]
   # Same option for glyph codes
   automatically_set_glyph_code: false
   enable_configs_updater: true


### PR DESCRIPTION
Closes #451 

Settings.yml example
```yml
  automatically_set_model_data: true
  skipped_model_data_numbers: # list of model data numbers the automatic system will skip
    - 1-4
    - 10-12
    - 7-9
    ```