### PR TITLE
Add minimum protocol requirement to send resource pack

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ repositories {
     maven("https://oss.sonatype.org/content/repositories/snapshots") // Because Spigot depends on Bungeecord ChatComponent-API
     maven("https://jitpack.io") // JitPack
     maven("https://repo.dmulloy2.net/repository/public/") // ProtocolLib
+    maven("https://repo.viaversion.com/") // ViaVersion
     maven("https://libraries.minecraft.net/") // Minecraft repo (commodore)
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/") // PlaceHolderAPI
     maven("https://maven.elmakers.com/repository/") // EffectLib
@@ -48,6 +49,7 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.20-R0.1-SNAPSHOT")
     compileOnly("io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT") { exclude("net.kyori") }
     compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0")
+    compileOnly("com.viaversion:viaversion-api:4.7.0")
     compileOnly("me.clip:placeholderapi:2.11.3")
     compileOnly("com.github.BeYkeRYkt:LightAPI:5.3.0-Bukkit")
     compileOnly("me.gabytm.util:actions-core:$actionsVersion")
@@ -143,7 +145,7 @@ bukkit {
     name = "Oraxen"
     apiVersion = "1.18"
     authors = listOf("th0rgal", "boy0000")
-    softDepend = listOf("LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "BossShopPro", "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared", "NBTAPI", "ModelEngine", "CrashClaim", "ViaBackwards")
+    softDepend = listOf("LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "BossShopPro", "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared", "NBTAPI", "ModelEngine", "CrashClaim", "ViaVersion", "ViaBackwards")
     depend = listOf("ProtocolLib")
     loadBefore = listOf("Realistic_World")
     libraries = listOf("org.springframework:spring-expression:6.0.6", "org.apache.httpcomponents:httpmime:4.5.13", "dev.jorel:commandapi-bukkit-shade:$commandApiVersion", "org.joml:joml:1.10.5")

--- a/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -89,6 +89,7 @@ public enum Settings {
     SEND_PACK_ADVANCED("Pack.dispatch.send_pack_advanced.enabled"),
     SEND_PACK_ADVANCED_MANDATORY("Pack.dispatch.send_pack_advanced.mandatory"),
     SEND_PACK_ADVANCED_MESSAGE("Pack.dispatch.send_pack_advanced.message"),
+    SEND_PACK_ADVANCED_MIN_PROTOCOL("Pack.dispatch.send_pack_advanced.min_protocol"),
     SEND_JOIN_MESSAGE("Pack.dispatch.join_message.enabled"),
     JOIN_MESSAGE_DELAY("Pack.dispatch.join_message.delay"),
 

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -85,6 +85,7 @@ Pack:
       enabled: true
       mandatory: true
       message: "<#fa4943>Accept the pack to enjoy a full <b><gradient:#9055FF:#13E2DA>Oraxen</b><#fa4943> experience"
+      min_protocol: -1
     join_message:
       enabled: false
       delay: -1


### PR DESCRIPTION
`min_protocol` config on advanced pack send
ViaVersion is used as optional dependency if it's present (the plugin override player protocol, so ProtocolLib cannot detect by itself)