### PR TITLE
Change checked protection for Thor Mechanic

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.159.0
+pluginVersion=1.160.0

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/spell/thor/ThorMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/spell/thor/ThorMechanicListener.java
@@ -36,7 +36,8 @@ public class ThorMechanicListener implements Listener {
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (event.useItemInHand() == Event.Result.DENY) return;
         if (BlockHelpers.isInteractable(block) && event.useInteractedBlock() == Event.Result.ALLOW) return;
-        if (!ProtectionLib.canUse(player, location)) return;
+        //if (!ProtectionLib.canUse(player, location)) return;
+        if (!ProtectionLib.canUse(player, player.getTargetBlock(null, 50).getLocation())) return;
         if (factory.isNotImplementedIn(itemID)) return;
         if (mechanic == null) return;
 


### PR DESCRIPTION
Instead of checking the protection for the block the player interacts with, I changed it to check for the block where the lightning is going to be summoned on. With a 50 blocks range, the interacted block tends to be a "safe" block even when pointing into a protected area where the player is not supposed to be summoning anything.