### PR TITLE
Improve interact event

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/api/events/OraxenNoteBlockInteractEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/api/events/OraxenNoteBlockInteractEvent.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,14 +19,16 @@ public class OraxenNoteBlockInteractEvent extends Event implements Cancellable {
     private final ItemStack itemInHand;
     private final BlockFace blockFace;
     private boolean isCancelled;
+    private final EquipmentSlot hand;
     private static final HandlerList HANDLERS = new HandlerList();
 
-    public OraxenNoteBlockInteractEvent(NoteBlockMechanic mechanic, Block block, BlockFace blockFace, Player player, ItemStack itemInHand) {
+    public OraxenNoteBlockInteractEvent(NoteBlockMechanic mechanic, Block block, BlockFace blockFace, Player player, ItemStack itemInHand, EquipmentSlot hand) {
         this.mechanic = mechanic;
         this.block = block;
         this.player = player;
         this.itemInHand = itemInHand;
         this.blockFace = blockFace;
+        this.hand = hand;
         this.isCancelled = false;
     }
 
@@ -64,6 +67,12 @@ public class OraxenNoteBlockInteractEvent extends Event implements Cancellable {
         return blockFace;
     }
 
+    /**
+     * @return The hand used to perform interaction
+     */
+    public EquipmentSlot getHand() {
+        return hand;
+    }
 
     @Override
     public boolean isCancelled() {

--- a/src/main/java/io/th0rgal/oraxen/api/events/OraxenStringBlockInteractEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/api/events/OraxenStringBlockInteractEvent.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,14 +19,16 @@ public class OraxenStringBlockInteractEvent extends Event implements Cancellable
     private final ItemStack itemInHand;
     private boolean isCancelled;
     private final BlockFace blockFace;
+    private final EquipmentSlot hand;
     private static final HandlerList HANDLERS = new HandlerList();
 
-    public OraxenStringBlockInteractEvent(StringBlockMechanic mechanic, Block block, ItemStack itemInHand, Player player, BlockFace blockFace) {
+    public OraxenStringBlockInteractEvent(StringBlockMechanic mechanic, Block block, ItemStack itemInHand, Player player, BlockFace blockFace, EquipmentSlot hand) {
         this.mechanic = mechanic;
         this.itemInHand = itemInHand;
         this.block = block;
         this.player = player;
         this.isCancelled = false;
+        this.hand = hand;
         this.blockFace = blockFace;
     }
 
@@ -57,12 +60,18 @@ public class OraxenStringBlockInteractEvent extends Event implements Cancellable
         return itemInHand;
     }
 
-
     /**
      * @return Clicked block face
      */
     public BlockFace getBlockFace() {
         return blockFace;
+    }
+
+    /**
+     * @return The hand used to perform interaction
+     */
+    public EquipmentSlot getHand() {
+        return hand;
     }
 
     @Override

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -184,7 +184,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (mechanic.isDirectional() && !mechanic.getDirectional().isParentBlock())
             mechanic = mechanic.getDirectional().getParentMechanic();
 
-        OraxenNoteBlockInteractEvent noteBlockInteractEvent = new OraxenNoteBlockInteractEvent(noteMechanic, block, event.getBlockFace(), event.getPlayer(), event.getItem(), event.getHand());
+        OraxenNoteBlockInteractEvent noteBlockInteractEvent = new OraxenNoteBlockInteractEvent(mechanic, block, event.getBlockFace(), event.getPlayer(), event.getItem(), event.getHand());
         OraxenPlugin.get().getServer().getPluginManager().callEvent(noteBlockInteractEvent);
         if (noteBlockInteractEvent.isCancelled()) {
             event.setCancelled(true);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -54,12 +54,11 @@ public class NoteBlockMechanicListener implements Listener {
     public void callInteract(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
         if (block == null) return;
-        if (event.getHand() != EquipmentSlot.HAND) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (event.getClickedBlock().getType() != Material.NOTE_BLOCK) return;
         NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
         if (mechanic == null) return;
-        OraxenNoteBlockInteractEvent oraxenEvent = new OraxenNoteBlockInteractEvent(mechanic, block, event.getBlockFace(), event.getPlayer(), event.getItem());
+        OraxenNoteBlockInteractEvent oraxenEvent = new OraxenNoteBlockInteractEvent(mechanic, block, event.getBlockFace(), event.getPlayer(), event.getItem(), event.getHand());
         Bukkit.getPluginManager().callEvent(oraxenEvent);
         if (oraxenEvent.isCancelled()) event.setCancelled(true);
     }
@@ -185,7 +184,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (noteMechanic.isDirectional())
             noteMechanic = noteMechanic.getDirectional().getParentBlockMechanic(noteMechanic);
 
-        OraxenNoteBlockInteractEvent noteBlockInteractEvent = new OraxenNoteBlockInteractEvent(noteMechanic, block, event.getBlockFace(), event.getPlayer(), event.getItem());
+        OraxenNoteBlockInteractEvent noteBlockInteractEvent = new OraxenNoteBlockInteractEvent(noteMechanic, block, event.getBlockFace(), event.getPlayer(), event.getItem(), event.getHand());
         OraxenPlugin.get().getServer().getPluginManager().callEvent(noteBlockInteractEvent);
         if (noteBlockInteractEvent.isCancelled()) {
             event.setCancelled(true);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -58,12 +58,11 @@ public class StringBlockMechanicListener implements Listener {
     public void callInteract(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
         if (block == null) return;
-        if (event.getHand() != EquipmentSlot.HAND) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (event.getClickedBlock().getType() != Material.NOTE_BLOCK) return;
         StringBlockMechanic mechanic = OraxenBlocks.getStringMechanic(block);
         if (mechanic == null) return;
-        OraxenStringBlockInteractEvent oraxenEvent = new OraxenStringBlockInteractEvent(mechanic, block, event.getItem(), event.getPlayer(), event.getBlockFace());
+        OraxenStringBlockInteractEvent oraxenEvent = new OraxenStringBlockInteractEvent(mechanic, block, event.getItem(), event.getPlayer(), event.getBlockFace(), event.getHand());
         Bukkit.getPluginManager().callEvent(oraxenEvent);
         if (oraxenEvent.isCancelled()) event.setCancelled(true);
     }
@@ -221,7 +220,7 @@ public class StringBlockMechanicListener implements Listener {
             // Call the event
             StringBlockMechanic stringBlockMechanic = OraxenBlocks.getStringMechanic(block);
             if (stringBlockMechanic == null) return;
-            OraxenStringBlockInteractEvent wireBlockInteractEvent = new OraxenStringBlockInteractEvent(stringBlockMechanic, block, event.getItem(), event.getPlayer(), event.getBlockFace());
+            OraxenStringBlockInteractEvent wireBlockInteractEvent = new OraxenStringBlockInteractEvent(stringBlockMechanic, block, event.getItem(), event.getPlayer(), event.getBlockFace(), event.getHand());
             OraxenPlugin.get().getServer().getPluginManager().callEvent(wireBlockInteractEvent);
             if (wireBlockInteractEvent.isCancelled()) {
                 event.setCancelled(true);


### PR DESCRIPTION
Interact event would be triggered twice because players have two hands. Added equipmentslot params for developers to get the hand