### PR TITLE
Backpack fix & Console Spam fix

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -134,7 +134,9 @@ public class FurnitureListener implements Listener {
         final Player player = event.getPlayer();
         final Block placedAgainst = event.getClickedBlock();
         final EquipmentSlot hand = event.getHand();
-        assert placedAgainst != null;
+
+        if (placedAgainst == null) return;
+
         Block block = getTarget(placedAgainst, event.getBlockFace());
         ItemStack item = event.getItem();
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/backpack/BackpackListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/backpack/BackpackListener.java
@@ -98,6 +98,8 @@ public class BackpackListener implements Listener {
             if (contents != null) gui.getInventory().setContents(contents);
             if (mechanic.hasOpenSound())
                 player.playSound(player.getLocation(), mechanic.getOpenSound(), mechanic.getVolume(), mechanic.getPitch());
+
+            player.getInventory().setItemInMainHand(backpack);
         });
 
         gui.setCloseGuiAction(event -> {


### PR DESCRIPTION
This PR aims to fix the bug of the Backpack content not being saved after closing the inventory and console spawn 

`[Server thread/ERROR]: Could not pass event PlayerInteractEvent to Oraxen v1.155.1
java.lang.NullPointerException: Cannot invoke "org.bukkit.block.Block.getType()" because "<parameter1>" is null
	at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureListener.getTarget(FurnitureListener.java:197) ~[oraxen-1.155.1.jar:?]
	at io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureListener.onFurniturePlace(FurnitureListener.java:138) ~[oraxen-1.155.1.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor182.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:git-Paper-448]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.19.3.jar:git-Paper-448]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[paper-1.19.3.jar:git-Paper-448]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:615) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:546) ~[paper-1.19.3.jar:git-Paper-448]
	at org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:503) ~[paper-1.19.3.jar:git-Paper-448]
	at org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:498) ~[paper-1.19.3.jar:git-Paper-448]
	at org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:493) ~[paper-1.19.3.jar:git-Paper-448]
	at org.bukkit.craftbukkit.v1_19_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:489) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleAnimate(ServerGamePacketListenerImpl.java:2606) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundSwingPacket.handle(ServerboundSwingPacket.java:25) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundSwingPacket.a(ServerboundSwingPacket.java:11) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1341) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:197) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1318) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1311) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:114) ~[?:?]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1445) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1173) ~[paper-1.19.3.jar:git-Paper-448]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-448]
	at java.lang.Thread.run(Thread.java:1589) ~[?:?]`