### PR TITLE
1.149.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,7 @@ repositories {
     maven { url 'https://mvn.lumine.io/repository/maven-public/' }
     // commandAPI snapshots
     maven { url = 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
-    // Thriumph Gui
-    maven { url = 'https://repo.mattstudios.me/artifactory/public/' }
-    // WorldEdit
+	// WorldEdit
     maven { url 'https://maven.enginehub.org/repo/' }
 }
 
@@ -84,7 +82,7 @@ dependencies {
     implementation group: 'net.kyori', name: 'adventure-text-minimessage', version: '4.11.0'
     implementation group: 'net.kyori', name: 'adventure-platform-bukkit', version: '4.1.2'
     implementation group: 'com.github.stefvanschie.inventoryframework', name: 'IF', version: '0.10.0'
-    implementation group: 'dev.jorel', name: 'commandapi-shade', version: '8.5.1-SNAPSHOT'
+    implementation "dev.jorel:commandapi-shade:8.7.0"
     implementation "com.jeff_media:CustomBlockData:2.0.0"
     implementation "com.jeff_media:MorePersistentDataTypes:2.3.1"
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 apply plugin: 'maven-publish'
 
 group 'io.th0rgal'
-def pluginVersion = '1.149.0'
+def pluginVersion = '1.150.0'
 ext.jitpackGroup = group + '.oraxen'
 ext.jitpackVersion = 'main-' + pluginVersion
 version = pluginVersion

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 apply plugin: 'maven-publish'
 
 group 'io.th0rgal'
-def pluginVersion = '1.150.0'
+def pluginVersion = '1.149.1'
 ext.jitpackGroup = group + '.oraxen'
 ext.jitpackVersion = 'main-' + pluginVersion
 version = pluginVersion

--- a/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
@@ -25,11 +25,11 @@ public class ReloadCommand {
 
     private static void reloadPack(OraxenPlugin plugin, CommandSender sender) {
         Message.PACK_REGENERATED.send(sender);
-        OraxenPlugin.get().setFontManager(new FontManager(OraxenPlugin.get().getConfigsManager()));
-        OraxenPlugin.get().setSoundManager(new SoundManager(OraxenPlugin.get().getConfigsManager().getSound()));
-        OraxenPlugin.get().getResourcePack().generate(OraxenPlugin.get().getFontManager(),
-                OraxenPlugin.get().getSoundManager());
-        plugin.getUploadManager().uploadAsyncAndSendToPlayers(OraxenPlugin.get().getResourcePack(), true);
+        plugin.setFontManager(new FontManager(plugin.getConfigsManager()));
+        plugin.setSoundManager(new SoundManager(plugin.getConfigsManager().getSound()));
+        plugin.getResourcePack().generate(plugin.getFontManager(),
+                plugin.getSoundManager());
+        plugin.getUploadManager().uploadAsyncAndSendToPlayers(plugin.getResourcePack(), true, true);
     }
 
     private static void reloadHud(CommandSender sender) {

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -47,6 +47,7 @@ public enum Settings {
     POLYMATH_SERVER("Pack.upload.polymath.server"),
 
     SEND_PACK("Pack.dispatch.send_pack"),
+    SEND_ON_RELOAD("Pack.dispatch.send_on_reload"),
     SEND_PACK_DELAY("Pack.dispatch.delay"),
     SEND_PACK_ADVANCED("Pack.dispatch.send_pack_advanced.enabled"),
     SEND_PACK_ADVANCED_MANDATORY("Pack.dispatch.send_pack_advanced.mandatory"),

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -35,6 +35,7 @@ public enum Settings {
     GENERATE("Pack.generation.generate"),
     ATTEMPT_TO_MIGRATE_DUPLICATES("Pack.generation.attempt_to_migrate_duplicates"),
     ARMOR_RESOLUTION("Pack.generation.armor_resolution"),
+    ANIMATED_ARMOR_FRAMERATE("Pack.generation.animated_armor_framerate"),
     AUTOMATICALLY_GENERATE_SHADER_COMPATIBLE_ARMOR("Pack.generation.automatically_generate_shader_compatible_armor"),
     COMPRESSION("Pack.generation.compression"),
     PROTECTION("Pack.generation.protection"),

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockSoundListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockSoundListener.java
@@ -55,7 +55,7 @@ public class BlockSoundListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPlacing(final BlockBreakEvent event) {
+    public void onPlacing(final BlockPlaceEvent event) {
         BlockMechanic mechanic = OraxenBlocks.getBlockMechanic(event.getBlock());
         if (mechanic == null || !mechanic.hasBlockSounds() || !mechanic.getBlockSounds().hasPlaceSound()) return;
         BlockSounds blockSounds = mechanic.getBlockSounds();
@@ -64,7 +64,7 @@ public class BlockSoundListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onBreaking(final BlockPlaceEvent event) {
+    public void onBreaking(final BlockBreakEvent event) {
         BlockMechanic mechanic = OraxenBlocks.getBlockMechanic(event.getBlock());
         if (mechanic == null || !mechanic.hasBlockSounds()) return;
         BlockSounds blockSounds = mechanic.getBlockSounds();

--- a/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
@@ -36,14 +36,11 @@ public class BukkitPackSender extends PackSender implements Listener {
             sendWelcomeMessage(event.getPlayer(), true);
         if (Settings.SEND_PACK.toBool()) {
             int delay = (int) Settings.SEND_PACK_DELAY.getValue();
-            if(delay <= 0)
+            if (delay <= 0)
                 sendPack(event.getPlayer());
-            else
-                Bukkit
-                        .getScheduler()
-                        .runTaskLaterAsynchronously(OraxenPlugin.get(),
-                                () -> sendPack(event.getPlayer()),
-                                delay * 20L);
+            else Bukkit.getScheduler().runTaskLaterAsynchronously(OraxenPlugin.get(),
+                    () -> sendPack(event.getPlayer()),
+                    delay * 20L);
         }
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/PackConvertor.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/PackConvertor.java
@@ -22,6 +22,7 @@ public class PackConvertor {
         convertBlocksPack_1_19_3(output);
         convertItemsPack_1_19_3(output);
         generateAtlasFile(output);
+        Logs.logSuccess("Finished converting the resourcepack to 1.19.3 format");
     }
 
     //TODO This will probably not get pulling bow models etc, check ModelGenerator for this
@@ -29,7 +30,13 @@ public class PackConvertor {
         try {
             Set<VirtualFile> items = output.stream().filter(v -> v.getPath().startsWith("assets/minecraft/models/item") && v.getPath().endsWith(".json")).collect(Collectors.toSet());
             for (VirtualFile virtualFile : items.stream().filter(v -> {
-                Material.valueOf(v.getPath().split("/")[v.getPath().split("/").length - 1].replace(".json", "").toUpperCase());
+                try {
+                    Material.valueOf(v.getPath().split("/")[v.getPath().split("/").length - 1].replace(".json", "").toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    // If someone has their model inside item folder, but it isn't
+                    // a material this should return false to exclude it
+                    return false;
+                }
                 return true;
             }).collect(Collectors.toSet())) {
                 String itemModelContent = IOUtils.toString(virtualFile.getInputStream(), String.valueOf(StandardCharsets.UTF_8));

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/PackConvertor.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/PackConvertor.java
@@ -21,8 +21,21 @@ public class PackConvertor {
         Logs.logSuccess("Starting pack conversion for 1.19.3");
         convertBlocksPack_1_19_3(output);
         convertItemsPack_1_19_3(output);
+        convertAnimPack_1_19_3(output);
         generateAtlasFile(output);
         Logs.logSuccess("Finished converting the resourcepack to 1.19.3 format");
+    }
+
+    private void convertAnimPack_1_19_3(List<VirtualFile> output) {
+        try {
+            Set<VirtualFile> anims = output.stream().filter(v -> v.getPath().endsWith(".png.mcmeta")).collect(Collectors.toSet());
+            for (VirtualFile virtualFile : anims) {
+                String metaPath = virtualFile.getPath().split("assets/.*/textures/")[1];
+                virtualFile.setPath("assets/oraxen_converted/textures/" + (!metaPath.startsWith("oraxen/") ? "oraxen/" : "") + metaPath);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     //TODO This will probably not get pulling bow models etc, check ModelGenerator for this
@@ -135,7 +148,6 @@ public class PackConvertor {
             for (VirtualFile file : textures) {
                 String texturePath = file.getPath().split("assets/.*/textures/")[1];
                 file.setPath("assets/oraxen_converted/textures/" + (!texturePath.startsWith("oraxen/") ? "oraxen/" : "") + texturePath);
-                output.set(output.indexOf(file), file);
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
@@ -47,10 +47,10 @@ public class UploadManager {
     }
 
     public void uploadAsyncAndSendToPlayers(final ResourcePack resourcePack) {
-        uploadAsyncAndSendToPlayers(resourcePack, false);
+        uploadAsyncAndSendToPlayers(resourcePack, false, false);
     }
 
-    public void uploadAsyncAndSendToPlayers(final ResourcePack resourcePack, final boolean updatePackSender) {
+    public void uploadAsyncAndSendToPlayers(final ResourcePack resourcePack, final boolean updatePackSender, final boolean isReload) {
         if (!enabled)
             return;
 
@@ -79,7 +79,10 @@ public class UploadManager {
                         ? new AdvancedPackSender(hostingProvider) : new BukkitPackSender(hostingProvider);
             }
 
-            if (Settings.SEND_PACK.toBool() || Settings.SEND_JOIN_MESSAGE.toBool()) {
+            if (isReload && !Settings.SEND_ON_RELOAD.toBool()) {
+                if (packSender != null) packSender.unregister();
+            }
+            else if (Settings.SEND_PACK.toBool() || Settings.SEND_JOIN_MESSAGE.toBool()) {
                 packSender.register();
                 if (!hostingProvider.getPackURL().equals(url))
                     for (Player player : Bukkit.getOnlinePlayers())

--- a/src/main/resources/languages/english.yml
+++ b/src/main/resources/languages/english.yml
@@ -8,7 +8,7 @@ general:
   pack_uploading: "<prefix><#D5D6D8>Automatic upload of the resource pack is enabled, uploading..."
   pack_not_uploaded: "<prefix><#fa4943>Resourcepack not uploaded"
   pack_uploaded: "<prefix><#55ffa4>Resourcepack uploaded on url <url> in <delay> ms"
-  pack_regenerated: "<prefix><#55ffa4>resourcepack successfully regenerated"
+  pack_regenerated: "<prefix><#55ffa4>Resourcepack successfully regenerated"
   updating_config: "<prefix><#facc43>Configuration option \"<option>\" not found, adding it!"
   configs_validation_failed: "<prefix><#fa4943>Configurations validation failed, plugin automatically disabled!"
   repaired_items: "<prefix><#55ffa4><amount> item(s) were successfully repaired!"

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -46,6 +46,7 @@ Pack:
 
   dispatch:
     send_pack: true
+    send_on_reload: true
     delay: -1
     # this option requires ProtocolLib and will make the pack loading more fluid
     send_pack_advanced:

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -25,6 +25,7 @@ Pack:
     # 64x32 layer is default size and corresponds to 16. If you need higher
     # resolution, e.g. 128x64, you should set this parameter to 32 and so on.
     armor_resolution: 16
+    animated_armor_framerate: 24
     automatically_generate_shader_compatible_armor: true
     compression: BEST_COMPRESSION # see Deflater.class
     # protection will use several methods to make your pack impossible to extract


### PR DESCRIPTION
**1.149.1**

```yml
- 1.19.3 preliminary support
  * Oraxen now loads on 1.19.3 servers, but still recommend sticking to 1.19.2 if you can
- Fix some cases where 1.19.3 Pack Conversion would fail and prevent the plugin from loading
- Fix animated textures(mcmeta files) not being converted to 1.19.3 format
- "Fix" animated custom armor
  * Shader compatible versions will not be animated at the moment and only display a static version
- Add option to disable resourcepack being resent when using the reload command
- Fix Block-mechanic place/break sounds
```