### PR TITLE
Add better texture system

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -4,6 +4,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,19 +44,19 @@ public class OraxenMeta {
         this.fireworkModel = readModelName(configurationSection, "firework_model");
         this.pullingModels = configurationSection.isList("pulling_models")
                 ? configurationSection.getStringList("pulling_models") : null;
-        this.layers = configurationSection.getStringList("textures");
-        ConfigurationSection texturesSection = configurationSection.getConfigurationSection("textures");
-        if (texturesSection != null) {
-            Map<String, String> layersMap = new HashMap<>();
-            texturesSection.getKeys(false).forEach(key -> layersMap.put(key, texturesSection.getString(key)));
-            this.layersMap = layersMap;
+
+        if (configurationSection.isList("textures")) {
+            this.layers = configurationSection.getStringList("textures");
+            List<String> layers = new ArrayList<>();
+            this.layers.forEach(layer -> layers.add(this.layers.indexOf(layer), layer.replace(".png", "")));
+            this.layers = layers;
         }
-        // can't be refactored with for each or stream because it'll throw
-        // ConcurrentModificationException
-        for (int i = 0; i < layers.size(); i++) {
-            String layer = layers.get(i);
-            if (layer.endsWith(".png"))
-                layers.set(i, layer.substring(0, layer.length() - 4));
+        else if (configurationSection.isConfigurationSection("textures")) {
+            ConfigurationSection texturesSection = configurationSection.getConfigurationSection("textures");
+            assert texturesSection != null;
+            Map<String, String> layersMap = new HashMap<>();
+            texturesSection.getKeys(false).forEach(key -> layersMap.put(key, texturesSection.getString(key).replace(".png", "")));
+            this.layersMap = layersMap;
         }
 
         // If not specified, check if a model or texture is set

--- a/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -4,7 +4,9 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class OraxenMeta {
 
@@ -16,6 +18,7 @@ public class OraxenMeta {
     private String fireworkModel;
     private String castModel;
     private List<String> layers;
+    private Map<String, String> layersMap;
     private String parentModel;
     private boolean generate_model;
     private boolean hasPackInfos = false;
@@ -41,6 +44,12 @@ public class OraxenMeta {
         this.pullingModels = configurationSection.isList("pulling_models")
                 ? configurationSection.getStringList("pulling_models") : null;
         this.layers = configurationSection.getStringList("textures");
+        ConfigurationSection texturesSection = configurationSection.getConfigurationSection("textures");
+        if (texturesSection != null) {
+            Map<String, String> layersMap = new HashMap<>();
+            texturesSection.getKeys(false).forEach(key -> layersMap.put(key, texturesSection.getString(key)));
+            this.layersMap = layersMap;
+        }
         // can't be refactored with for each or stream because it'll throw
         // ConcurrentModificationException
         for (int i = 0; i < layers.size(); i++) {
@@ -141,6 +150,14 @@ public class OraxenMeta {
 
     public List<String> getLayers() {
         return layers;
+    }
+
+    public boolean hasLayersMap() {
+        return layersMap != null && !layersMap.isEmpty();
+    }
+
+    public Map<String, String> getLayersMap() {
+        return layersMap;
     }
 
     public String getParentModel() {

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
@@ -11,25 +11,29 @@ public class ModelGenerator {
 
     public ModelGenerator(OraxenMeta oraxenMeta) {
         JsonObject textures = new JsonObject();
-        List<String> layers = oraxenMeta.getLayers();
         String parentModel = oraxenMeta.getParentModel();
 
         json.addProperty("parent", parentModel);
-        if (parentModel.equals("block/cube_all")) {
-            textures.addProperty("all", layers.get(0));
-        } else if (parentModel.equals("block/cross")) {
-            textures.addProperty("cross", layers.get(0));
-        } else if (parentModel.startsWith("block/orientable")) {
-            textures.addProperty("front", layers.get(0));
-            textures.addProperty("side", layers.get(1));
-            if (!parentModel.endsWith("vertical"))
-                textures.addProperty("top", layers.get(2));
-        } else if (parentModel.equals("block/cube_column")) {
-            textures.addProperty("end", layers.get(0));
-            textures.addProperty("side", layers.get(1));
-        } else {
-            for (int i = 0; i < layers.size(); i++)
-                textures.addProperty("layer" + i, layers.get(i));
+        if (oraxenMeta.hasLayersMap()) { //Check if oraxen meta uses new texture system
+            oraxenMeta.getLayersMap().forEach(textures::addProperty);
+        } else { //Use old texture system
+            List<String> layers = oraxenMeta.getLayers();
+            if (parentModel.equals("block/cube_all")) {
+                textures.addProperty("all", layers.get(0));
+            } else if (parentModel.equals("block/cross")) {
+                textures.addProperty("cross", layers.get(0));
+            } else if (parentModel.startsWith("block/orientable")) {
+                textures.addProperty("front", layers.get(0));
+                textures.addProperty("side", layers.get(1));
+                if (!parentModel.endsWith("vertical"))
+                    textures.addProperty("top", layers.get(2));
+            } else if (parentModel.equals("block/cube_column")) {
+                textures.addProperty("end", layers.get(0));
+                textures.addProperty("side", layers.get(1));
+            } else {
+                for (int i = 0; i < layers.size(); i++)
+                    textures.addProperty("layer" + i, layers.get(i));
+            }
         }
         json.add("textures", textures);
 

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
@@ -16,7 +16,7 @@ public class ModelGenerator {
         json.addProperty("parent", parentModel);
         if (oraxenMeta.hasLayersMap()) { //Check if oraxen meta uses new texture system
             oraxenMeta.getLayersMap().forEach(textures::addProperty);
-        } else { //Use old texture system
+        } else if (oraxenMeta.hasLayers()) { //Use old texture system
             List<String> layers = oraxenMeta.getLayers();
             if (parentModel.equals("block/cube_all")) {
                 textures.addProperty("all", layers.get(0));
@@ -35,6 +35,7 @@ public class ModelGenerator {
                     textures.addProperty("layer" + i, layers.get(i));
             }
         }
+
         json.add("textures", textures);
 
     }


### PR DESCRIPTION
This PR adds a better texture system with support to the old one (so it's optional).
The advantage of this system is that it allows you to use any parent model template (so if you create custom model and you want it to work as template like `block/cube_all` etc., this system allows you to to that!)

Examples:
```yaml
Pack:
  generate_model: true
  parent_model: block/cube
  textures:
    particle: block/texture_north
    down: block/texture_down
    up: block/texture_up
    north: block/texture_north
    south: block/texture_south
    west: block/texture_west
    east: block/texture_east
```
```yaml
Pack:
  generate_model: true
  parent_model: block/cube_bottom_top
  textures:
    top: block/texture_top
    side: block/texture_side
    bottom: block/texture_bottom
```