### PR TITLE
Add OraxenPackGenerateEvent

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/api/events/OraxenPackGenerateEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/api/events/OraxenPackGenerateEvent.java
@@ -1,0 +1,23 @@
+package io.th0rgal.oraxen.api.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Lets other plugins detect when pack is being generated
+ */
+public class OraxenPackGenerateEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.api.events.OraxenPackGenerateEvent;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.config.ResourcesManager;
 import io.th0rgal.oraxen.config.Settings;
@@ -118,6 +119,8 @@ public class ResourcePack {
         if (Settings.GESTURES_ENABLED.toBool()) generateGestureFiles();
         if (Settings.HIDE_SCOREBOARD_NUMBERS.toBool()) generateScoreboardFiles();
         if (Settings.GENERATE_ARMOR_SHADER_FILES.toBool()) CustomArmorsTextures.generateArmorShaderFiles();
+
+        OraxenPlugin.get().getServer().getPluginManager().callEvent(new OraxenPackGenerateEvent());
 
         for (final Collection<Consumer<File>> packModifiers : packModifiers.values())
             for (Consumer<File> packModifier : packModifiers)


### PR DESCRIPTION
Adds OraxenPackGenerateEvent - allows plugins to correctly use methods like `Resourcepack#writeStringToVirtual` (which wasn't possible before because of clearing output files when generating pack)