### PR TITLE
1.154.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     id("idea")
     id("eclipse")
     id("maven-publish")
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     id("xyz.jpenilla.run-paper") version "2.0.1"
-    id("net.minecrell.plugin-yml.bukkit") version "0.5.2" // Generates plugin.yml
+    id("net.minecrell.plugin-yml.bukkit") version "0.5.3" // Generates plugin.yml
 }
 
 val pluginVersion: String by project
@@ -161,12 +161,12 @@ val pluginPath = project.findProperty("oraxen_plugin_path")
 if (pluginPath != null) {
     tasks {
         register<Copy>("copyJar") {
+            this.doNotTrackState("Overwrites the plugin jar to allow for easier reloading")
+            dependsOn(shadowJar, jar)
             from(findByName("reobfJar") ?: findByName("shadowJar") ?: findByName("jar"))
             into(pluginPath)
             doLast {
-                println(pluginVersion)
                 println("Copied to plugin directory $pluginPath")
-                println(version)
             }
         }
         named<DefaultTask>("build") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     val actionsVersion = "1.0.0-SNAPSHOT"
 
     compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
-    compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT") { exclude(group = "net.kyori") }
+    compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT") { exclude("net.kyori") }
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.2")
     compileOnly("com.github.BeYkeRYkt:LightAPI:5.3.0-Bukkit")
@@ -56,6 +56,7 @@ dependencies {
     compileOnly("com.ticxo.modelengine:api:R3.1.5")
     compileOnly(fileTree(mapOf("dir" to "libs/compile", "include" to listOf("*.jar"))))
     compileOnly("dev.jorel:commandapi-shade:8.8.0")
+    compileOnly("org.joml:joml:1.10.5") // Because pre 1.19.4 api does not have this in the server-jar
 
     implementation("dev.triumphteam:triumph-gui:3.1.4")
     implementation("org.bstats:bstats-bukkit:3.0.0")
@@ -103,13 +104,12 @@ tasks {
         relocate("com.jeff_media.customblockdata", "io.th0rgal.oraxen.shaded.customblockdata")
         relocate("com.jeff_media.morepersistentdatatypes", "io.th0rgal.oraxen.shaded.morepersistentdatatypes")
         relocate("com.github.stefvanschie.inventoryframework", "io.th0rgal.oraxen.shaded.if")
-        //relocate("dev.jorel.commandapi", "io.th0rgal.oraxen.shaded.commandapi")
         relocate("me.gabytm.util.actions", "io.th0rgal.oraxen.shaded.actions")
         relocate("org.intellij.lang.annotations", "io.th0rgal.oraxen.shaded.intellij.annotations")
         relocate("org.jetbrains.annotations", "io.th0rgal.oraxen.shaded.jetbrains.annotations")
         relocate("com.udojava.evalex", "io.th0rgal.oraxen.shaded.evalex")
         relocate("com.ticxo.playeranimator", "io.th0rgal.oraxen.shaded.playeranimator")
-        relocate("com.github.aternosorg", "io.th0rgal.oraxen.shaded.aternosorg")
+        //relocate("org.joml", "io.th0rgal.oraxen.shaded.joml")
 
         //mapOf("dir" to "libs/compile", "include" to listOf("*.jar"))
         manifest {
@@ -142,7 +142,7 @@ bukkit {
     softDepend = listOf("LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "BossShopPro", "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared", "NBTAPI", "ModelEngine")
     depend = listOf("ProtocolLib")
     loadBefore = listOf("Realistic_World")
-    libraries = listOf("org.springframework:spring-expression:6.0.6", "org.apache.httpcomponents:httpmime:4.5.13", "dev.jorel:commandapi-shade:8.8.0")
+    libraries = listOf("org.springframework:spring-expression:6.0.6", "org.apache.httpcomponents:httpmime:4.5.13", "dev.jorel:commandapi-shade:8.8.0", "org.joml:joml:1.10.5")
     permissions.create("oraxen.command") {
         description = "Allows the player to use the /oraxen command"
         default = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission.Default.TRUE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.154.0
+pluginVersion=1.154.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.154.1
+pluginVersion=1.154.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.154.2
+pluginVersion=1.155.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -5,6 +5,7 @@ import com.comphenix.protocol.ProtocolManager;
 import com.ticxo.playeranimator.PlayerAnimatorImpl;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIConfig;
+import gs.mclo.java.Log;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
 import io.th0rgal.oraxen.commands.CommandsManager;
@@ -20,6 +21,8 @@ import io.th0rgal.oraxen.gestures.GestureManager;
 import io.th0rgal.oraxen.hud.HudManager;
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.pack.generation.ResourcePack;
 import io.th0rgal.oraxen.pack.upload.UploadManager;
 import io.th0rgal.oraxen.recipes.RecipesManager;
@@ -55,14 +58,16 @@ public class OraxenPlugin extends JavaPlugin {
     private ClickActionManager clickActionManager;
     private ProtocolManager protocolManager;
     public final boolean isPaperServer;
+    public boolean supportsDisplayEntities;
 
     public OraxenPlugin() throws NoSuchFieldException, IllegalAccessException {
         oraxen = this;
         isPaperServer = isPaperServer();
+        supportsDisplayEntities = false;
         Logs.enableFilter();
     }
 
-    private boolean isPaperServer() {
+    private static boolean isPaperServer() {
         try {
             Class.forName("com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent");
             return true;
@@ -71,9 +76,15 @@ public class OraxenPlugin extends JavaPlugin {
         }
     }
 
-    public boolean supportsDisplayEntities() {
+    public static boolean supportsDisplayEntities() {
         try {
             Class.forName("org.bukkit.entity.ItemDisplay");
+            if (Bukkit.getPluginManager().isPluginEnabled("ViaBackwards") && FurnitureFactory.getInstance().detectViabackwards) {
+                Logs.logWarning("ViaBackwards is installed, disabling Display Entity type for Furniture");
+                Logs.logWarning("Display Entity furniture is entirely invisible and uninteractable for players using 1.19.3 or lower");
+                Logs.logWarning("If you still want to use Display Entity type for Furniture, disable detect_viabackwards in the mechanics.yml");
+                return false;
+            }
             return true;
         } catch (ClassNotFoundException e) {
             return false;

--- a/src/main/java/io/th0rgal/oraxen/api/events/OraxenFurnitureInteractEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/api/events/OraxenFurnitureInteractEvent.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.api.events;
 
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;

--- a/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
+++ b/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
@@ -1,11 +1,12 @@
 package io.th0rgal.oraxen.commands;
 
 import dev.jorel.commandapi.CommandAPICommand;
-import gs.mclo.java.APIResponse;
-import gs.mclo.java.Log;
-import gs.mclo.java.MclogsAPI;
+import gs.mclo.api.Log;
+import gs.mclo.api.MclogsClient;
+import gs.mclo.api.response.UploadLogResponse;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.logs.Logs;
+import org.apache.http.protocol.RequestUserAgent;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedReader;
@@ -36,8 +37,8 @@ public class LogDumpCommand {
                     }
 
                     try {
-                        APIResponse post = MclogsAPI.share(new Log(logfile));
-                        Logs.logSuccess("Logfile has been dumped to: " + post.url);
+                        UploadLogResponse post = new MclogsClient(new RequestUserAgent().toString()).uploadLog(new Log(logfile));
+                        Logs.logSuccess("Logfile has been dumped to: " + post.getUrl());
                     } catch (IOException e) {
                         Logs.logWarning("Failed to upload logfile to mclo.gs, attempting to using pastebin");
                         try {

--- a/src/main/java/io/th0rgal/oraxen/config/RemovedSettings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/RemovedSettings.java
@@ -5,7 +5,8 @@ import java.util.List;
 
 public enum RemovedSettings {
     CONVERT_PACK_FOR_1_19_3("Plugin.experimental.convert_pack_for_1_19_3"),
-    INVULNERABLE_DURING_PACK_LOADING("Pack.dispatch.invulnerable_during_pack_loading")
+    INVULNERABLE_DURING_PACK_LOADING("Pack.dispatch.invulnerable_during_pack_loading"),
+    ATTEMPT_TO_MIGRATE_DUPLICATES("Pack.generation.attempt_to_migrate_duplicates"),
     ;
 
     private final String path;

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -24,6 +24,7 @@ public enum Settings {
     FORMAT_SIGNS("Plugin.formatting.signs"),
     FORMAT_CHAT("Plugin.formatting.chat"),
     FORMAT_BOOKS("Plugin.formatting.books"),
+    VERIFY_PACK_FILES("Plugin.experimental.verify_pack_files"),
 
     CONFIGS_VERSION("configs_version"),
     UPDATE_CONFIGS("ConfigsTools.enable_configs_updater"),

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -24,8 +24,6 @@ public enum Settings {
     FORMAT_SIGNS("Plugin.formatting.signs"),
     FORMAT_CHAT("Plugin.formatting.chat"),
     FORMAT_BOOKS("Plugin.formatting.books"),
-    MERGE_ITEM_MODELS("Plugin.experimental.merge_item_base_models"),
-    MERGE_FONTS("Plugin.experimental.merge_font_files"),
 
     CONFIGS_VERSION("configs_version"),
     UPDATE_CONFIGS("ConfigsTools.enable_configs_updater"),
@@ -47,7 +45,6 @@ public enum Settings {
     HIDE_SCOREBOARD_NUMBERS("Misc.hide_scoreboard_numbers"),
 
     GENERATE("Pack.generation.generate"),
-    ATTEMPT_TO_MIGRATE_DUPLICATES("Pack.generation.attempt_to_migrate_duplicates"),
     EXCLUDED_FILE_EXTENSIONS("Pack.generation.excluded_file_extensions"),
     GENERATE_ATLAS_FILE("Pack.generation.generate_atlas_file"),
     GENERATE_MODEL_BASED_ON_TEXTURE_PATH("Pack.generation.auto_generated_models_follow_texture_path"),
@@ -59,6 +56,10 @@ public enum Settings {
     COMPRESSION("Pack.generation.compression"),
     PROTECTION("Pack.generation.protection"),
     COMMENT("Pack.generation.comment"),
+    MERGE_DUPLICATES("Pack.import.merge_duplicates"),
+    RETAIN_CUSTOM_MODEL_DATA("Pack.import.retain_custom_model_data"),
+    MERGE_ITEM_MODELS("Pack.import.merge_item_base_models"),
+    MERGE_FONTS("Pack.import.merge_font_files"),
 
     UPLOAD_TYPE("Pack.upload.type"),
     UPLOAD("Pack.upload.enabled"),

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -47,6 +47,7 @@ public enum Settings {
     GENERATE("Pack.generation.generate"),
     EXCLUDED_FILE_EXTENSIONS("Pack.generation.excluded_file_extensions"),
     GENERATE_ATLAS_FILE("Pack.generation.generate_atlas_file"),
+    ATLAS_GENERATION_TYPE("Pack.generation.atlas_generation_type"),
     GENERATE_MODEL_BASED_ON_TEXTURE_PATH("Pack.generation.auto_generated_models_follow_texture_path"),
     ARMOR_RESOLUTION("Pack.generation.armor_resolution"),
     ANIMATED_ARMOR_FRAMERATE("Pack.generation.animated_armor_framerate"),

--- a/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 public enum UpdatedSettings {
     GUI_INVENTORY("gui_inventory", "oraxen_inventory.menu_layout"),
+    MERGE_ITEM_MODELS("Plugin.experimental.merge_item_base_models", "Pack.import.merge_item_base_models"),
+    MERGE_FONTS("Plugin.experimental.merge_font_files", "Pack.import.merge_font_files"),
     ;
 
     private final String path;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/DisplayEntityProperties.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/DisplayEntityProperties.java
@@ -1,11 +1,10 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture;
 
-import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.logs.Logs;
-import org.bukkit.Color;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.ItemDisplay;
+import org.joml.Vector3f;
 
 import java.util.Arrays;
 
@@ -21,8 +20,8 @@ public class DisplayEntityProperties {
     private Integer interpolationDelay;
     private final float width;
     private final float height;
+    private final Vector3f scale;
     private final boolean isInteractable;
-
 
     public DisplayEntityProperties(ConfigurationSection configSection) {
         String itemID = configSection.getParent().getParent().getParent().getName();
@@ -35,6 +34,11 @@ public class DisplayEntityProperties {
         shadowRadius = (float) configSection.getDouble("shadow_radius");
         width = (float) configSection.getDouble("width", 1.0);
         height = (float) configSection.getDouble("height", 1.0);
+        if (configSection.isConfigurationSection("scale"))
+            scale = new Vector3f((float) configSection.getDouble("scale.x", 1.0),
+                    (float) configSection.getDouble("scale.y", 1.0),
+                    (float) configSection.getDouble("scale.z", 1.0));
+        else scale = null;
 
         if (viewRange == 0) viewRange = null;
         if (interpolationDuration == 0) interpolationDuration = null;
@@ -69,22 +73,83 @@ public class DisplayEntityProperties {
 
     //public boolean hasGlowColor() { return glowColor != null; }
     //public Color getGlowColor() { return glowColor; }
-    public boolean hasSpecifiedViewRange() { return viewRange != null; }
-    public int getViewRange() { return viewRange; }
-    public boolean hasInterpolationDuration() { return interpolationDuration != null; }
-    public int getInterpolationDuration() { return interpolationDuration; }
-    public boolean hasInterpolationDelay() { return interpolationDelay != null; }
-    public int getInterpolationDelay() { return interpolationDelay; }
-    public boolean hasBrightness() { return brightness != null; }
-    public Display.Brightness getBrightness() { return brightness; }
-    public ItemDisplay.ItemDisplayTransform getDisplayTransform() { return displayTransform; }
-    public boolean hasTrackingRotation() { return trackingRotation != null; }
-    public Display.Billboard getTrackingRotation() { return trackingRotation; }
-    public boolean hasShadowStrength() { return shadowStrength != null; }
-    public float getShadowStrength() { return shadowStrength; }
-    public boolean hasShadowRadius() { return shadowRadius != null; }
-    public float getShadowRadius() { return shadowRadius; }
-    public float getWidth() { return width; }
-    public float getHeight() { return height; }
-    public boolean isInteractable() { return isInteractable; }
+    public boolean hasSpecifiedViewRange() {
+        return viewRange != null;
+    }
+
+    public int getViewRange() {
+        return viewRange;
+    }
+
+    public boolean hasInterpolationDuration() {
+        return interpolationDuration != null;
+    }
+
+    public int getInterpolationDuration() {
+        return interpolationDuration;
+    }
+
+    public boolean hasInterpolationDelay() {
+        return interpolationDelay != null;
+    }
+
+    public int getInterpolationDelay() {
+        return interpolationDelay;
+    }
+
+    public boolean hasBrightness() {
+        return brightness != null;
+    }
+
+    public Display.Brightness getBrightness() {
+        return brightness;
+    }
+
+    public ItemDisplay.ItemDisplayTransform getDisplayTransform() {
+        return displayTransform;
+    }
+
+    public boolean hasTrackingRotation() {
+        return trackingRotation != null;
+    }
+
+    public Display.Billboard getTrackingRotation() {
+        return trackingRotation;
+    }
+
+    public boolean hasShadowStrength() {
+        return shadowStrength != null;
+    }
+
+    public float getShadowStrength() {
+        return shadowStrength;
+    }
+
+    public boolean hasShadowRadius() {
+        return shadowRadius != null;
+    }
+
+    public float getShadowRadius() {
+        return shadowRadius;
+    }
+
+    public float getWidth() {
+        return width;
+    }
+
+    public float getHeight() {
+        return height;
+    }
+
+    public boolean hasScale() {
+        return scale != null;
+    }
+
+    public Vector3f getScale() {
+        return scale;
+    }
+
+    public boolean isInteractable() {
+        return isInteractable;
+    }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture;
 
+import io.lumine.mythic.bukkit.utils.lib.jooq.impl.QOM;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
@@ -19,6 +20,7 @@ public class FurnitureFactory extends MechanicFactory {
     private boolean evolvingFurnitures;
     private static EvolutionTask evolutionTask;
     public final boolean customSounds;
+    public final boolean detectViabackwards;
 
     public FurnitureFactory(ConfigurationSection section) {
         super(section);
@@ -34,6 +36,8 @@ public class FurnitureFactory extends MechanicFactory {
         customSounds = OraxenPlugin.get().getConfigsManager().getMechanics().getConfigurationSection("custom_block_sounds").getBoolean("stringblock_and_furniture", true);
 
         if (customSounds) MechanicsManager.registerListeners(OraxenPlugin.get(), new FurnitureSoundListener());
+        detectViabackwards = OraxenPlugin.get().getConfigsManager().getMechanics().getConfigurationSection("furniture").getBoolean("detect_viabackwards", true);
+        OraxenPlugin.get().supportsDisplayEntities = OraxenPlugin.supportsDisplayEntities();
     }
 
     @Override

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -307,12 +307,11 @@ public class FurnitureListener implements Listener {
         Entity baseEntity = event.getRightClicked();
         final Player player = event.getPlayer();
 
-        event.setCancelled(true);
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(baseEntity);
         if (mechanic == null) return;
         // Swap baseEntity to the baseEntity if interacted with entity is Interaction type
-        Interaction interaction = null;
-        if (baseEntity instanceof Interaction interactionEntity) {
+        Entity interaction = null;
+        if (OraxenPlugin.get().supportsDisplayEntities() && baseEntity instanceof Interaction interactionEntity) {
             interaction = interactionEntity;
             baseEntity = mechanic.getBaseEntity(interaction);
         }
@@ -320,23 +319,15 @@ public class FurnitureListener implements Listener {
         OraxenPlugin.get().getServer().getPluginManager().callEvent(furnitureInteractEvent);
         if (furnitureInteractEvent.isCancelled()) return;
 
-        if (mechanic.hasClickActions()) {
-            mechanic.runClickActions(player);
-            event.setCancelled(true);
-        }
+        mechanic.runClickActions(player);
 
         if (mechanic.isStorage()) {
             StorageMechanic storage = mechanic.getStorage();
             switch (storage.getStorageType()) {
-                case STORAGE:
-                case SHULKER:
-                    storage.openStorage(baseEntity, player);
-                case PERSONAL:
-                    storage.openPersonalStorage(player, baseEntity.getLocation(), baseEntity);
-                case DISPOSAL:
-                    storage.openDisposal(player, baseEntity.getLocation(), baseEntity);
-                case ENDERCHEST:
-                    player.openInventory(player.getEnderChest());
+                case STORAGE: case SHULKER: storage.openStorage(baseEntity, player);
+                case PERSONAL: storage.openPersonalStorage(player, baseEntity.getLocation(), baseEntity);
+                case DISPOSAL: storage.openDisposal(player, baseEntity.getLocation(), baseEntity);
+                case ENDERCHEST: player.openInventory(player.getEnderChest());
             }
             event.setCancelled(true);
         }
@@ -369,40 +360,24 @@ public class FurnitureListener implements Listener {
         if (block == null || block.getType() != Material.BARRIER || player.isSneaking()) return;
 
         final FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(block);
-
-        Utils.swingHand(player, event.getHand());
-
         if (mechanic == null) return;
 
         final Entity baseEntity = mechanic.getBaseEntity(block);
 
         final OraxenFurnitureInteractEvent furnitureInteractEvent = new OraxenFurnitureInteractEvent(mechanic, player, block, baseEntity);
         Bukkit.getPluginManager().callEvent(furnitureInteractEvent);
+        if (furnitureInteractEvent.isCancelled()) return;
 
-        if (furnitureInteractEvent.isCancelled()) {
-            event.setCancelled(true);
-            return;
-        }
-
-        if (mechanic.hasClickActions()) {
-            mechanic.runClickActions(player);
-            event.setCancelled(true);
-        }
+        mechanic.runClickActions(player);
 
         if (mechanic.isStorage()) {
             StorageMechanic storage = mechanic.getStorage();
             switch (storage.getStorageType()) {
-                case STORAGE:
-                case SHULKER:
-                    storage.openStorage(baseEntity, player);
-                case PERSONAL:
-                    storage.openPersonalStorage(player, baseEntity.getLocation(), baseEntity);
-                case DISPOSAL:
-                    storage.openDisposal(player, baseEntity.getLocation(), baseEntity);
-                case ENDERCHEST:
-                    player.openInventory(player.getEnderChest());
+                case STORAGE: case SHULKER: storage.openStorage(baseEntity, player);
+                case PERSONAL: storage.openPersonalStorage(player, baseEntity.getLocation(), baseEntity);
+                case DISPOSAL: storage.openDisposal(player, baseEntity.getLocation(), baseEntity);
+                case ENDERCHEST: player.openInventory(player.getEnderChest());
             }
-            event.setCancelled(true);
         }
 
         if (mechanic.hasSeat()) {
@@ -420,7 +395,6 @@ public class FurnitureListener implements Listener {
 
             if (stand != null && stand.getPassengers().isEmpty()) {
                 stand.addPassenger(event.getPlayer());
-                event.setCancelled(true);
             }
         }
     }
@@ -435,12 +409,12 @@ public class FurnitureListener implements Listener {
             if (rayTraceResult == null) return;
             final Block block = rayTraceResult.getHitBlock();
             if (block == null) return;
-            FurnitureMechanic furnitureMechanic = OraxenFurniture.getFurnitureMechanic(block);
-            if (furnitureMechanic == null) return;
+            FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(block);
+            if (mechanic == null) return;
 
-            ItemStack item = OraxenItems.getItemById(furnitureMechanic.getItemID()).build();
+            ItemStack item = OraxenItems.getItemById(mechanic.getItemID()).build();
             for (int i = 0; i <= 8; i++) {
-                if (Objects.equals(OraxenItems.getIdByItem(player.getInventory().getItem(i)), furnitureMechanic.getItemID())) {
+                if (Objects.equals(OraxenItems.getIdByItem(player.getInventory().getItem(i)), mechanic.getItemID())) {
                     player.getInventory().setHeldItemSlot(i);
                     event.setCancelled(true);
                     return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -90,7 +90,7 @@ public class FurnitureListener implements Listener {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(block);
         if (mechanic == null) return;
 
-        OraxenFurnitureInteractEvent oraxenEvent = new OraxenFurnitureInteractEvent(mechanic, event.getPlayer(), block, mechanic.getBaseEntity(block));
+        OraxenFurnitureInteractEvent oraxenEvent = new OraxenFurnitureInteractEvent(mechanic, event.getPlayer(), block, mechanic.getItemFrame(block));
         Bukkit.getPluginManager().callEvent(oraxenEvent);
         if (oraxenEvent.isCancelled()) event.setCancelled(true);
     }
@@ -251,7 +251,7 @@ public class FurnitureListener implements Listener {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(block);
         if (mechanic == null) return;
 
-        OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, event.getPlayer(), block, mechanic.getBaseEntity(block));
+        OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, event.getPlayer(), block, mechanic.getItemFrame(block));
         OraxenPlugin.get().getServer().getPluginManager().callEvent(furnitureBreakEvent);
         if (furnitureBreakEvent.isCancelled()) {
             event.setCancelled(true);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -311,7 +311,7 @@ public class FurnitureListener implements Listener {
         if (mechanic == null) return;
         // Swap baseEntity to the baseEntity if interacted with entity is Interaction type
         Entity interaction = null;
-        if (OraxenPlugin.get().supportsDisplayEntities() && baseEntity instanceof Interaction interactionEntity) {
+        if (OraxenPlugin.get().supportsDisplayEntities && baseEntity instanceof Interaction interactionEntity) {
             interaction = interactionEntity;
             baseEntity = mechanic.getBaseEntity(interaction);
         }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -16,6 +16,7 @@ import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
 import io.th0rgal.oraxen.utils.limitedplacing.LimitedPlacing;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.oraxen.utils.storage.StorageMechanic;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
@@ -401,6 +402,7 @@ public class FurnitureListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onMiddleClick(final InventoryCreativeEvent event) {
+        Logs.debug("hit");
         if (event.getClick() != ClickType.CREATIVE) return;
         final Player player = (Player) event.getInventory().getHolder();
         if (player == null) return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -402,7 +402,6 @@ public class FurnitureListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onMiddleClick(final InventoryCreativeEvent event) {
-        Logs.debug("hit");
         if (event.getClick() != ClickType.CREATIVE) return;
         final Player player = (Player) event.getInventory().getHolder();
         if (player == null) return;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -395,6 +395,7 @@ public class FurnitureMechanic extends Mechanic {
             interaction.setInteractionWidth(width);
             interaction.setInteractionHeight(height);
             interaction.setResponsive(responsive);
+            Logs.logWarning(String.valueOf(responsive));
             interaction.getPersistentDataContainer().set(FURNITURE_KEY, DataType.STRING, getItemID());
             interaction.getPersistentDataContainer().set(ROOT_KEY, DataType.LOCATION, location);
         });

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -395,7 +395,6 @@ public class FurnitureMechanic extends Mechanic {
             interaction.setInteractionWidth(width);
             interaction.setInteractionHeight(height);
             interaction.setResponsive(responsive);
-            Logs.logWarning(String.valueOf(responsive));
             interaction.getPersistentDataContainer().set(FURNITURE_KEY, DataType.STRING, getItemID());
             interaction.getPersistentDataContainer().set(ROOT_KEY, DataType.LOCATION, location);
         });

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -33,8 +33,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Transformation;
-import org.joml.Quaternionf;
-import org.joml.Quaternionfc;
 import org.joml.Vector3f;
 
 import java.util.*;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -32,6 +32,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.Transformation;
+import org.joml.Quaternionf;
+import org.joml.Quaternionfc;
+import org.joml.Vector3f;
 
 import java.util.*;
 
@@ -425,7 +429,16 @@ public class FurnitureMechanic extends Mechanic {
         itemDisplay.setDisplayWidth(properties.getWidth());
         itemDisplay.setDisplayHeight(properties.getHeight());
         itemDisplay.setItemStack(item);
-        itemDisplay.setRotation(rotationToYaw(rotation), 0f);
+
+        // Set scale to .5 if FIXED aka ItemFrame to fix size. Also flip it 90 degrees on pitch
+        boolean isFixed = properties.getDisplayTransform().equals(ItemDisplay.ItemDisplayTransform.FIXED);
+        Transformation transform = itemDisplay.getTransformation();
+        if (properties.hasScale()) {
+            transform.getScale().set(properties.getScale());
+        } else if (isFixed) transform.getScale().set(new Vector3f(0.5f, 0.5f, 0.5f));
+
+        itemDisplay.setTransformation(transform);
+        itemDisplay.setRotation(rotationToYaw(rotation.rotateClockwise().rotateClockwise().rotateClockwise().rotateClockwise()), isFixed ? 90f : 0f);
     }
 
     private void setFrameData(ItemFrame frame, ItemStack item, BlockFace facing, Rotation rotation) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -84,7 +84,7 @@ public class FurnitureMechanic extends Mechanic {
 
         try {
             furnitureType = FurnitureType.valueOf(section.getString("type", FurnitureType.ITEM_FRAME.name()));
-            if (furnitureType == FurnitureType.DISPLAY_ENTITY && !OraxenPlugin.get().supportsDisplayEntities()) {
+            if (furnitureType == FurnitureType.DISPLAY_ENTITY && !OraxenPlugin.get().supportsDisplayEntities) {
                 Logs.logError("Use of Display Entity on unsupported server version.");
                 Logs.logError("This EntityType is only supported on 1.19.4 and above.");
                 Logs.logError("Setting type to ITEM_FRAME for <i>" + getItemID() + "</i>.");
@@ -97,7 +97,7 @@ public class FurnitureMechanic extends Mechanic {
             furnitureType = FurnitureType.ITEM_FRAME;
         }
         ConfigurationSection displayEntitySection = section.getConfigurationSection("display_entity_properties");
-        displayEntityProperties = OraxenPlugin.get().supportsDisplayEntities() && displayEntitySection != null
+        displayEntityProperties = OraxenPlugin.get().supportsDisplayEntities && displayEntitySection != null
                 ? new DisplayEntityProperties(displayEntitySection)
                 : null;
 
@@ -388,7 +388,7 @@ public class FurnitureMechanic extends Mechanic {
     }
 
     private Interaction spawnInteractionEntity(Entity entity, Location location, float width, float height, boolean responsive) {
-        if (!OraxenPlugin.get().supportsDisplayEntities()) return null;
+        if (!OraxenPlugin.get().supportsDisplayEntities) return null;
         return entity.getWorld().spawn(BlockHelpers.toCenterBlockLocation(location), Interaction.class, (Interaction interaction) -> {
             interaction.setInteractionWidth(width);
             interaction.setInteractionHeight(height);
@@ -624,7 +624,7 @@ public class FurnitureMechanic extends Mechanic {
             }
         }
 
-        if (OraxenPlugin.get().supportsDisplayEntities()) {
+        if (OraxenPlugin.get().supportsDisplayEntities) {
             for (Entity entity : baseEntity.getNearbyEntities(0.1, 0.1, 0.1)) {
                 if (!(entity instanceof Interaction interaction)) continue;
                 PersistentDataContainer pdc = interaction.getPersistentDataContainer();
@@ -751,7 +751,7 @@ public class FurnitureMechanic extends Mechanic {
     }
 
     public Interaction getInteractionEntity(Entity baseEntity) {
-        if (OraxenPlugin.get().supportsDisplayEntities()) {
+        if (OraxenPlugin.get().supportsDisplayEntities) {
             for (Entity entity : baseEntity.getNearbyEntities(0.1, 0.1, 0.1)) {
                 if (!(entity instanceof Interaction interaction)) continue;
                 PersistentDataContainer pdc = interaction.getPersistentDataContainer();

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
@@ -24,6 +24,7 @@ import org.bukkit.event.world.GenericGameEvent;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
@@ -31,7 +32,7 @@ import static io.th0rgal.oraxen.utils.blocksounds.BlockSounds.*;
 
 public class FurnitureSoundListener implements Listener {
 
-    private final Map<Block, BukkitTask> breakerPlaySound = new HashMap<>();
+    private final Map<Location, BukkitTask> breakerPlaySound = new HashMap<>();
 
     // Play sound due to furniture/barrier custom sound replacing stone
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -47,38 +48,40 @@ public class FurnitureSoundListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onBreakingStone(final BlockBreakEvent event) {
         Block block = event.getBlock();
+        Location location = block.getLocation();
 
         if (block.getType() == Material.TRIPWIRE) return;
         if (block.getBlockData().getSoundGroup().getBreakSound() != Sound.BLOCK_STONE_BREAK) return;
-        if (breakerPlaySound.containsKey(block)) {
-            breakerPlaySound.get(block).cancel();
-            breakerPlaySound.remove(block);
+        if (breakerPlaySound.containsKey(location)) {
+            breakerPlaySound.get(location).cancel();
+            breakerPlaySound.remove(location);
         }
 
-        if (!event.isCancelled() && ProtectionLib.canBreak(event.getPlayer(), block.getLocation()))
-            BlockHelpers.playCustomBlockSound(event.getBlock().getLocation(), VANILLA_STONE_BREAK, VANILLA_BREAK_VOLUME, VANILLA_BREAK_PITCH);
+        if (!event.isCancelled() && ProtectionLib.canBreak(event.getPlayer(), location))
+            BlockHelpers.playCustomBlockSound(location, VANILLA_STONE_BREAK, VANILLA_BREAK_VOLUME, VANILLA_BREAK_PITCH);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onHitStone(final BlockDamageEvent event) {
         Block block = event.getBlock();
+        Location location = block.getLocation();
         SoundGroup soundGroup = block.getBlockData().getSoundGroup();
 
         if (event.getInstaBreak()) return;
         if (block.getType() == Material.BARRIER || soundGroup.getHitSound() != Sound.BLOCK_STONE_HIT) return;
-        if (breakerPlaySound.containsKey(block)) return;
+        if (breakerPlaySound.containsKey(location)) return;
 
         BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
-                BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_STONE_HIT, VANILLA_HIT_VOLUME, VANILLA_HIT_PITCH), 2L, 4L);
-        breakerPlaySound.put(block, task);
+                BlockHelpers.playCustomBlockSound(location, VANILLA_STONE_HIT, VANILLA_HIT_VOLUME, VANILLA_HIT_PITCH), 2L, 4L);
+        breakerPlaySound.put(location, task);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStopHittingStone(final BlockDamageAbortEvent event) {
-        Block block = event.getBlock();
-        if (breakerPlaySound.containsKey(block)) {
-            breakerPlaySound.get(block).cancel();
-            breakerPlaySound.remove(block);
+        Location location = event.getBlock().getLocation();
+        if (breakerPlaySound.containsKey(location)) {
+            breakerPlaySound.get(location).cancel();
+            breakerPlaySound.remove(location);
         }
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -56,7 +56,7 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
     }
 
     public static String getInstrumentName(int id) {
-        return switch (id / 25 % 384) {
+        return switch ((id % 400) / 25) {
             case 1 -> "basedrum";
             case 2 -> "snare";
             case 3 -> "hat";
@@ -187,7 +187,7 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
          */
         id += 26;
         NoteBlock noteBlock = (NoteBlock) Bukkit.createBlockData(Material.NOTE_BLOCK);
-        noteBlock.setInstrument(Instrument.getByType((byte) (id / 25 % 400)));
+        noteBlock.setInstrument(Instrument.getByType((byte) ((id % 400) / 25)));
         noteBlock.setNote(new Note(id % 25));
         noteBlock.setPowered(id >= 400);
         return noteBlock;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -80,12 +80,13 @@ public class StringBlockMechanicListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void tripwireEvent(BlockPhysicsEvent event) {
-        if (event.getChangedType() == Material.TRIPWIRE)
-            event.setCancelled(true);
+        Block block = event.getBlock();
+        if (event.getChangedType() != Material.TRIPWIRE) return;
+        event.setCancelled(true);
 
         for (BlockFace f : BlockFace.values()) {
             if (!f.isCartesian() || f.getModY() != 0 || f == BlockFace.SELF) continue; // Only take N/S/W/E
-            final Block changed = event.getBlock().getRelative(f);
+            final Block changed = block.getRelative(f);
             if (changed.getType() != Material.TRIPWIRE) continue;
 
             final BlockData data = changed.getBlockData().clone();
@@ -108,7 +109,7 @@ public class StringBlockMechanicListener implements Listener {
         if (placedBlock.getType() != Material.TRIPWIRE || OraxenItems.exists(event.getItemInHand()))
             return;
         // Placing string, meant for the first blockstate as invisible string
-        placedBlock.setBlockData(Bukkit.createBlockData(Material.TRIPWIRE), false);
+        placedBlock.setBlockData(Bukkit.createBlockData(Material.TRIPWIRE), true);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -161,6 +162,8 @@ public class StringBlockMechanicListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPrePlacingCustomBlock(final PlayerInteractEvent event) {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (event.getHand() != EquipmentSlot.HAND) return;
+
         final ItemStack item = event.getItem();
         final String itemID = OraxenItems.getIdByItem(item);
         final Block placedAgainst = event.getClickedBlock();
@@ -177,10 +180,8 @@ public class StringBlockMechanicListener implements Listener {
             for (BlockFace face : BlockFace.values()) {
                 if (!face.isCartesian() || face.getModZ() != 0) continue;
                 final Block relative = placedAgainst.getRelative(face);
-                if (relative.getType() == Material.NOTE_BLOCK)
-                    if (OraxenBlocks.getNoteBlockMechanic(relative) == null) continue;
-                if (relative.getType() == Material.TRIPWIRE)
-                    if (OraxenBlocks.getStringMechanic(relative) == null) continue;
+                if (OraxenBlocks.getNoteBlockMechanic(relative) == null) continue;
+                if (OraxenBlocks.getStringMechanic(relative) == null) continue;
                 if (item.getItemMeta() instanceof BlockStateMeta) continue;
                 if (item.getType().hasGravity()) continue;
                 if (item.getType().toString().endsWith("SLAB")) continue;
@@ -238,15 +239,12 @@ public class StringBlockMechanicListener implements Listener {
             }
 
             event.setCancelled(true);
-            if (clicked == null)
-                return;
+            if (clicked == null || clicked.getType().isInteractable()) return;
+
             Material type = clicked.getType();
-            if (clicked.getType().isInteractable())
-                return;
-            if (type == Material.LAVA_BUCKET)
-                type = Material.LAVA;
-            if (type == Material.WATER_BUCKET)
-                type = Material.WATER;
+            if (type == Material.LAVA_BUCKET) type = Material.LAVA;
+            else if (type == Material.WATER_BUCKET) type = Material.WATER;
+
             if (type.isBlock())
                 makePlayerPlaceBlock(event.getPlayer(), event.getHand(), event.getItem(), block, event.getBlockFace(), Bukkit.createBlockData(type));
         }
@@ -267,7 +265,7 @@ public class StringBlockMechanicListener implements Listener {
                     for (ItemStack item : block.getDrops())
                         if (item.getType() != Material.AIR)
                             player.getWorld().dropItemNaturally(block.getLocation(), item);
-                block.setType(Material.AIR, false);
+                block.setType(Material.AIR, true);
                 if (BlockHelpers.REPLACEABLE_BLOCKS.contains(blockAbove.getType())) blockAbove.breakNaturally();
                 Bukkit.getScheduler().runTaskLater(OraxenPlugin.get(), Runnable ->
                         fixClientsideUpdate(block.getLocation()), 1);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/music_disc/MusicDiscListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/music_disc/MusicDiscListener.java
@@ -49,7 +49,7 @@ public class MusicDiscListener implements Listener {
         if (!playing) return;
         player.swingMainHand();
         Component message = AdventureUtils.MINI_MESSAGE.deserialize(Message.MECHANICS_JUKEBOX_NOW_PLAYING.toString(),
-                TagResolver.builder().resolvers(AdventureUtils.OraxenTagResolver, AdventureUtils.tagResolver("disc", itemStack.getItemMeta().getDisplayName())).build());
+                TagResolver.builder().resolvers(AdventureUtils.OraxenTagResolver, AdventureUtils.tagResolver("disc", AdventureUtils.parseLegacy(itemStack.getItemMeta().getDisplayName()))).build());
         OraxenPlugin.get().getAudience().player(player).sendActionBar(message);
         event.setCancelled(true);
     }

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.VirtualFile;
 import io.th0rgal.oraxen.utils.logs.Logs;
@@ -52,10 +53,23 @@ public class AtlasGenerator {
 
             JsonObject atlasEntry = new JsonObject();
             String namespace = virtual.getPath().replaceFirst("assets/", "").split("/")[0];
-            String sprite = namespace + ":" + path;
-            atlasEntry.addProperty("type", "single");
-            atlasEntry.addProperty("resource", sprite);
-            atlasEntry.addProperty("sprite", sprite);
+            if (Settings.ATLAS_GENERATION_TYPE.toString().equals("DIRECTORY")) {
+                if (path.endsWith(".png")) {
+                    String sprite = Utils.removeParentDirs(Utils.removeExtension(virtual.getPath()));
+                    atlasEntry.addProperty("type", "single");
+                    atlasEntry.addProperty("resource", namespace + ":" + Utils.removeExtension(path));
+                    atlasEntry.addProperty("sprite", namespace + ":" + sprite);
+                } else {
+                    atlasEntry.addProperty("type", "directory");
+                    atlasEntry.addProperty("source", path);
+                    atlasEntry.addProperty("prefix", path + "/");
+                }
+            } else {
+                String sprite = namespace + ":" + path;
+                atlasEntry.addProperty("type", "single");
+                atlasEntry.addProperty("resource", sprite);
+                atlasEntry.addProperty("sprite", sprite);
+            }
 
             if (!atlasContent.contains(atlasEntry))
                 atlasContent.add(atlasEntry);

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -278,7 +278,7 @@ public class DuplicationHandler {
             Logs.logWarning("Failed to migrate duplicate file-entry, failed to load items/migrated_duplicates.yml");
             return false;
         }
-        Path path = Path.of(OraxenPlugin.get().getDataFolder().getAbsolutePath(), "\\pack\\", name);
+        Path path = Path.of(OraxenPlugin.get().getDataFolder().getAbsolutePath(), "pack", name);
         String fileContent;
         try {
             fileContent = Files.readString(path);

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -212,12 +212,12 @@ public class DuplicationHandler {
             out.putNextEntry(entry);
         } catch (IOException e) {
             Logs.logWarning("Duplicate file detected: <blue>" + name + "</blue> - Attempting to migrate it");
-            if (!Settings.ATTEMPT_TO_MIGRATE_DUPLICATES.toBool()) {
-                Logs.logError("Not attempting to migrate duplicate file as <#22b14c>attempt_to_migrate_duplicates</#22b14c> is disabled in settings.yml");
+            if (!Settings.MERGE_DUPLICATES.toBool()) {
+                Logs.logError("Not attempting to migrate duplicate file as <#22b14c>" + Settings.MERGE_DUPLICATES.getPath() + "</#22b14c> is disabled in settings.yml");
             } else if (attemptToMigrateDuplicate(name)) {
                 Logs.logSuccess("Duplicate file fixed:<blue> " + name);
                 try {
-                    OraxenPlugin.get().getDataFolder().toPath().resolve("pack/" + name).toFile().delete();
+                    OraxenPlugin.get().getDataFolder().toPath().resolve("pack").resolve(name).toFile().delete();
                     Logs.logSuccess("Deleted the imported <blue>" + Utils.removeParentDirs(name) + "</blue> and migrated it to its supported Oraxen config(s)");
                 } catch (Exception ignored) {
                     Log.error("Failed to delete the imported <blue>" + Utils.removeParentDirs(name) + "</blue> after migrating it");
@@ -229,12 +229,10 @@ public class DuplicationHandler {
     }
 
     private static boolean attemptToMigrateDuplicate(String name) {
-        if (name.startsWith("assets/minecraft/models/item/")) {
+        if (name.matches("assets/minecraft/models/item/.*.json")) {
             Logs.logWarning("Found a duplicate <blue>" + Utils.removeParentDirs(name) + "</blue>, attempting to migrate it into Oraxen item configs");
             return migrateItemJson(name);
         } else if (name.matches("assets/.*/font/.*.json")) {
-            //Logs.logWarning("Found a duplicated font file, trying to migrate it into Oraxens glyph configs");
-            //return migrateDefaultFontJson(name);
             Logs.logWarning("Found a duplicated font file, trying to migrate it into Oraxens generated copy");
             return mergeDuplicateFontJson(name);
         } else if (name.matches("assets/.*/sounds.json")) {
@@ -260,8 +258,11 @@ public class DuplicationHandler {
         }
     }
 
+    //TODO
+    // Fix importing other aspects of parent-model like shields display
+    // It should use the imported as a base and merge the overrides only
     private static boolean migrateItemJson(String name) {
-        String itemMaterial = Utils.removeParentDirs(name).split(".json")[0].toUpperCase();
+        String itemMaterial = Utils.removeParentDirs(name).replace(".json", "").toUpperCase();
         try {
             Material.valueOf(itemMaterial);
         } catch (IllegalArgumentException e) {
@@ -303,9 +304,9 @@ public class DuplicationHandler {
             migratedYaml.set(id + ".material", itemMaterial);
             migratedYaml.set(id + ".excludeFromInventory", true);
             migratedYaml.set(id + ".excludeFromCommands", true);
-            migratedYaml.set(id + ".Pack.custom_model_data", cmd);
-            migratedYaml.set(id + ".Pack.model", modelPath);
             migratedYaml.set(id + ".Pack.generate_model", false);
+            migratedYaml.set(id + ".Pack.model", modelPath);
+            if (Settings.RETAIN_CUSTOM_MODEL_DATA.toBool()) migratedYaml.set(id + ".Pack.custom_model_data", cmd);
         }
 
         try {
@@ -432,7 +433,8 @@ public class DuplicationHandler {
     }
 
     private static YamlConfiguration loadMigrateYaml(String folder) {
-        File file = new File(OraxenPlugin.get().getDataFolder(), "\\" + folder + "\\" + "migrated_duplicates.yml");
+
+        File file = OraxenPlugin.get().getDataFolder().toPath().toAbsolutePath().resolve(folder).resolve("migrated_duplicates.yml").toFile();
         if (!file.exists()) {
             try {
                 file.createNewFile();

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -1,7 +1,9 @@
 package io.th0rgal.oraxen.pack.generation;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Message;
@@ -17,12 +19,15 @@ import io.th0rgal.oraxen.sound.CustomSound;
 import io.th0rgal.oraxen.sound.SoundManager;
 import io.th0rgal.oraxen.utils.*;
 import io.th0rgal.oraxen.utils.logs.Logs;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -141,16 +146,113 @@ public class ResourcePack {
                 DuplicationHandler.mergeBaseItemFiles(output);
         }
 
+        verifyPackFormatting(output);
+
         List<String> excludedExtensions = Settings.EXCLUDED_FILE_EXTENSIONS.toStringList();
         excludedExtensions.removeIf(f -> f.equals("png") || f.equals("json"));
         if (!excludedExtensions.isEmpty() && !output.isEmpty()) {
             List<VirtualFile> newOutput = new ArrayList<>();
-            for (VirtualFile virtual : output) for (String extension : excludedExtensions)
-                if (virtual.getPath().endsWith(extension)) newOutput.add(virtual);
+            for (VirtualFile virtual : output)
+                for (String extension : excludedExtensions)
+                    if (virtual.getPath().endsWith(extension)) newOutput.add(virtual);
             output.removeAll(newOutput);
         }
 
         ZipUtils.writeZipFile(pack, output);
+    }
+
+    private static void verifyPackFormatting(List<VirtualFile> output) {
+        Logs.logInfo("Verifying formatting for textures and models...");
+
+        Set<VirtualFile> textures = new HashSet<>();
+        Set<String> texturePaths = new HashSet<>();
+        Set<String> mcmeta = new HashSet<>();
+        Set<VirtualFile> models = new HashSet<>();
+        Set<VirtualFile> malformedTextures = new HashSet<>();
+        Set<VirtualFile> malformedModels = new HashSet<>();
+        for (VirtualFile virtualFile : output) {
+            if (virtualFile.getPath().endsWith(".json")) models.add(virtualFile);
+            else if (virtualFile.getPath().endsWith(".png.mcmeta")) mcmeta.add(virtualFile.getPath());
+            else if (virtualFile.getPath().endsWith(".png")) {
+                textures.add(virtualFile);
+                texturePaths.add(virtualFile.getPath());
+            }
+        }
+
+        if (!models.isEmpty() || !textures.isEmpty()) {
+            //TODO Read modelfile and make sure all textures exist?
+            for (VirtualFile model : models) {
+                if (model.getPath().contains(" ") || !model.getPath().toLowerCase().equals(model.getPath())) {
+                    Logs.logWarning("Found invalid model at <blue>" + model.getPath() + " </blue>.");
+                    Logs.logError("Models cannot contain spaces or Capital Letters in the filepath or filename");
+                    Logs.newline();
+                    malformedModels.add(model);
+                }
+
+                String content;
+                try {
+                    content = IOUtils.toString(model.getInputStream(), StandardCharsets.UTF_8);
+                } catch (IOException e) {
+                    content = "";
+                }
+                if (!content.isEmpty()) {
+                    JsonObject jsonModel = JsonParser.parseString(content).getAsJsonObject();
+                    if (jsonModel.has("textures")) {
+                        JsonObject jsonTextures = jsonModel.getAsJsonObject("textures");
+                        for (Map.Entry<String, JsonElement> element : jsonTextures.entrySet()) {
+                            String t = element.getValue().getAsString();
+                            if (!texturePaths.contains(modelPathToPackPath(t))) {
+                                if (!t.startsWith("item/") && !t.startsWith("block/")) {
+                                    try {
+                                        Material.valueOf(Utils.removeParentDirs(Utils.removeExtension(t)).toUpperCase());
+                                    } catch (IllegalArgumentException e) {
+                                        Logs.logError(t);
+                                        Logs.logError(modelPathToPackPath(t));
+                                        Logs.logWarning("Found invalid texture inside <blue>" + model.getPath() + " </blue>.");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+            }
+
+            for (VirtualFile texture : textures) {
+                if (texture.getPath().contains(" ") || !texture.getPath().toLowerCase().equals(texture.getPath())) {
+                    Logs.logWarning("Found invalid texture at <blue>" + texture.getPath() + " </blue>.");
+                    Logs.logError("Textures cannot contain spaces or Capital Letters in the filepath or filename");
+                    Logs.newline();
+                    malformedTextures.add(texture);
+                }
+                if (!texture.getPath().matches(".*_layer_.*.png")) {
+                    if (mcmeta.contains(texture.getPath() + ".mcmeta")) continue;
+                    BufferedImage image;
+                    try {
+                        image = ImageIO.read(texture.getInputStream());
+                    } catch (IOException e) {
+                        continue;
+                    }
+                    if (image.getHeight() > 256 || image.getWidth() > 256) {
+                        Logs.logWarning("Found invalid texture at <blue>" + texture.getPath() + " </blue>.");
+                        Logs.logError("Resolution of textures cannot exceed 256x256");
+                        malformedTextures.add(texture);
+                    }
+                }
+            }
+
+            if (!malformedTextures.isEmpty() || !malformedModels.isEmpty()) {
+                Logs.logError("Pack contains malformed texture(s) and/or model(s)");
+                Logs.logError("These need to be fixed, otherwise the resourcepack will be broken");
+            } else Logs.logSuccess("No broken models or textures were found");
+        }
+    }
+
+    private static String modelPathToPackPath(String modelPath) {
+        String namespace = modelPath.split(":").length == 1 ? "minecraft" : modelPath.split(":")[0];
+        String texturePath = modelPath.split(":").length == 1 ? modelPath : modelPath.split(":")[1];
+        texturePath = texturePath.endsWith(".png") ? texturePath : texturePath + ".png";
+        return "assets/" + namespace + "/textures/" + texturePath;
     }
 
     private void extractFolders(boolean extractModels, boolean extractTextures, boolean extractShaders,

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -145,7 +145,8 @@ public class ResourcePack {
                 DuplicationHandler.mergeBaseItemFiles(output);
         }
 
-        verifyPackFormatting(output);
+        if (Settings.VERIFY_PACK_FILES.toBool())
+            verifyPackFormatting(output);
 
         List<String> excludedExtensions = Settings.EXCLUDED_FILE_EXTENSIONS.toStringList();
         excludedExtensions.removeIf(f -> f.equals("png") || f.equals("json"));

--- a/src/main/java/io/th0rgal/oraxen/utils/ZipUtils.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/ZipUtils.java
@@ -28,10 +28,9 @@ public class ZipUtils {
             final int compressionLevel = Deflater.class.getDeclaredField(Settings.COMPRESSION.toString()).getInt(null);
             zos.setLevel(compressionLevel);
             zos.setComment(Settings.COMMENT.toString());
-            for (final VirtualFile file : fileList)
-                addToZip(file.getPath(),
-                        file.getInputStream(),
-                        zos);
+            for (final VirtualFile file : fileList) {
+                addToZip(file.getPath(), file.getInputStream(), zos);
+            }
 
         } catch (final IOException | NoSuchFieldException | IllegalAccessException ex) {
             ex.printStackTrace();
@@ -44,17 +43,11 @@ public class ZipUtils {
         DuplicationHandler.checkForDuplicate(zos, zipEntry);
 
         final byte[] bytes = new byte[1024];
-        int length;
-        try (fis) {
-            while ((length = fis.read(bytes)) >= 0)
-                zos.write(bytes, 0, length);
-        } catch (IOException ignored) {
-        } finally {
-            zos.closeEntry();
-            if (Settings.PROTECTION.toBool()) {
-                zipEntry.setCrc(bytes.length);
-                zipEntry.setSize(new BigInteger(bytes).mod(BigInteger.valueOf(Long.MAX_VALUE)).longValue());
-            }
+        fis.transferTo(zos);
+        zos.closeEntry();
+        if (Settings.PROTECTION.toBool()) {
+            zipEntry.setCrc(bytes.length);
+            zipEntry.setSize(new BigInteger(bytes).mod(BigInteger.valueOf(Long.MAX_VALUE)).longValue());
         }
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -112,14 +112,8 @@ public class BreakerSystem {
                     breakerPerLocation.get(location).cancelTasks(OraxenPlugin.get());
 
                 final BukkitScheduler scheduler = Bukkit.getScheduler();
-                final PlayerInteractEvent playerInteractEvent = new PlayerInteractEvent(
-                        player,
-                        Action.LEFT_CLICK_BLOCK,
-                        player.getInventory().getItemInMainHand(),
-                        block,
-                        blockFace,
-                        EquipmentSlot.HAND
-                );
+                final PlayerInteractEvent playerInteractEvent =
+                        new PlayerInteractEvent(player, Action.LEFT_CLICK_BLOCK, player.getInventory().getItemInMainHand(), block, blockFace, EquipmentSlot.HAND);
                 //scheduler.runTask(OraxenPlugin.get(), () -> Bukkit.getPluginManager().callEvent(playerInteractEvent));
                 if (playerInteractEvent.useInteractedBlock().equals(Event.Result.DENY)) return;
 
@@ -212,7 +206,9 @@ public class BreakerSystem {
                     return false;
                 }
             }
-            default -> { return true; }
+            default -> {
+                return true;
+            }
         }
     }
 

--- a/src/main/resources/mechanics.yml
+++ b/src/main/resources/mechanics.yml
@@ -86,6 +86,7 @@ furniture:
   # ticks between each check for plant growth
   evolution_check_delay: 200
   enabled: true
+  detect_viabackwards: true  # Blocks use of Item Display Furniture when server allows clients below 1.19.4
 
 durability:
   enabled: true

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -22,21 +22,10 @@ Plugin:
   worldedit: # Please note these are both experimental still and should be used with caution
     noteblock_mechanic: false
     stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
-  experimental:
-    # Unlike duplication handler, this will simply attempt to merge the Jsons for the final pack
-    # This will not be flawless and still will cause issues, but they are there
-    # [merge_item,_base_models] can be used to merge paper.json etc from imported packs
-    merge_font_files: false
-    merge_item_base_models: false
 
 Pack:
   generation:
     generate: true # Unlike Plugin.generation.default_assets, this will enable/disable all pack generation
-    # If you have a duplicate json file due to importing a resourcepack,
-    # have Oraxen attempt to migrate it into config files to generate a working resourcepack
-    # Keep in mind this is still experimental, and you should not enable it before
-    # you have a backup of the resourcepack you are importing.
-    attempt_to_migrate_duplicates: false
     # List of file extensions that will not be included in the final zipped ResourcePack
     excluded_file_extensions: []
     generate_atlas_file: true
@@ -59,6 +48,20 @@ Pack:
      \nplugin and any complete or partial
      \nuse must comply with the terms and
      \nconditions of Oraxen."
+
+  import:
+    merge_duplicates: false
+    # Whether the above merger will set the custommodeldata to the same values as in the imported file
+    # To avoid issues, only set this to true if you need them to be these values for another plugin
+    # This might override some of your other OraxenItems if they have they have their custom_model_data set to the same.
+    retain_custom_model_data: false
+    # Unlike duplication handler, this will simply attempt to merge the Jsons for the final pack
+    # This will not be flawless but will not be generating item-configs like above.
+    # The issue of custom-model-data is still here but it will copy it over no matter what [retain_custom_model_data] is set to
+    # [merge_item,_base_models] can be used to merge paper.json etc from imported packs
+    merge_font_files: false
+    merge_item_base_models: false
+
 
   upload:
     enabled: true

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -22,6 +22,8 @@ Plugin:
   worldedit: # Please note these are both experimental still and should be used with caution
     noteblock_mechanic: false
     stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
+  experimental:
+    verify_pack_files: true # Checks all textures and models to make sure they abide by valid Resourcepack formatting
 
 Pack:
   generation:

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -29,6 +29,7 @@ Pack:
     # List of file extensions that will not be included in the final zipped ResourcePack
     excluded_file_extensions: []
     generate_atlas_file: true
+    atlas_generation_type: SPRITE # Can be SPRITE or DIRECTORY
     auto_generated_models_follow_texture_path: false
     # 64x32 layer is default size and corresponds to 16. If you need higher
     # resolution, e.g. 128x64, you should set this parameter to 32 and so on.


### PR DESCRIPTION
```yml
- Verify that all textures and models follow Resourcepack rules
- Add setting to change Atlas Generation between sprite and directory based
  * Sprite will be better unless you want to have malformed textures in the pack
- Fix issue with MMOItems and CrucibleItems not importing properly
- Fix issue with Wood/Stone blocks often infinitly playing hit-sound
```