### PR TITLE
fix disabling error when evolution task doesn't exist

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -21,6 +21,7 @@ import io.th0rgal.oraxen.hud.HudManager;
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionTask;
 import io.th0rgal.oraxen.pack.generation.ResourcePack;
 import io.th0rgal.oraxen.pack.upload.UploadManager;
 import io.th0rgal.oraxen.recipes.RecipesManager;
@@ -136,7 +137,10 @@ public class OraxenPlugin extends JavaPlugin {
     public void onDisable() {
         unregisterListeners();
         ItemUpdater.furnitureUpdateTask.cancel();
-        FurnitureFactory.getEvolutionTask().cancel();
+        EvolutionTask evolutionTask = FurnitureFactory.getEvolutionTask();
+        if(evolutionTask != null ){
+            evolutionTask.cancel();
+        }
 
         CompatibilitiesManager.disableCompatibilities();
         Message.PLUGIN_UNLOADED.log();


### PR DESCRIPTION
```
[20:16:31 ERROR]: Error occurred (in the plugin loader) while disabling Oraxen v1.157.2 (Is it up to date?)
java.lang.NullPointerException: Cannot invoke "io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionTask.cancel()" because the return value of "io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory.getEvolutionTask()" is null
	at io.th0rgal.oraxen.OraxenPlugin.onDisable(OraxenPlugin.java:139) ~[oraxen-1.157.2.jar:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:283) ~[paper-api-1.20.1-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugin(PaperPluginInstanceManager.java:224) ~[paper-1.20.1.jar:git-Paper-39]
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugins(PaperPluginInstanceManager.java:148) ~[paper-1.20.1.jar:git-Paper-39]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.disablePlugins(PaperPluginManagerImpl.java:92) ~[paper-1.20.1.jar:git-Paper-39]
	at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:528) ~[paper-api-1.20.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R1.CraftServer.disablePlugins(CraftServer.java:497) ~[paper-1.20.1.jar:git-Paper-39]
	at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:943) ~[paper-1.20.1.jar:git-Paper-39]
	at net.minecraft.server.dedicated.DedicatedServer.stopServer(DedicatedServer.java:806) ~[paper-1.20.1.jar:git-Paper-39]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1210) ~[paper-1.20.1.jar:git-Paper-39]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:318) ~[paper-1.20.1.jar:git-Paper-39]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```