### PR TITLE
Changing the path of the generated model

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -4,6 +4,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class OraxenMeta {
@@ -17,10 +18,12 @@ public class OraxenMeta {
     private String castModel;
     private List<String> layers;
     private String parentModel;
+    private String modelDirectory;
     private boolean generate_model;
     private boolean hasPackInfos = false;
     private boolean excludedFromInventory = false;
     private boolean noUpdate = false;
+    private boolean hasCustomModelDirectory = false;
 
     public void setExcludedFromInventory() {
         this.excludedFromInventory = true;
@@ -51,6 +54,12 @@ public class OraxenMeta {
         // If not specified, check if a model or texture is set
         this.generate_model = configurationSection.getBoolean("generate_model", getModelName().isEmpty());
         this.parentModel = configurationSection.getString("parent_model", "item/generated");
+        String modelDirectory = configurationSection.getString("model_directory");
+        if (modelDirectory != null) {
+            this.modelDirectory = modelDirectory;
+            this.hasCustomModelDirectory = true;
+        } else
+            this.modelDirectory = "minecraft/models";
     }
 
     // this might not be a very good function name
@@ -89,6 +98,16 @@ public class OraxenMeta {
     }
 
     public String getModelName() {
+        return modelName;
+    }
+
+    public String getModelPath() {
+        if (hasCustomModelDirectory()) {
+            String[] modelDirElements = modelDirectory.split("/");
+            String path = String.join("/", Arrays.copyOfRange(modelDirElements, 2, modelDirElements.length));
+            String fixedPath = !path.isEmpty() ? path + "/" : "";
+            return modelDirElements[0] + ":" + fixedPath + modelName;
+        }
         return modelName;
     }
 
@@ -144,6 +163,10 @@ public class OraxenMeta {
         return parentModel;
     }
 
+    public String getModelDirectory() {
+        return modelDirectory;
+    }
+
     public boolean shouldGenerateModel() {
         return generate_model;
     }
@@ -152,4 +175,7 @@ public class OraxenMeta {
         return noUpdate;
     }
 
+    public boolean hasCustomModelDirectory() {
+        return hasCustomModelDirectory;
+    }
 }

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
@@ -102,9 +102,9 @@ public class PredicatesGenerator {
             int customModelData = oraxenMeta.getCustomModelData();
 
             // Skip duplicate
-            if (overrides.contains(getOverride("custom_model_data", customModelData, oraxenMeta.getModelName()))) continue;
+            if (overrides.contains(getOverride("custom_model_data", customModelData, oraxenMeta.getModelPath()))) continue;
 
-            overrides.add(getOverride("custom_model_data", customModelData, oraxenMeta.getModelName()));
+            overrides.add(getOverride("custom_model_data", customModelData, oraxenMeta.getModelPath()));
             if (oraxenMeta.hasBlockingModel()) {
                 final JsonObject predicate = new JsonObject();
                 predicate.addProperty("blocking", 1);

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -241,7 +241,7 @@ public class ResourcePack {
             final ItemBuilder item = entry.getValue();
             if (item.getOraxenMeta().hasPackInfos()) {
                 if (item.getOraxenMeta().shouldGenerateModel())
-                    writeStringToVirtual("assets/minecraft/models",
+                    writeStringToVirtual("assets/" + item.getOraxenMeta().getModelDirectory(),
                             item.getOraxenMeta().getModelName() + ".json",
                             new ModelGenerator(item.getOraxenMeta()).getJson().toString());
                 final List<ItemBuilder> items = texturedItems.getOrDefault(item.build().getType(), new ArrayList<>());


### PR DESCRIPTION
Allows you to change the path of the generated model:
Example:
```yaml
Pack:
  generate_model: true
  model_directory: example/models/block #Model in assets/example/models/block/
  parent_model: block/cube_all
  textures:
  - minecraft:block/texture #Texture in assets/minecraft/textures/block/
```

Currently only supports main model (pulling models, blocking models etc. currently don't work)