### PR TITLE
1.153.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,8 @@ repositories {
 dependencies {
     val actionsVersion = "1.0.0-SNAPSHOT"
 
-    compileOnly("org.spigotmc:spigot-api:1.19.3-R0.1-SNAPSHOT")
-    compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT") { exclude(group = "net.kyori") }
+    compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT") { exclude(group = "net.kyori") }
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.2")
     compileOnly("com.github.BeYkeRYkt:LightAPI:5.3.0-Bukkit")
@@ -60,13 +60,13 @@ dependencies {
     implementation("dev.triumphteam:triumph-gui:3.1.2")
     implementation("org.bstats:bstats-bukkit:3.0.0")
     implementation("com.github.oraxen:protectionlib:1.2.3")
-    implementation("net.kyori:adventure-text-minimessage:4.13.0-SNAPSHOT")
-    implementation("net.kyori:adventure-text-serializer-plain:4.13.0-SNAPSHOT")
-    implementation("net.kyori:adventure-text-serializer-legacy:4.13.0-SNAPSHOT")
-    implementation("net.kyori:adventure-text-serializer-gson:4.13.0-SNAPSHOT")
-    implementation("net.kyori:adventure-platform-bukkit:4.2.0")
+    implementation("net.kyori:adventure-text-minimessage:4.13.0")
+    implementation("net.kyori:adventure-text-serializer-plain:4.13.0")
+    implementation("net.kyori:adventure-text-serializer-legacy:4.13.0")
+    implementation("net.kyori:adventure-text-serializer-gson:4.13.0")
+    implementation("net.kyori:adventure-platform-bukkit:4.3.0")
     implementation("com.github.stefvanschie.inventoryframework:IF:0.10.8")
-    implementation("dev.jorel:commandapi-shade:8.7.6")
+    implementation("dev.jorel:commandapi-shade:8.8.0")
     implementation("com.jeff_media:CustomBlockData:2.2.0")
     implementation("com.jeff_media:MorePersistentDataTypes:2.3.1")
     implementation("gs.mclo:mclogs:2.1.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.153.0
+pluginVersion=1.153.1

--- a/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
+++ b/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
@@ -40,8 +40,13 @@ public class OraxenExpansion extends PlaceholderExpansion {
     @Override
     public String onRequest(final OfflinePlayer player, @NotNull final String params) {
         final Glyph glyph = plugin.getFontManager().getGlyphFromName(params);
-        if (glyph != null)
+        if (glyph != null) {
             return String.valueOf(glyph.getCharacter());
+        } else if (params.equals("pack_url")) {
+            return plugin.getUploadManager().getHostingProvider().getPackURL();
+        } else if (params.equals("pack_hash")) {
+            return plugin.getUploadManager().getHostingProvider().getOriginalSHA1();
+        }
         return null; // Placeholder is unknown by the Expansion
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.logs.Logs;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -149,9 +150,17 @@ public class Glyph {
 
     public void verifyGlyph(List<Glyph> glyphs) {
         // Return on first run as files aren't generated yet
-        if (!Path.of(OraxenPlugin.get().getDataFolder().getAbsolutePath()).resolve("/pack").toFile().exists()) return;
-        String namespace = getTexture().contains(":") ? "pack/assets/" + getTexture().split(":")[0] + "textures/" : "pack/textures";
-        final File texture = new File(OraxenPlugin.get().getDataFolder().getAbsolutePath() + namespace, getTexture());
+        Path packFolder = Path.of(OraxenPlugin.get().getDataFolder().getAbsolutePath()).resolve("pack");
+        if (!packFolder.toFile().exists()) return;
+
+        String texturePath = getTexture().contains(":") ? "assets/" + StringUtils.substringBefore(getTexture(), ":") + "/textures/" : "textures/";
+        texturePath = texturePath + (getTexture().contains(":") ? getTexture().split(":")[1] : getTexture());
+        final File texture;
+        // If using minecraft as a namespace, make sure it is in assets or root pack-dir
+        if (!StringUtils.substringBefore(getTexture(), ":").equals("minecraft") || packFolder.resolve(texturePath).toFile().exists())
+            texture = packFolder.resolve(texturePath).toFile();
+        else texture = packFolder.resolve(texturePath.replace("assets/minecraft/", "")).toFile();
+
         Map<Glyph, Boolean> sameCodeMap = glyphs.stream().filter(g -> g != this && g.getCode() == this.getCode()).collect(Collectors.toMap(g -> g, g -> true));
         // Check if the texture is a vanilla item texture and therefore not in oraxen, but the vanilla pack
         boolean isMinecraftNamespace = !getTexture().contains(":") || getTexture().split(":")[0].equals("minecraft");

--- a/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -60,11 +60,11 @@ public class ItemParser {
     }
 
     public boolean usesMMOItems() {
-        return type == null && crucibleItem == null;
+        return type == null && crucibleItem == null && mmoItem != null;
     }
 
     public boolean usesCrucibleItems() {
-        return type == null && mmoItem == null;
+        return type == null && mmoItem == null && crucibleItem != null;
     }
 
     private String parseComponentString(String miniString) {

--- a/src/main/java/io/th0rgal/oraxen/utils/CustomArmorsTextures.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/CustomArmorsTextures.java
@@ -148,6 +148,12 @@ public class CustomArmorsTextures {
             setPixel(image.getRaster(), 2, 0, Color.fromRGB(1, 0, 0));
         }
 
+        if(image.getColorModel().getPixelSize() < 32) {
+            int width = image.getWidth(), height = image.getHeight();
+            Image resizedImage = original.getScaledInstance(width, height, Image.SCALE_DEFAULT);
+            image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+            image.getGraphics().drawImage(resizedImage, 0, 0, null);
+        }
         addPixel(image, builder, name, prefix, isAnimated);
 
         return true;


### PR DESCRIPTION
```yml
- Preliminary 1.19.4 support
  * This will only make the plugin load, no new features or bugfixes are added yet
  * Recommend not updating to 1.19.4 until full Oraxen support is added
- Add %oraxen_pack_hash% and %oraxen_pack_url% placeholders
- Fix issue where HUD not parsing legacy formatting
- Fix issue with low bit-depth custom armor textures not working
- Fix issue with namespaces in glyph
- Fix issue with verification of glyphs
```