### PR TITLE
Temp fix npe

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -100,15 +100,17 @@ public class FurnitureMechanic extends Mechanic {
             Logs.logError("Setting type to ITEM_FRAME.");
             furnitureType = FurnitureType.ITEM_FRAME;
         }
+
         ConfigurationSection displayEntitySection = section.getConfigurationSection("display_entity_properties");
-        if(furnitureType== FurnitureType.DISPLAY_ENTITY && displayEntitySection == null) {
+        if (displayEntitySection == null) {
             Logs.logError("Use of Display Entity without display_entity_properties in " + getItemID() + " furniture.");
             Logs.logError("Setting type to ITEM_FRAME.");
             furnitureType = FurnitureType.ITEM_FRAME;
-        }
-        displayEntityProperties = OraxenPlugin.supportsDisplayEntities && displayEntitySection != null
-                ? new DisplayEntityProperties(displayEntitySection)
-                : null;
+            displayEntityProperties = null;
+        } else
+            displayEntityProperties = OraxenPlugin.supportsDisplayEntities
+                    ? new DisplayEntityProperties(displayEntitySection)
+                    : null;
 
         barriers = new ArrayList<>();
         if (CompatibilitiesManager.hasPlugin("ProtocolLib")) {

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -101,7 +101,12 @@ public class FurnitureMechanic extends Mechanic {
             furnitureType = FurnitureType.ITEM_FRAME;
         }
         ConfigurationSection displayEntitySection = section.getConfigurationSection("display_entity_properties");
-        displayEntityProperties = OraxenPlugin.get().supportsDisplayEntities && displayEntitySection != null
+        if(furnitureType== FurnitureType.DISPLAY_ENTITY && displayEntitySection == null) {
+            Logs.logError("Use of Display Entity without display_entity_properties in " + getItemID() + " furniture.");
+            Logs.logError("Setting type to ITEM_FRAME.");
+            furnitureType = FurnitureType.ITEM_FRAME;
+        }
+        displayEntityProperties = OraxenPlugin.supportsDisplayEntities && displayEntitySection != null
                 ? new DisplayEntityProperties(displayEntitySection)
                 : null;
 


### PR DESCRIPTION
[00:33:03 ERROR]: Could not pass event PlayerInteractEvent to Oraxen v1.154.2
java.lang.NullPointerException: Cannot invoke "io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.DisplayEntityProperties.getDisplayTransform()" because "<parameter4>" is null
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.setItemDisplayData(FurnitureMechanic.java:415) ~[oraxen-1.154.2.jar:?]
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.setEntityData(FurnitureMechanic.java:377) ~[oraxen-1.154.2.jar:?]
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.lambda$place$3(FurnitureMechanic.java:345) ~[oraxen-1.154.2.jar:?]
        at org.bukkit.craftbukkit.v1_19_R3.CraftRegionAccessor.addEntity(CraftRegionAccessor.java:545) ~[purpur-1.19.4.jar:git-Purpur-1949]
        at org.bukkit.craftbukkit.v1_19_R3.CraftRegionAccessor.spawn(CraftRegionAccessor.java:524) ~[purpur-1.19.4.jar:git-Purpur-1949]
        at org.bukkit.craftbukkit.v1_19_R3.CraftRegionAccessor.spawn(CraftRegionAccessor.java:518) ~[purpur-1.19.4.jar:git-Purpur-1949]
        at org.bukkit.craftbukkit.v1_19_R3.CraftRegionAccessor.spawn(CraftRegionAccessor.java:509) ~[purpur-1.19.4.jar:git-Purpur-1949]
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.place(FurnitureMechanic.java:344) ~[oraxen-1.154.2.jar:?]
        at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureListener.onFurniturePlace(FurnitureListener.java:171) ~[oraxen-1.154.2.jar:?]