### PR TITLE
Adventure API fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,24 +48,25 @@ dependencies {
     compileOnly("me.clip:placeholderapi:2.11.2")
     compileOnly("com.github.BeYkeRYkt:LightAPI:5.3.0-Bukkit")
     compileOnly("me.gabytm.util:actions-core:$actionsVersion")
-    compileOnly("org.springframework:spring-expression:6.0.6")
     compileOnly("io.lumine:Mythic-Dist:5.2.0-SNAPSHOT")
     compileOnly("io.lumine:MythicCrucible:1.6.0-SNAPSHOT")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.0")
     compileOnly("commons-io:commons-io:2.11.0")
     compileOnly("com.ticxo.modelengine:api:R3.1.5")
     compileOnly(files("libs/compile/BSP.jar"))
-    compileOnly("dev.jorel:commandapi-shade:8.8.0")
     compileOnly("io.lumine:MythicLib:1.1.6")
     compileOnly("net.Indyuce:MMOItems:6.7.3")
-    compileOnly("org.joml:joml:1.10.5") // Because pre 1.19.4 api does not have this in the server-jar
+
+    library("org.joml:joml:1.10.5") // Because pre 1.19.4 api does not have this in the server-jar
+    library("org.springframework:spring-expression:6.0.6")
+    library("dev.jorel:commandapi-shade:8.8.0")
+    library("net.kyori:adventure-text-minimessage:4.13.0")
+    library("net.kyori:adventure-text-serializer-plain:4.13.0")
+    library("net.kyori:adventure-platform-bukkit:4.3.0")
 
     implementation("dev.triumphteam:triumph-gui:3.1.4")
     implementation("org.bstats:bstats-bukkit:3.0.0")
     implementation("com.github.oraxen:protectionlib:1.2.6")
-    implementation("net.kyori:adventure-text-minimessage:4.13.0")
-    implementation("net.kyori:adventure-text-serializer-plain:4.13.0")
-    implementation("net.kyori:adventure-platform-bukkit:4.3.0")
     implementation("com.github.stefvanschie.inventoryframework:IF:0.10.8")
     implementation("com.jeff_media:CustomBlockData:2.2.0")
     implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
@@ -102,7 +103,7 @@ tasks {
     shadowJar {
         //archiveClassifier = null
         relocate("org.bstats", "io.th0rgal.oraxen.shaded.bstats")
-        relocate("net.kyori", "io.th0rgal.oraxen.shaded.kyori")
+        //relocate("net.kyori", "io.th0rgal.oraxen.shaded.kyori")
         relocate("dev.triumphteam.gui", "io.th0rgal.oraxen.shaded.triumphteam.gui")
         relocate("com.jeff_media.customblockdata", "io.th0rgal.oraxen.shaded.customblockdata")
         relocate("com.jeff_media.morepersistentdatatypes", "io.th0rgal.oraxen.shaded.morepersistentdatatypes")
@@ -145,7 +146,7 @@ bukkit {
     softDepend = listOf("LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "BossShopPro", "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared", "NBTAPI", "ModelEngine", "CrashClaim")
     depend = listOf("ProtocolLib")
     loadBefore = listOf("Realistic_World")
-    libraries = listOf("org.springframework:spring-expression:6.0.6", "org.apache.httpcomponents:httpmime:4.5.13", "dev.jorel:commandapi-shade:8.8.0", "org.joml:joml:1.10.5")
+    libraries = listOf("org.apache.httpcomponents:httpmime:4.5.13")
     permissions.create("oraxen.command") {
         description = "Allows the player to use the /oraxen command"
         default = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission.Default.TRUE


### PR DESCRIPTION
Moves adventure api (and also some other libraries) from implementation to plugin.yml libraries.
Because of this, fully compiled plugin will weight less, and also adventure components added in paper api will be compatible with oraxen.