### PR TITLE
fix: duplicate file entries not reading on linux

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -278,7 +278,7 @@ public class DuplicationHandler {
             Logs.logWarning("Failed to migrate duplicate file-entry, failed to load items/migrated_duplicates.yml");
             return false;
         }
-        Path path = Path.of(OraxenPlugin.get().getDataFolder().getAbsolutePath(), "\\pack\\", name);
+        Path path = Path.of(OraxenPlugin.get().getDataFolder().getAbsolutePath(), "pack", name);
         String fileContent;
         try {
             fileContent = Files.readString(path);


### PR DESCRIPTION
This covers a bug which I was made aware of when working with Oraxen, where duplicated files could not be migrated on Linux-based systems (e.g.):
```
[17:46:20] [Server thread/INFO]: Oraxen | Successfully updated settings.yml
[17:46:21] [Server thread/INFO]: Oraxen | Generating atlas-file for 1.19.3 Resource Pack format
[17:46:21] [Server thread/INFO]: Oraxen | Duplicate file detected: assets/minecraft/models/item/leather_horse_armor.json - Attempting to migrate it
[17:46:21] [Server thread/INFO]: Oraxen | Found a duplicate leather_horse_armor.json, attempting to migrate it into Oraxen item configs
[17:46:21] [Server thread/INFO]: Oraxen | Failed to migrate duplicate file-entry, could not read file
```
With the main culprit being shared host services.

This PR removes the use of backslashes which causes this issue, and have confirmed it through my own server running the same software and OS:
```
[22:53:40 INFO]: Oraxen | Successfully updated settings.yml
[22:53:41 INFO]: Oraxen | Generating atlas-file for 1.19.3 Resource Pack format
[22:53:42 INFO]: Oraxen | Duplicate file detected: assets/minecraft/models/item/leather_horse_armor.json - Attempting to migrate it
[22:53:42 INFO]: Oraxen | Found a duplicate leather_horse_armor.json, attempting to migrate it into Oraxen item configs
[22:53:42 INFO]: Oraxen | Duplicate file fixed: assets/minecraft/models/item/leather_horse_armor.json
[22:53:42 INFO]: Oraxen | Deleted the imported leather_horse_armor.json and migrated it to its supported Oraxen config(s)
[22:53:42 INFO]: Oraxen | Might need to restart your server ones before the resourcepack works fully
```
One thing I did notice that brought my attention to this was that backslashes are still used on line 435 in the DuplicationHandler class - although doesn't have an impact because it still saves to the correctly named file in the end.