### PR TITLE
Add new glyph tab completion

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -75,13 +75,20 @@ public class OraxenPlugin extends JavaPlugin {
         reloadConfigs();
         if (Settings.KEEP_UP_TO_DATE.toBool())
             new SettingsUpdater().handleSettingsUpdate();
-        fontManager = new FontManager(configsManager);
-        hudManager = new HudManager(configsManager);
-        new CommandsManager().loadCommands();
         final PluginManager pluginManager = Bukkit.getPluginManager();
+        if (ProtocolLibrary.getPlugin().isEnabled()) {
+            protocolManager = ProtocolLibrary.getProtocolManager();
+            new BreakerSystem().registerListener();
+            if (Settings.FORMAT_INVENTORY_TITLES.toBool())
+                protocolManager.addPacketListener(new InventoryPacketListener());
+            protocolManager.addPacketListener(new TitlePacketListener());
+        } else Logs.logWarning("ProtocolLib is not on your server, some features will not work");
+        if (Settings.DISABLE_LEATHER_REPAIR_CUSTOM.toBool())
+            pluginManager.registerEvents(new CustomArmorListener(), this);
         resourcePack = new ResourcePack(this);
         MechanicsManager.registerNativeMechanics();
         //CustomBlockData.registerListener(this); //Handle this manually
+        hudManager = new HudManager(configsManager);
         fontManager = new FontManager(configsManager);
         soundManager = new SoundManager(configsManager.getSound());
         OraxenItems.loadItems(configsManager);
@@ -103,15 +110,6 @@ public class OraxenPlugin extends JavaPlugin {
         } catch (Exception ignore) {
         }
         CompatibilitiesManager.enableNativeCompatibilities();
-        if (ProtocolLibrary.getPlugin().isEnabled()) {
-            protocolManager = ProtocolLibrary.getProtocolManager();
-            new BreakerSystem().registerListener();
-            if (Settings.FORMAT_INVENTORY_TITLES.toBool())
-                protocolManager.addPacketListener(new InventoryPacketListener());
-            protocolManager.addPacketListener(new TitlePacketListener());
-        } else Logs.logWarning("ProtocolLib is not on your server, some features will not work");
-        if (Settings.DISABLE_LEATHER_REPAIR_CUSTOM.toBool())
-            pluginManager.registerEvents(new CustomArmorListener(), this);
     }
 
     private void postLoading(final ConfigsManager configsManager) {

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -176,9 +176,8 @@ public class FontManager {
                     .toList());
 
             protocolManager.sendServerPacket(player, packet);
-            return;
         }
-        for (Glyph glyph : getGlyphByPlaceholderMap().values()) {
+        else for (Glyph glyph : getGlyphByPlaceholderMap().values()) {
             if (glyph.hasTabCompletion()) {
                 PacketContainer packet = new PacketContainer(PacketType.Play.Server.PLAYER_INFO);
 

--- a/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -172,39 +172,37 @@ public class FontManager {
 
             packet.getModifier().write(1, getGlyphByPlaceholderMap().values().stream()
                     .filter(Glyph::hasTabCompletion)
-                    .flatMap(glyph -> Arrays.stream(glyph.getPlaceholders()))
+                    .map(glyph -> String.valueOf(glyph.getCharacter()))
                     .toList());
 
             protocolManager.sendServerPacket(player, packet);
             return;
         }
-        for (Map.Entry<String, Glyph> entry : getGlyphByPlaceholderMap().entrySet()) {
-            if (entry.getValue().hasTabCompletion()) {
-                for (String placeholder : entry.getValue().getPlaceholders()) {
-                    PacketContainer packet = new PacketContainer(PacketType.Play.Server.PLAYER_INFO);
+        for (Glyph glyph : getGlyphByPlaceholderMap().values()) {
+            if (glyph.hasTabCompletion()) {
+                PacketContainer packet = new PacketContainer(PacketType.Play.Server.PLAYER_INFO);
 
-                    packet.getPlayerInfoAction().write(0, (add) ? EnumWrappers.PlayerInfoAction.ADD_PLAYER : EnumWrappers.PlayerInfoAction.REMOVE_PLAYER);
+                packet.getPlayerInfoAction().write(0, (add) ? EnumWrappers.PlayerInfoAction.ADD_PLAYER : EnumWrappers.PlayerInfoAction.REMOVE_PLAYER);
 
-                    final WrappedGameProfile profile = new WrappedGameProfile(
-                            UUID.randomUUID(), placeholder);
+                final WrappedGameProfile profile = new WrappedGameProfile(
+                        UUID.randomUUID(), String.valueOf(glyph.getCharacter()));
 
-                    if (entry.getValue().getTabIconTexture() != null && entry.getValue().getTabIconSignature() != null)
-                        profile.getProperties().put("textures",
-                                new WrappedSignedProperty(
-                                        "textures",
-                                        entry.getValue().getTabIconTexture(),
-                                        entry.getValue().getTabIconSignature()));
+                if (glyph.getTabIconTexture() != null && glyph.getTabIconSignature() != null)
+                    profile.getProperties().put("textures",
+                            new WrappedSignedProperty(
+                                    "textures",
+                                    glyph.getTabIconTexture(),
+                                    glyph.getTabIconSignature()));
 
-                    PlayerInfoData data = new PlayerInfoData(profile,
-                            0, EnumWrappers.NativeGameMode.SPECTATOR,
-                            WrappedChatComponent.fromText(""));
+                PlayerInfoData data = new PlayerInfoData(profile,
+                        0, EnumWrappers.NativeGameMode.SPECTATOR,
+                        WrappedChatComponent.fromText(""));
 
-                    List<PlayerInfoData> dataList = new ArrayList<>();
-                    dataList.add(data);
-                    packet.getPlayerInfoDataLists().write(0, dataList);
+                List<PlayerInfoData> dataList = new ArrayList<>();
+                dataList.add(data);
+                packet.getPlayerInfoDataLists().write(0, dataList);
 
-                    protocolManager.sendServerPacket(player, packet);
-                }
+                protocolManager.sendServerPacket(player, packet);
             }
         }
     }


### PR DESCRIPTION
Adds new glyph tab completion system using 1.19.1 custom chat completion packet, should work on lower versions using old code.
Also fixes null protocolManager field in FontManager and removes double initialization of CommandManager and FontManager.

![obraz](https://user-images.githubusercontent.com/67753196/218492157-ccf2940d-1326-4a2e-a829-4e4864d15d4f.png)
