### PR TITLE
Ignore os being null on startup

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -88,7 +88,9 @@ public class OraxenPlugin extends JavaPlugin {
         new BreakerSystem().registerListener();
         new CommandsManager().loadCommands();
         postLoading(configsManager);
-        Message.PLUGIN_LOADED.log(Utils.tagResolver("os", OS.getOs().getPlatformName()));
+        try {
+            Message.PLUGIN_LOADED.log(Utils.tagResolver("os", OS.getOs().getPlatformName()));
+        } catch (Exception ignore) {}
         CompatibilitiesManager.enableNativeCompatibilities();
     }
 


### PR DESCRIPTION
I had the problem that the plugins throws a NullPointer when using the plugin on ArchLinux.
This simple PR fixes this problem 