### PR TITLE
Fix Lifeleech mechanic killing npcs and giving player health

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/lifeleech/LifeLeechMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/lifeleech/LifeLeechMechanicListener.java
@@ -39,12 +39,11 @@ public class LifeLeechMechanicListener implements Listener {
 
         if (event.getEntity() instanceof LivingEntity damaged) {
             if(damaged.hasMetadata("NPC")){
-                // Its a NPC so just cancel the event and return
-                event.setCancelled(true);
+                // Its a Citizens NPC so just ignore
                 return;
             }
 
-            // If its not an npc then only give the health to damager
+            // If its not a Citizens NPC then only give the health to damager
             damager.setHealth(Math.min(health, maxHealth));
 
             

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/lifeleech/LifeLeechMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/lifeleech/LifeLeechMechanicListener.java
@@ -37,8 +37,17 @@ public class LifeLeechMechanicListener implements Listener {
         double health = damager.getHealth() + mechanic.getAmount();
         double maxHealth = damager.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
 
-        damager.setHealth(Math.min(health, maxHealth));
         if (event.getEntity() instanceof LivingEntity damaged) {
+            if(damaged.hasMetadata("NPC")){
+                // Its a NPC so just cancel the event and return
+                event.setCancelled(true);
+                return;
+            }
+
+            // If its not an npc then only give the health to damager
+            damager.setHealth(Math.min(health, maxHealth));
+
+            
             damaged
                     .setHealth(
                             damaged.getHealth() - mechanic.getAmount() <= 0


### PR DESCRIPTION
This pr closes the bug [https://github.com/oraxen/oraxen/issues/796], basically players are able to kill npc's using the Lifeleech mechanic and they are getting the health too. so added a check to see if the damaged entity is an npc or not