### PR TITLE
Fixed armors breaking when they shouldn't

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
@@ -22,23 +22,27 @@ public class DurabilityMechanicManager implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onItemDamaged(PlayerItemDamageEvent event) {
-        changeDurability(event.getItem(), -event.getDamage());
+        if (changeDurability(event.getItem(), -event.getDamage())) {
+            event.setDamage(0);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onItemMend(PlayerItemMendEvent event) {
-        changeDurability(event.getItem(), event.getRepairAmount());
+        if (changeDurability(event.getItem(), event.getRepairAmount())) {
+            event.setRepairAmount(0);
+        }
     }
 
-    public void changeDurability(ItemStack item, int amount) {
+    public boolean changeDurability(ItemStack item, int amount) {
         String itemID = OraxenItems.getIdByItem(item);
         if (factory.isNotImplementedIn(itemID))
-            return;
+            return false;
 
         DurabilityMechanic durabilityMechanic = (DurabilityMechanic) factory.getMechanic(itemID);
 
         ItemMeta itemMeta = item.getItemMeta();
-        if (itemMeta == null) return;
+        if (itemMeta == null) return false;
         PersistentDataContainer persistentDataContainer = itemMeta.getPersistentDataContainer();
         if (persistentDataContainer.has(DurabilityMechanic.NAMESPACED_KEY, PersistentDataType.INTEGER)) {
             int realDurabilityLeft = persistentDataContainer
@@ -47,7 +51,7 @@ public class DurabilityMechanicManager implements Listener {
                 persistentDataContainer
                         .set(DurabilityMechanic.NAMESPACED_KEY, PersistentDataType.INTEGER, realDurabilityLeft);
 
-                if(!(itemMeta instanceof Damageable)) return;
+                if(!(itemMeta instanceof Damageable)) return true;
                 double realMaxDurability = durabilityMechanic.getItemMaxDurability(); // because int rounded values suck
 
                 ((Damageable) itemMeta)
@@ -57,9 +61,9 @@ public class DurabilityMechanicManager implements Listener {
             } else {
                 item.setAmount(0);
             }
-
+            return true;
         }
-        
+        return false;
     }
 
 }


### PR DESCRIPTION
Since the plugin may handle the durability of some items, we have to update the event accordingly when we do so.

changeDurability method now returns if we have made any modification to the item.
When it returns true, we set the damage or repair amount to 0 so we don't break or repair an item.
This is needed because we need to know if we have handled the durability ourselves or not before modifying the event.

This fixes armours breaking when they shouldn't and items with mending displaying incorrect damage after being repaired.