### PR TITLE
Adventure Component fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,8 @@ repositories {
 dependencies {
     val actionsVersion = "1.0.0-SNAPSHOT"
 
-    compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
     compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT") { exclude("net.kyori") }
+    compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.2")
     compileOnly("com.github.BeYkeRYkt:LightAPI:5.3.0-Bukkit")

--- a/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -9,6 +9,9 @@ import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.Utils;
+import net.kyori.adventure.text.Component;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
@@ -67,15 +70,15 @@ public class ItemParser {
         return type == null && mmoItem == null && crucibleItem != null;
     }
 
-    private String parseComponentString(String miniString) {
-        return AdventureUtils.LEGACY_SERIALIZER.serialize(AdventureUtils.MINI_MESSAGE.deserialize(miniString));
+    private Component parseComponentString(String miniString) {
+        return AdventureUtils.MINI_MESSAGE.deserialize(miniString);
     }
 
     public ItemBuilder buildItem() {
         return buildItem(section.contains("displayname") ? parseComponentString(section.getString("displayname")) : null);
     }
 
-    public ItemBuilder buildItem(String name) {
+    public ItemBuilder buildItem(Component name) {
         ItemBuilder item;
         if (usesCrucibleItems()) item = new ItemBuilder(crucibleItem);
         else if (usesMMOItems()) item = new ItemBuilder(mmoItem);
@@ -89,9 +92,10 @@ public class ItemParser {
     private ItemBuilder applyConfig(ItemBuilder item) {
 
         if (section.contains("lore")) {
-            List<String> lore = section.getStringList("lore");
-            lore.replaceAll(this::parseComponentString);
-            item.setLore(lore);
+            List<Component> lore = section.getStringList("lore").stream()
+                    .map(this::parseComponentString)
+                    .toList();
+            item.setComponentLore(lore);
         }
 
         if (section.contains("durability"))


### PR DESCRIPTION
**Won't work if #824 not merged!**

Makes item's name and lore use component(s) to support e.g. translatable components.

Should work only on paper (tested with commands on singleplayer, however not with compiled plugin on server, bc I don't have time rn)
![obraz](https://user-images.githubusercontent.com/67753196/236621506-6ce130a2-ade6-4d61-b60b-1579fe6901a0.png)
