### PR TITLE
Fix glyphs placeholders not showing on chat

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -258,7 +258,7 @@ public class FontEvents implements Listener {
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
                 message = message.replaceText(TextReplacementConfig.builder().match(entry.getKey())
-                        .replacement(Component.text().color(NamedTextColor.WHITE)).build());
+                        .replacement(Component.text(entry.getValue().getCharacter()).color(NamedTextColor.WHITE)).build());
             }
 
             event.result(message);


### PR DESCRIPTION
When I send a glyph placeholder on the chat, it gets replaced to an empty char