### PR TITLE
Added option to cancel Custom mechanic events

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/CustomMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/CustomMechanic.java
@@ -27,16 +27,17 @@ public class CustomMechanic extends Mechanic {
                 loadedListener.unregister();
             }
 
-            ClickAction clickAction = ClickAction.from(subsection);
+            boolean cancelEvent = subsection.getBoolean("cancel_event", false);
+
+            ClickAction clickAction = ClickAction.from(subsection, cancelEvent);
 
             if (clickAction == null) {
                 continue;
             }
 
-            CustomListener listener = new CustomEvent(
-                    subsection.getString("event"),
-                    subsection.getBoolean("one_usage", false)
-            ).getListener(getItemID(), subsection.getLong("cooldown"), clickAction);
+            CustomListener listener = new CustomEvent(subsection.getString("event"),
+                    subsection.getBoolean("one_usage", false), cancelEvent)
+                    .getListener(getItemID(), subsection.getLong("cooldown"), clickAction);
 
             listener.register();
             LOADED_VARIANTS.put(key, listener);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/fields/CustomEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/fields/CustomEvent.java
@@ -12,12 +12,14 @@ public class CustomEvent {
     public final CustomEventType type;
     private final List<String> params = new ArrayList<>();
     private final boolean oneUsage;
+    private final boolean cancelEvent;
 
-    public CustomEvent(String action, boolean oneUsage) {
+    public CustomEvent(String action, boolean oneUsage, boolean cancelEvent) {
         String[] actionParams = action.split(":");
         type = CustomEventType.valueOf(actionParams[0]);
         params.addAll(Arrays.asList(actionParams).subList(1, actionParams.length));
         this.oneUsage = oneUsage;
+        this.cancelEvent = cancelEvent;
     }
 
     public List<String> getParams() {
@@ -30,5 +32,9 @@ public class CustomEvent {
 
     public boolean isOneUsage() {
         return oneUsage;
+    }
+
+    public boolean isCancelEvent() {
+        return cancelEvent;
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/ClickListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/ClickListener.java
@@ -65,6 +65,8 @@ public class ClickListener extends CustomListener {
             if (!itemID.equals(OraxenItems.getIdByItem(item)))
                 return;
             perform(event.getPlayer(), item);
+            if(this.event.isCancelEvent())
+                event.setCancelled(true);
         }
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/DropListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/DropListener.java
@@ -19,6 +19,8 @@ public class DropListener extends CustomListener {
         ItemStack item = event.getItemDrop().getItemStack();
         if (!itemID.equals(OraxenItems.getIdByItem(item))) return;
         perform(event.getPlayer(), item);
+        if(this.event.isCancelEvent())
+            event.setCancelled(true);
     }
 
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/EquipListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/EquipListener.java
@@ -18,5 +18,7 @@ public class EquipListener extends CustomListener {
         ItemStack newArmor = event.getNewArmorPiece();
         if (newArmor == null || !itemID.equals(OraxenItems.getIdByItem(newArmor))) return;
         perform(event.getPlayer(), newArmor);
+        if(this.event.isCancelEvent())
+            event.setCancelled(true);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/InvClickListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/InvClickListener.java
@@ -20,5 +20,8 @@ public class InvClickListener extends CustomListener {
         ItemStack clicked = event.getCurrentItem();
         if (clicked != null && itemID.equals(OraxenItems.getIdByItem(clicked)))
             perform((Player) event.getWhoClicked(), clicked);
+
+        if(this.event.isCancelEvent())
+            event.setCancelled(true);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/PickupListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/PickupListener.java
@@ -22,6 +22,8 @@ public class PickupListener extends CustomListener {
         if (!itemID.equals(OraxenItems.getIdByItem(item)))
             return;
         perform(player, item);
+        if(this.event.isCancelEvent())
+            event.setCancelled(true);
     }
 
 }

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/UnequipListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/custom/listeners/UnequipListener.java
@@ -18,5 +18,7 @@ public class UnequipListener extends CustomListener {
         ItemStack oldArmor = event.getOldArmorPiece();
         if (oldArmor == null || !itemID.equals(OraxenItems.getIdByItem(oldArmor))) return;
         perform(event.getPlayer(), oldArmor);
+        if(this.event.isCancelEvent())
+            event.setCancelled(true);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/utils/actions/ClickAction.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/actions/ClickAction.java
@@ -28,15 +28,14 @@ public class ClickAction {
         this.actions = actions;
     }
 
-    @SuppressWarnings("unchecked")
     private static ClickAction from(final LinkedHashMap<String, Object> config) {
         final Object conditionsObject = config.get("conditions");
-        final List<String> conditions = (conditionsObject == null) ? Collections.emptyList() : (List<String>) conditionsObject;
+        final List<String> conditions = (conditionsObject == null) ? Collections.emptyList()
+                : (List<String>) conditionsObject;
 
         final Object actionsObject = config.get("actions");
-        final List<Action<Player>> actions = (actionsObject == null) ?
-                Collections.emptyList() :
-                OraxenPlugin.get().getClickActionManager().parse(Player.class, (List<String>) actionsObject);
+        final List<Action<Player>> actions = (actionsObject == null) ? Collections.emptyList()
+                : OraxenPlugin.get().getClickActionManager().parse(Player.class, (List<String>) actionsObject);
 
         // If the action doesn't have any actions, return null
         if (actions.isEmpty()) {
@@ -47,11 +46,15 @@ public class ClickAction {
     }
 
     public static ClickAction from(final ConfigurationSection config) {
+        return from(config, false);
+    }
+    public static ClickAction from(final ConfigurationSection config, boolean allowEmptyActions) {
         final List<String> conditions = config.getStringList("conditions");
-        final List<Action<Player>> actions = OraxenPlugin.get().getClickActionManager().parse(Player.class, config.getStringList("actions"));
+        final List<Action<Player>> actions = OraxenPlugin.get().getClickActionManager().parse(Player.class,
+                config.getStringList("actions"));
 
         // If the action doesn't have any actions, return null
-        if (actions.isEmpty()) {
+        if (actions.isEmpty() && !allowEmptyActions) {
             return null;
         }
 
@@ -65,7 +68,8 @@ public class ClickAction {
             return Collections.emptyList();
         }
 
-        final List<LinkedHashMap<String, Object>> list = (List<LinkedHashMap<String, Object>>) section.getList("clickActions");
+        final List<LinkedHashMap<String, Object>> list = (List<LinkedHashMap<String, Object>>) section
+                .getList("clickActions");
 
         // Return an empty list if the clickActions list is null / empty
         if (list == null || list.isEmpty()) {


### PR DESCRIPTION
I've added a [Custom](https://docs.oraxen.com/mechanics/all-mechanics/custom-mechanic) mechanic configuration option to cancel related events.
An example usage:
```yml
example:
  displayname: "test"
  material: DIAMOND_HOE
  Mechanics:
      custom:
        test:
          one_usage: false
          event: "CLICK:right:all"
          actions:
            - "[console] give <player> cooked_beef 1"
          cancel_event: true
```
`cancel_event` is the new option. If it's true the `event` is canceled (but actions still get executed).
This applies to:
- CLICK events
- DROP and PICKUP events
- EQUIP and UNEQUIP events
- INV_CLICK events  

On the remaining events this option is ignored.
I've also added possibility to ommit the `actions` field as long as `cancel_event` is true.