### PR TITLE
Add more cube parent models

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
@@ -15,7 +15,14 @@ public class ModelGenerator {
         String parentModel = oraxenMeta.getParentModel();
 
         json.addProperty("parent", parentModel);
-        if (parentModel.equals("block/cube_all")) {
+        if (parentModel.equals("block/cube") || parentModel.equals("block/cube_directional")) {
+            textures.addProperty("down", layers.get(0));
+            textures.addProperty("up", layers.get(1));
+            textures.addProperty("north", layers.get(2));
+            textures.addProperty("south", layers.get(3));
+            textures.addProperty("west", layers.get(4));
+            textures.addProperty("east", layers.get(5));
+        } else if (parentModel.equals("block/cube_all") || parentModel.equals("block/cube_mirrored_all")) {
             textures.addProperty("all", layers.get(0));
         } else if (parentModel.equals("block/cross")) {
             textures.addProperty("cross", layers.get(0));
@@ -24,8 +31,17 @@ public class ModelGenerator {
             textures.addProperty("side", layers.get(1));
             if (!parentModel.endsWith("vertical"))
                 textures.addProperty("top", layers.get(2));
-        } else if (parentModel.equals("block/cube_column")) {
+            if (parentModel.endsWith("with_bottom"))
+                textures.addProperty("bottom", layers.get(3));
+        } else if (parentModel.startsWith("block/cube_column")) {
             textures.addProperty("end", layers.get(0));
+            textures.addProperty("side", layers.get(1));
+        } else if (parentModel.equals("block/cube_bottom_top")) {
+            textures.addProperty("top", layers.get(0));
+            textures.addProperty("side", layers.get(1));
+            textures.addProperty("bottom", layers.get(2));
+        } else if (parentModel.equals("block/cube_top")) {
+            textures.addProperty("top", layers.get(0));
             textures.addProperty("side", layers.get(1));
         } else {
             for (int i = 0; i < layers.size(); i++)

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
@@ -16,6 +16,7 @@ public class ModelGenerator {
 
         json.addProperty("parent", parentModel);
         if (parentModel.equals("block/cube") || parentModel.equals("block/cube_directional") || parentModel.equals("block/cube_mirrored")) {
+            textures.addProperty("particle", layers.get(2));
             textures.addProperty("down", layers.get(0));
             textures.addProperty("up", layers.get(1));
             textures.addProperty("north", layers.get(2));

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
@@ -15,7 +15,7 @@ public class ModelGenerator {
         String parentModel = oraxenMeta.getParentModel();
 
         json.addProperty("parent", parentModel);
-        if (parentModel.equals("block/cube") || parentModel.equals("block/cube_directional")) {
+        if (parentModel.equals("block/cube") || parentModel.equals("block/cube_directional") || parentModel.equals("block/cube_mirrored")) {
             textures.addProperty("down", layers.get(0));
             textures.addProperty("up", layers.get(1));
             textures.addProperty("north", layers.get(2));


### PR DESCRIPTION
This adds:
- `block/cube`,
- `block/cube_mirrored`,
- `block/cube_directional`,
- `block/cube_mirrored_all`,
- `block/orientable_with_bottom`,
- `block/cube_column_horizontal`,
- `block/cube_column_mirrored`,
- `block/cube_bottom_top`,
- `block/cube_top`

And i think that's all

Examples:
<details>
<summary>
For:

`block/cube`, `block/cube_mirrored`, `block/cube_directional`
</summary>
<p>

```yaml
cube:
  displayname: Example
  material: PAPER
  Pack:
    generate_model: true
    parent_model: block/cube
    textures:
      - block/down
      - block/up
      - block/north
      - block/south
      - block/west
      - block/east
```
</p>
</details>
<details>
<summary>
For:

`block/cube_mirrored_all`
</summary>
<p>

Same as `block/cube_all`
</p>
</details>
<details>
<summary>
For:

`block/orientable_with_bottom`
</summary>
<p>

```yaml
cube:
  displayname: Example
  material: PAPER
  Pack:
    generate_model: true
    parent_model: block/orientable_with_bottom
    textures:
      - block/front
      - block/side
      - block/top
      - block/bottom
```
</p>
</details>
<details>
<summary>
For:

`block/cube_column_horizontal`, `block/cube_column_mirrored`,
</summary>
<p>

Same as `block/cube_column`
</p>
</details>
<details>
<summary>
For:

`block/cube_bottom_top`
</summary>
<p>

```yaml
cube:
  displayname: Example
  material: PAPER
  Pack:
    generate_model: true
    parent_model: block/cube_bottom_top
    textures:
      - block/top
      - block/side
      - block/bottom
```
</p>
</details>
<details>
<summary>
For:

`block/cube_top`
</summary>
<p>

```yaml
cube:
  displayname: Example
  material: PAPER
  Pack:
    generate_model: true
    parent_model: block/cube_top
    textures:
      - block/top
      - block/side
```
</p>
</details>