### PR TITLE
Change checked protection for Thor Mechanic

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/spell/thor/ThorMechanicListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/spell/thor/ThorMechanicListener.java
@@ -31,12 +31,12 @@ public class ThorMechanicListener implements Listener {
         String itemID = OraxenItems.getIdByItem(item);
         ThorMechanic mechanic = (ThorMechanic) factory.getMechanic(item);
         Block block = event.getClickedBlock();
-        Location location = block != null ? block.getLocation() : player.getLocation();
+        Location targetBlock = player.getTargetBlock(null, 50).getLocation();
 
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (event.useItemInHand() == Event.Result.DENY) return;
         if (BlockHelpers.isInteractable(block) && event.useInteractedBlock() == Event.Result.ALLOW) return;
-        if (!ProtectionLib.canUse(player, location)) return;
+        if (!ProtectionLib.canUse(player, targetBlock)) return;
         if (factory.isNotImplementedIn(itemID)) return;
         if (mechanic == null) return;
 
@@ -49,8 +49,7 @@ public class ThorMechanicListener implements Listener {
         playerTimer.reset();
         mechanic.removeCharge(item);
         for (int i = 0; i < mechanic.getLightningBoltsAmount(); i++) {
-            Location target = event.getPlayer().getTargetBlock(null, 50).getLocation();
-            player.getWorld().strikeLightning(mechanic.getRandomizedLocation(target));
+            player.getWorld().strikeLightning(mechanic.getRandomizedLocation(targetBlock));
         }
 
     }


### PR DESCRIPTION
This is the same as #1029, but I closed that one by mistake when changing my default branch name hehe.

Almost same explanation as before...
Repeated part:
> Instead of checking the protection for the block the player interacts with, I changed it to check for the block where the lightning is going to be summoned on. With a 50 blocks range, the interacted block tends to be a "safe" block even when pointing into a protected area where the player is not supposed to be summoning anything.

New info:
Due to how lightning mechanic works (affecting/burning entities such as villagers or pets away from the strike zone), it might be good to consider a 3x3 or 5x5 area check, but I decided to leave that to your opinion whether to do it that way or not.