### PR TITLE
1.155.1

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -24,6 +24,7 @@ public enum Settings {
     FORMAT_SIGNS("Plugin.formatting.signs"),
     FORMAT_CHAT("Plugin.formatting.chat"),
     FORMAT_BOOKS("Plugin.formatting.books"),
+    VERIFY_PACK_FILES("Plugin.experimental.verify_pack_files"),
 
     CONFIGS_VERSION("configs_version"),
     UPDATE_CONFIGS("ConfigsTools.enable_configs_updater"),

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -25,6 +25,7 @@ public enum Settings {
     FORMAT_CHAT("Plugin.formatting.chat"),
     FORMAT_BOOKS("Plugin.formatting.books"),
     VERIFY_PACK_FILES("Plugin.experimental.verify_pack_files"),
+    EXCLUDE_MALFORMED_ATLAS("Plugin.experimental.exclude_malformed_from_atlas"),
 
     CONFIGS_VERSION("configs_version"),
     UPDATE_CONFIGS("ConfigsTools.enable_configs_updater"),

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -47,7 +47,8 @@ public enum Settings {
 
     GENERATE("Pack.generation.generate"),
     EXCLUDED_FILE_EXTENSIONS("Pack.generation.excluded_file_extensions"),
-    GENERATE_ATLAS_FILE("Pack.generation.generate_atlas_file"),
+    GENERATE_ATLAS_FILE("Pack.generation.atlas.generate"),
+    ATLAS_GENERATION_TYPE("Pack.generation.atlas.type"),
     GENERATE_MODEL_BASED_ON_TEXTURE_PATH("Pack.generation.auto_generated_models_follow_texture_path"),
     ARMOR_RESOLUTION("Pack.generation.armor_resolution"),
     ANIMATED_ARMOR_FRAMERATE("Pack.generation.animated_armor_framerate"),

--- a/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
@@ -9,6 +9,7 @@ public enum UpdatedSettings {
     GUI_INVENTORY("gui_inventory", "oraxen_inventory.menu_layout"),
     MERGE_ITEM_MODELS("Plugin.experimental.merge_item_base_models", "Pack.import.merge_item_base_models"),
     MERGE_FONTS("Plugin.experimental.merge_font_files", "Pack.import.merge_font_files"),
+    GENERATE_ATLAS_FILE("Pack.generation.generate_atlas_file", "Pack.generation.atlas.generate")
     ;
 
     private final String path;

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -95,6 +95,13 @@ public class FurnitureListener implements Listener {
         if (oraxenEvent.isCancelled()) event.setCancelled(true);
     }
 
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemFrameRotate(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof ItemFrame frame)) return;
+        if (!OraxenFurniture.isFurniture(frame)) return;
+        event.setCancelled(true);
+    }
+
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onLimitedPlacing(final PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
@@ -311,9 +318,10 @@ public class FurnitureListener implements Listener {
         if (mechanic == null) return;
         // Swap baseEntity to the baseEntity if interacted with entity is Interaction type
         Entity interaction = null;
-        if (OraxenPlugin.get().supportsDisplayEntities && baseEntity instanceof Interaction interactionEntity) {
+        if (OraxenPlugin.supportsDisplayEntities && baseEntity instanceof Interaction interactionEntity) {
             interaction = interactionEntity;
             baseEntity = mechanic.getBaseEntity(interaction);
+            baseEntity = baseEntity != null ? baseEntity : interaction;
         }
         OraxenFurnitureInteractEvent furnitureInteractEvent = new OraxenFurnitureInteractEvent(mechanic, player, null, baseEntity);
         OraxenPlugin.get().getServer().getPluginManager().callEvent(furnitureInteractEvent);

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -403,7 +403,6 @@ public class FurnitureMechanic extends Mechanic {
     }
 
     private void setBaseFurnitureData(Entity entity) {
-        entity.setInvulnerable(true);
         entity.setPersistent(true);
         PersistentDataContainer pdc = entity.getPersistentDataContainer();
         pdc.set(FURNITURE_KEY, PersistentDataType.STRING, getItemID());

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
@@ -24,6 +24,7 @@ import org.bukkit.event.world.GenericGameEvent;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
@@ -31,7 +32,7 @@ import static io.th0rgal.oraxen.utils.blocksounds.BlockSounds.*;
 
 public class FurnitureSoundListener implements Listener {
 
-    private final Map<Block, BukkitTask> breakerPlaySound = new HashMap<>();
+    private final Map<Location, BukkitTask> breakerPlaySound = new HashMap<>();
 
     // Play sound due to furniture/barrier custom sound replacing stone
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -47,38 +48,40 @@ public class FurnitureSoundListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onBreakingStone(final BlockBreakEvent event) {
         Block block = event.getBlock();
+        Location location = block.getLocation();
 
         if (block.getType() == Material.TRIPWIRE) return;
         if (block.getBlockData().getSoundGroup().getBreakSound() != Sound.BLOCK_STONE_BREAK) return;
-        if (breakerPlaySound.containsKey(block)) {
-            breakerPlaySound.get(block).cancel();
-            breakerPlaySound.remove(block);
+        if (breakerPlaySound.containsKey(location)) {
+            breakerPlaySound.get(location).cancel();
+            breakerPlaySound.remove(location);
         }
 
-        if (!event.isCancelled() && ProtectionLib.canBreak(event.getPlayer(), block.getLocation()))
-            BlockHelpers.playCustomBlockSound(event.getBlock().getLocation(), VANILLA_STONE_BREAK, VANILLA_BREAK_VOLUME, VANILLA_BREAK_PITCH);
+        if (!event.isCancelled() && ProtectionLib.canBreak(event.getPlayer(), location))
+            BlockHelpers.playCustomBlockSound(location, VANILLA_STONE_BREAK, VANILLA_BREAK_VOLUME, VANILLA_BREAK_PITCH);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onHitStone(final BlockDamageEvent event) {
         Block block = event.getBlock();
+        Location location = block.getLocation();
         SoundGroup soundGroup = block.getBlockData().getSoundGroup();
 
         if (event.getInstaBreak()) return;
         if (block.getType() == Material.BARRIER || soundGroup.getHitSound() != Sound.BLOCK_STONE_HIT) return;
-        if (breakerPlaySound.containsKey(block)) return;
+        if (breakerPlaySound.containsKey(location)) return;
 
         BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
-                BlockHelpers.playCustomBlockSound(block.getLocation(), VANILLA_STONE_HIT, VANILLA_HIT_VOLUME, VANILLA_HIT_PITCH), 2L, 4L);
-        breakerPlaySound.put(block, task);
+                BlockHelpers.playCustomBlockSound(location, VANILLA_STONE_HIT, VANILLA_HIT_VOLUME, VANILLA_HIT_PITCH), 2L, 4L);
+        breakerPlaySound.put(location, task);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStopHittingStone(final BlockDamageAbortEvent event) {
-        Block block = event.getBlock();
-        if (breakerPlaySound.containsKey(block)) {
-            breakerPlaySound.get(block).cancel();
-            breakerPlaySound.remove(block);
+        Location location = event.getBlock().getLocation();
+        if (breakerPlaySound.containsKey(location)) {
+            breakerPlaySound.get(location).cancel();
+            breakerPlaySound.remove(location);
         }
     }
 

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
@@ -19,7 +19,7 @@ public class AtlasGenerator {
     public AtlasGenerator() {
     }
 
-    public static void generateAtlasFile(List<VirtualFile> output) {
+    public static void generateAtlasFile(List<VirtualFile> output, Set<String> malformedTextures) {
         Logs.logSuccess("Generating atlas-file for 1.19.3 Resource Pack format");
 
         JsonObject atlas = new JsonObject();
@@ -65,6 +65,7 @@ public class AtlasGenerator {
                     atlasEntry.addProperty("prefix", path + "/");
                 }
             } else {
+                if (Settings.EXCLUDE_MALFORMED_ATLAS.toBool() && malformedTextures.contains(path)) continue;
                 String sprite = namespace + ":" + path;
                 atlasEntry.addProperty("type", "single");
                 atlasEntry.addProperty("resource", sprite);

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.VirtualFile;
 import io.th0rgal.oraxen.utils.logs.Logs;
@@ -52,10 +53,23 @@ public class AtlasGenerator {
 
             JsonObject atlasEntry = new JsonObject();
             String namespace = virtual.getPath().replaceFirst("assets/", "").split("/")[0];
-            String sprite = namespace + ":" + path;
-            atlasEntry.addProperty("type", "single");
-            atlasEntry.addProperty("resource", sprite);
-            atlasEntry.addProperty("sprite", sprite);
+            if (Settings.ATLAS_GENERATION_TYPE.toString().equals("DIRECTORY")) {
+                if (path.endsWith(".png")) {
+                    String sprite = Utils.removeParentDirs(Utils.removeExtension(virtual.getPath()));
+                    atlasEntry.addProperty("type", "single");
+                    atlasEntry.addProperty("resource", namespace + ":" + Utils.removeExtension(path));
+                    atlasEntry.addProperty("sprite", namespace + ":" + sprite);
+                } else {
+                    atlasEntry.addProperty("type", "directory");
+                    atlasEntry.addProperty("source", path);
+                    atlasEntry.addProperty("prefix", path + "/");
+                }
+            } else {
+                String sprite = namespace + ":" + path;
+                atlasEntry.addProperty("type", "single");
+                atlasEntry.addProperty("resource", sprite);
+                atlasEntry.addProperty("sprite", sprite);
+            }
 
             if (!atlasContent.contains(atlasEntry))
                 atlasContent.add(atlasEntry);

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -204,7 +204,7 @@ public class ResourcePack {
                         for (JsonElement element : jsonModel.getAsJsonObject("textures").entrySet().stream().map(Map.Entry::getValue).toList()) {
                             String jsonTexture = element.getAsString();
                             if (!texturePaths.contains(modelPathToPackPath(jsonTexture))) {
-                                if (!jsonTexture.startsWith("item/") && !jsonTexture.startsWith("block/")) {
+                                if (!jsonTexture.startsWith("#") && !jsonTexture.startsWith("item/") && !jsonTexture.startsWith("block/")) {
                                     try {
                                         Material.valueOf(Utils.removeParentDirs(Utils.removeExtension(jsonTexture)).toUpperCase());
                                     } catch (IllegalArgumentException e) {

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -19,7 +19,6 @@ import io.th0rgal.oraxen.sound.CustomSound;
 import io.th0rgal.oraxen.sound.SoundManager;
 import io.th0rgal.oraxen.utils.*;
 import io.th0rgal.oraxen.utils.logs.Logs;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -202,7 +201,7 @@ public class ResourcePack {
                 if (!content.isEmpty()) {
                     JsonObject jsonModel = JsonParser.parseString(content).getAsJsonObject();
                     if (jsonModel.has("textures")) {
-                        for (JsonElement element : jsonModel.getAsJsonObject("textures").asMap().values()) {
+                        for (JsonElement element : jsonModel.getAsJsonObject("textures").entrySet().stream().map(Map.Entry::getValue).toList()) {
                             String jsonTexture = element.getAsString();
                             if (!texturePaths.contains(modelPathToPackPath(jsonTexture))) {
                                 if (!jsonTexture.startsWith("item/") && !jsonTexture.startsWith("block/")) {

--- a/src/main/java/io/th0rgal/oraxen/utils/ZipUtils.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/ZipUtils.java
@@ -28,10 +28,9 @@ public class ZipUtils {
             final int compressionLevel = Deflater.class.getDeclaredField(Settings.COMPRESSION.toString()).getInt(null);
             zos.setLevel(compressionLevel);
             zos.setComment(Settings.COMMENT.toString());
-            for (final VirtualFile file : fileList)
-                addToZip(file.getPath(),
-                        file.getInputStream(),
-                        zos);
+            for (final VirtualFile file : fileList) {
+                addToZip(file.getPath(), file.getInputStream(), zos);
+            }
 
         } catch (final IOException | NoSuchFieldException | IllegalAccessException ex) {
             ex.printStackTrace();
@@ -44,17 +43,11 @@ public class ZipUtils {
         DuplicationHandler.checkForDuplicate(zos, zipEntry);
 
         final byte[] bytes = new byte[1024];
-        int length;
-        try (fis) {
-            while ((length = fis.read(bytes)) >= 0)
-                zos.write(bytes, 0, length);
-        } catch (IOException ignored) {
-        } finally {
-            zos.closeEntry();
-            if (Settings.PROTECTION.toBool()) {
-                zipEntry.setCrc(bytes.length);
-                zipEntry.setSize(new BigInteger(bytes).mod(BigInteger.valueOf(Long.MAX_VALUE)).longValue());
-            }
+        fis.transferTo(zos);
+        zos.closeEntry();
+        if (Settings.PROTECTION.toBool()) {
+            zipEntry.setCrc(bytes.length);
+            zipEntry.setSize(new BigInteger(bytes).mod(BigInteger.valueOf(Long.MAX_VALUE)).longValue());
         }
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -112,14 +112,8 @@ public class BreakerSystem {
                     breakerPerLocation.get(location).cancelTasks(OraxenPlugin.get());
 
                 final BukkitScheduler scheduler = Bukkit.getScheduler();
-                final PlayerInteractEvent playerInteractEvent = new PlayerInteractEvent(
-                        player,
-                        Action.LEFT_CLICK_BLOCK,
-                        player.getInventory().getItemInMainHand(),
-                        block,
-                        blockFace,
-                        EquipmentSlot.HAND
-                );
+                final PlayerInteractEvent playerInteractEvent =
+                        new PlayerInteractEvent(player, Action.LEFT_CLICK_BLOCK, player.getInventory().getItemInMainHand(), block, blockFace, EquipmentSlot.HAND);
                 //scheduler.runTask(OraxenPlugin.get(), () -> Bukkit.getPluginManager().callEvent(playerInteractEvent));
                 if (playerInteractEvent.useInteractedBlock().equals(Event.Result.DENY)) return;
 
@@ -212,7 +206,9 @@ public class BreakerSystem {
                     return false;
                 }
             }
-            default -> { return true; }
+            default -> {
+                return true;
+            }
         }
     }
 

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -24,6 +24,7 @@ Plugin:
     stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
   experimental:
     verify_pack_files: true # Checks all textures and models to make sure they abide by valid Resourcepack formatting
+    exclude_malformed_from_atlas: true # If a texture is malformed, it will not be included in the atlas
 
 Pack:
   generation:

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -22,6 +22,8 @@ Plugin:
   worldedit: # Please note these are both experimental still and should be used with caution
     noteblock_mechanic: false
     stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
+  experimental:
+    verify_pack_files: true # Checks all textures and models to make sure they abide by valid Resourcepack formatting
 
 Pack:
   generation:

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -30,7 +30,9 @@ Pack:
     generate: true # Unlike Plugin.generation.default_assets, this will enable/disable all pack generation
     # List of file extensions that will not be included in the final zipped ResourcePack
     excluded_file_extensions: []
-    generate_atlas_file: true
+    atlas:
+      generate: true
+      type: "SPRITE" # "SPRITE" or "DIRECTORY"
     auto_generated_models_follow_texture_path: false
     # 64x32 layer is default size and corresponds to 16. If you need higher
     # resolution, e.g. 128x64, you should set this parameter to 32 and so on.


### PR DESCRIPTION
```yml
- Verify that all textures and models follow Resourcepack rules
- Add setting to change Atlas Generation between sprite and directory based
  * Sprite will be better unless you want to have malformed textures in the pack
- Fix issue with MMOItems and CrucibleItems not importing properly
- Fix issue with Wood/Stone blocks often infinitly playing hit-sound
- Fix non-barrier furniture being unbreakable and rotatable
```