### PR TITLE
1.164.0

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,11 +22,15 @@ dependencies {
     implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
     implementation("com.jeff-media:persistent-data-serializer:1.0")
     implementation("gs.mclo:java:2.2.1")
-    implementation("com.ticxo.playeranimator:PlayerAnimator:R1.2.7")
+    implementation("com.ticxo:PlayerAnimator:R1.2.8") { isChanging = true }
     implementation("org.jetbrains:annotations:24.0.1") { isTransitive = false }
 
     implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }
     paperweight.paperDevBundle("1.20.2-R0.1-SNAPSHOT")
+}
+
+configurations.all {
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
 }
 
 java {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
     implementation("com.jeff-media:persistent-data-serializer:1.0")
     implementation("gs.mclo:java:2.2.1")
-    implementation("com.ticxo:PlayerAnimator:R1.2.7")
+    implementation("com.ticxo.playeranimator:PlayerAnimator:R1.2.7")
     implementation("org.jetbrains:annotations:24.0.1") { isTransitive = false }
 
     implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -9,10 +9,7 @@ import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
 import io.th0rgal.oraxen.commands.CommandsManager;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
-import io.th0rgal.oraxen.config.ConfigsManager;
-import io.th0rgal.oraxen.config.Message;
-import io.th0rgal.oraxen.config.Settings;
-import io.th0rgal.oraxen.config.SettingsUpdater;
+import io.th0rgal.oraxen.config.*;
 import io.th0rgal.oraxen.font.FontManager;
 import io.th0rgal.oraxen.font.packets.InventoryPacketListener;
 import io.th0rgal.oraxen.font.packets.TitlePacketListener;
@@ -38,6 +35,7 @@ import io.th0rgal.oraxen.utils.inventories.InvManager;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+import net.minecraft.server.packs.resources.ResourceManager;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -54,6 +52,7 @@ public class OraxenPlugin extends JavaPlugin {
     private static OraxenPlugin oraxen;
     private static GestureManager gestureManager;
     private ConfigsManager configsManager;
+    private ResourcesManager resourceManager;
     private BukkitAudiences audience;
     private UploadManager uploadManager;
     private FontManager fontManager;
@@ -110,6 +109,7 @@ public class OraxenPlugin extends JavaPlugin {
         pluginManager.registerEvents(new CustomArmorListener(), this);
         NMSHandlers.setup();
 
+        resourceManager = new ResourcesManager(this);
         resourcePack = new ResourcePack();
         MechanicsManager.registerNativeMechanics();
         //CustomBlockData.registerListener(this); //Handle this manually
@@ -162,6 +162,10 @@ public class OraxenPlugin extends JavaPlugin {
         hudManager.unregisterEvents();
         MechanicsManager.unloadListeners();
         HandlerList.unregisterAll(this);
+    }
+
+    public ResourcesManager getResourceManager() {
+        return resourceManager;
     }
 
     public ProtocolManager getProtocolManager() {

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -116,7 +116,7 @@ public class OraxenPlugin extends JavaPlugin {
         hudManager = new HudManager(configsManager);
         fontManager = new FontManager(configsManager);
         soundManager = new SoundManager(configsManager.getSound());
-        gestureManager = !VersionUtil.isSupportedVersionOrNewer("1.20.2") ? new GestureManager() : null;
+        gestureManager = new GestureManager();
         OraxenItems.loadItems();
         fontManager.registerEvents();
         fontManager.verifyRequired(); // Verify the required glyph is there

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -90,7 +90,7 @@ public class OraxenPlugin extends JavaPlugin {
     public void onEnable() {
         CommandAPI.onEnable();
         ProtectionLib.init(this);
-        if (!VersionUtil.isSupportedVersionOrNewer("1.20.2")) PlayerAnimatorImpl.initialize(this);
+        PlayerAnimatorImpl.initialize(this);
         audience = BukkitAudiences.create(this);
         clickActionManager = new ClickActionManager(this);
         supportsDisplayEntities = VersionUtil.isSupportedVersionOrNewer("1.19.4");

--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
@@ -312,18 +312,21 @@ public class OraxenBlocks {
                         + noteblock.getNote().getId() + (noteblock.isPowered() ? 400 : 0) - 26);
     }
 
+    @org.jetbrains.annotations.Nullable
     public static NoteBlockMechanic getNoteBlockMechanic(String itemID) {
         if (!NoteBlockMechanicFactory.isEnabled()) return null;
         Mechanic mechanic = NoteBlockMechanicFactory.getInstance().getMechanic(itemID);
         return mechanic instanceof NoteBlockMechanic noteBlockMechanic ? noteBlockMechanic : null;
     }
 
+    @org.jetbrains.annotations.Nullable
     public static StringBlockMechanic getStringMechanic(BlockData blockData) {
         if (!StringBlockMechanicFactory.isEnabled()) return null;
         if (!(blockData instanceof Tripwire tripwire)) return null;
         return StringBlockMechanicFactory.getBlockMechanic(StringBlockMechanicFactory.getCode(tripwire));
     }
 
+    @org.jetbrains.annotations.Nullable
     public static StringBlockMechanic getStringMechanic(Block block) {
         if (!StringBlockMechanicFactory.isEnabled()) return null;
         if (block.getType() == Material.TRIPWIRE) {
@@ -332,12 +335,13 @@ public class OraxenBlocks {
         } else return null;
     }
 
+    @org.jetbrains.annotations.Nullable
     public static StringBlockMechanic getStringMechanic(String itemID) {
         if (!StringBlockMechanicFactory.isEnabled()) return null;
-        Mechanic mechanic = StringBlockMechanicFactory.getInstance().getMechanic(itemID);
-        return mechanic instanceof StringBlockMechanic stringMechanic ? stringMechanic : null;
+        return StringBlockMechanicFactory.getInstance().getMechanic(itemID);
     }
 
+    @org.jetbrains.annotations.Nullable
     public static BlockMechanic getBlockMechanic(Block block) {
         if (block.getType() == Material.MUSHROOM_STEM) {
             return BlockMechanicFactory.getBlockMechanic(BlockMechanic.getCode(block));

--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
@@ -16,6 +16,7 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMech
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanicListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.sapling.SaplingMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -227,8 +228,7 @@ public class OraxenBlocks {
 
         if (player != null) {
             OraxenNoteBlockBreakEvent noteBlockBreakEvent = new OraxenNoteBlockBreakEvent(mechanic, block, player);
-            OraxenPlugin.get().getServer().getPluginManager().callEvent(noteBlockBreakEvent);
-            if (noteBlockBreakEvent.isCancelled()) return;
+            if (!EventUtils.callEvent(noteBlockBreakEvent)) return;
 
             if (player.getGameMode() != GameMode.CREATIVE)
                 noteBlockBreakEvent.getDrop().spawns(block.getLocation(), player.getInventory().getItemInMainHand());
@@ -251,8 +251,7 @@ public class OraxenBlocks {
 
         if (player != null) {
             OraxenStringBlockBreakEvent wireBlockBreakEvent = new OraxenStringBlockBreakEvent(mechanic, block, player);
-            OraxenPlugin.get().getServer().getPluginManager().callEvent(wireBlockBreakEvent);
-            if (wireBlockBreakEvent.isCancelled()) return;
+            if (!EventUtils.callEvent(wireBlockBreakEvent)) return;
 
             if (player.getGameMode() != GameMode.CREATIVE)
                 wireBlockBreakEvent.getDrop().spawns(block.getLocation(), item);

--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
@@ -253,7 +253,7 @@ public class OraxenFurniture {
      */
     public static FurnitureMechanic getFurnitureMechanic(String itemID) {
         if (!FurnitureFactory.isEnabled() || !OraxenItems.exists(itemID)) return null;
-        return (FurnitureMechanic) FurnitureFactory.getInstance().getMechanic(itemID);
+        return FurnitureFactory.getInstance().getMechanic(itemID);
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/commands/PackCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/PackCommand.java
@@ -59,9 +59,8 @@ public class PackCommand {
                     final ZipInputStream zip = ResourcesManager.browse();
                     try {
                         ZipEntry entry = zip.getNextEntry();
-                        final ResourcesManager resourcesManager = new ResourcesManager(OraxenPlugin.get());
                         while (entry != null) {
-                            extract(entry, type, resourcesManager, (Boolean) args.getOptional("override").orElse(false));
+                            extract(entry, type, OraxenPlugin.get().getResourceManager(), (Boolean) args.getOptional("override").orElse(false));
                             entry = zip.getNextEntry();
                         }
                         zip.closeEntry();

--- a/core/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
@@ -29,6 +29,7 @@ public class ReloadCommand {
     public static void reloadItems(@Nullable CommandSender sender) {
         Message.RELOAD.send(sender, AdventureUtils.tagResolver("reloaded", "items"));
         OraxenItems.loadItems();
+        OraxenPlugin.get().getInvManager().regen();
         Bukkit.getPluginManager().callEvent(new OraxenItemsLoadedEvent());
 
         if (Settings.UPDATE_ITEMS.toBool() && Settings.UPDATE_ITEMS_ON_RELOAD.toBool()) {
@@ -89,10 +90,7 @@ public class ReloadCommand {
                 .executes((sender, args) -> {
                     switch (((String) args.get("type")).toUpperCase()) {
                         case "HUD" -> reloadHud(sender);
-                        case "ITEMS" -> {
-                            reloadItems(sender);
-                            OraxenPlugin.get().getInvManager().regen();
-                        }
+                        case "ITEMS" -> reloadItems(sender);
                         case "PACK" -> reloadPack(sender);
                         case "RECIPES" -> reloadRecipes(sender);
                         case "CONFIGS" -> OraxenPlugin.get().reloadConfigs();
@@ -104,7 +102,6 @@ public class ReloadCommand {
                             reloadPack(sender);
                             reloadHud(sender);
                             reloadRecipes(sender);
-                            OraxenPlugin.get().getInvManager().regen();
                         }
                     }
                     for (Player player : Bukkit.getOnlinePlayers()) {

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/ecoitems/WrappedEcoItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/ecoitems/WrappedEcoItem.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.compatibilities.provided.ecoitems;
 
 import com.willfp.ecoitems.items.EcoItem;
 import com.willfp.ecoitems.items.EcoItems;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 
@@ -17,6 +18,7 @@ public class WrappedEcoItem {
     }
 
     public ItemStack build() {
+        if (id == null || !Bukkit.getPluginManager().isPluginEnabled("EcoItems")) return null;
         EcoItem ecoItem = EcoItems.INSTANCE.getByID(id);
         return ecoItem != null ? ecoItem.getItemStack() : null;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mmoitems/WrappedMMOItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mmoitems/WrappedMMOItem.java
@@ -1,10 +1,13 @@
 package io.th0rgal.oraxen.compatibilities.provided.mmoitems;
 
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import net.Indyuce.mmoitems.MMOItems;
 import net.Indyuce.mmoitems.api.ItemTier;
 import net.Indyuce.mmoitems.api.Type;
 import net.Indyuce.mmoitems.api.item.build.MMOItemBuilder;
 import net.Indyuce.mmoitems.api.item.template.MMOItemTemplate;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 
@@ -16,15 +19,23 @@ public class WrappedMMOItem {
     private final ItemTier tier;
 
     public WrappedMMOItem(ConfigurationSection section) {
-        type = MMOItems.plugin.getTypes().getOrThrow(section.getString("type"));
-        id = section.getString("id");
+        if (!Bukkit.getPluginManager().isPluginEnabled("MMOItems")) {
+            Logs.logError("MMOItems is not installed");
+            type = null;
+            id = null;
+            level = 0;
+            tier = null;
+        } else {
+            type = MMOItems.plugin.getTypes().getOrThrow(section.getString("type"));
+            id = section.getString("id");
 
-        // Check if template exists
-        MMOItems.plugin.getTemplates().getTemplateOrThrow(type, id);
+            // Check if template exists
+            MMOItems.plugin.getTemplates().getTemplateOrThrow(type, id);
 
-        // Optional stuff
-        level = section.getInt("level", 1);
-        tier = section.isString("tier") ? MMOItems.plugin.getTiers().getOrThrow(section.getString("tier")) : null;
+            // Optional stuff
+            level = section.getInt("level", 1);
+            tier = section.isString("tier") ? MMOItems.plugin.getTiers().getOrThrow(section.getString("tier")) : null;
+        }
     }
 
     public WrappedMMOItem(Type type, String id, int level, ItemTier tier) {
@@ -42,10 +53,24 @@ public class WrappedMMOItem {
     }
 
     private MMOItemTemplate getTemplate() {
-        return MMOItems.plugin.getTemplates().getTemplateOrThrow(type, id);
+        try {
+            return MMOItems.plugin.getTemplates().getTemplateOrThrow(type, id);
+        } catch (Exception e) {
+            Logs.logError("Failed to load MMOItem " + id);
+            if (Settings.DEBUG.toBool()) Logs.logWarning(e.getMessage());
+            return null;
+        }
     }
 
     public ItemStack build() {
-        return new MMOItemBuilder(getTemplate(), level, tier).build().newBuilder().build();
+        try {
+            return new MMOItemBuilder(getTemplate(), level, tier).build().newBuilder().build();
+        } catch (Exception e) {
+            Logs.logError("Failed to load MMOItem " + id);
+            if (!Bukkit.getPluginManager().isPluginEnabled("MMOItems"))
+                Logs.logWarning("MMOItems is not installed");
+            if (Settings.DEBUG.toBool()) Logs.logWarning(e.getMessage());
+            return null;
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mythiccrucible/WrappedCrucibleItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mythiccrucible/WrappedCrucibleItem.java
@@ -1,12 +1,18 @@
 package io.th0rgal.oraxen.compatibilities.provided.mythiccrucible;
 
+import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.core.items.MythicItem;
 import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 public class WrappedCrucibleItem {
     private final String id;
@@ -19,12 +25,11 @@ public class WrappedCrucibleItem {
         this.id = id;
     }
 
+    @Nullable
     public ItemStack build() {
         try {
-            MythicBukkit crucible = MythicCrucible.core();
-            ItemStack item = crucible.getItemManager().getItemStack(id);
-            crucible.close();
-            return item;
+            Optional<MythicItem> maybeItem = MythicBukkit.inst().getItemManager().getItem(id);
+            return BukkitAdapter.adapt(maybeItem.orElseThrow().generateItemStack(1));
         } catch (Exception e) {
             Logs.logError("Failed to load MythicCrucible item " + id);
             if (!Bukkit.getPluginManager().isPluginEnabled("MythicCrucible"))

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mythiccrucible/WrappedCrucibleItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mythiccrucible/WrappedCrucibleItem.java
@@ -4,6 +4,7 @@ import io.lumine.mythic.bukkit.MythicBukkit;
 import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.logs.Logs;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 
@@ -19,10 +20,15 @@ public class WrappedCrucibleItem {
     }
 
     public ItemStack build() {
-        try(MythicBukkit crucible = MythicCrucible.core()) {
-            return crucible.getItemManager().getItemStack(id);
+        try {
+            MythicBukkit crucible = MythicCrucible.core();
+            ItemStack item = crucible.getItemManager().getItemStack(id);
+            crucible.close();
+            return item;
         } catch (Exception e) {
             Logs.logError("Failed to load MythicCrucible item " + id);
+            if (!Bukkit.getPluginManager().isPluginEnabled("MythicCrucible"))
+                Logs.logWarning("MythicCrucible is not installed");
             if (Settings.DEBUG.toBool()) Logs.logWarning(e.getMessage());
             return null;
         }

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -115,7 +115,7 @@ public class ConfigsManager {
         if (!itemsFolder.exists()) {
             itemsFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                new ResourcesManager(plugin).extractConfigsInFolder("items", "yml");
+                OraxenPlugin.get().getResourceManager().extractConfigsInFolder("items", "yml");
         }
 
         // check glyphsFolder
@@ -123,8 +123,8 @@ public class ConfigsManager {
         if (!glyphsFolder.exists()) {
             glyphsFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                new ResourcesManager(plugin).extractConfigsInFolder("glyphs", "yml");
-            else new ResourcesManager(plugin).extractConfiguration("glyphs/interface.yml");
+                OraxenPlugin.get().getResourceManager().extractConfigsInFolder("glyphs", "yml");
+            else OraxenPlugin.get().getResourceManager().extractConfiguration("glyphs/interface.yml");
         }
 
         // check schematicsFolder
@@ -132,7 +132,7 @@ public class ConfigsManager {
         if (!schematicsFolder.exists()) {
             schematicsFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                new ResourcesManager(plugin).extractConfigsInFolder("schematics", "schem");
+                OraxenPlugin.get().getResourceManager().extractConfigsInFolder("schematics", "schem");
         }
 
         // check gestures
@@ -140,7 +140,7 @@ public class ConfigsManager {
         if (!gesturesFolder.exists()) {
             gesturesFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                new ResourcesManager(plugin).extractConfigsInFolder("gestures", "yml");
+                OraxenPlugin.get().getResourceManager().extractConfigsInFolder("gestures", "yml");
         }
 
     }
@@ -230,9 +230,8 @@ public class ConfigsManager {
     }
 
     public Map<File, Map<String, ItemBuilder>> parseItemConfig() {
-
         Map<File, Map<String, ItemBuilder>> parseMap = new LinkedHashMap<>();
-        for (File file : getItemFiles()) parseMap.put(file, parseItemConfig(OraxenYaml.loadConfiguration(file), file));
+        for (File file : getItemFiles()) parseMap.put(file, parseItemConfig(file));
         return parseMap;
     }
 
@@ -301,7 +300,8 @@ public class ConfigsManager {
         return model;
     }
 
-    public Map<String, ItemBuilder> parseItemConfig(YamlConfiguration config, File itemFile) {
+    public Map<String, ItemBuilder> parseItemConfig(File itemFile) {
+        YamlConfiguration config = OraxenYaml.loadConfiguration(itemFile);
         Map<String, ItemParser> parseMap = new LinkedHashMap<>();
         ItemParser errorItem = new ItemParser(Settings.ERROR_ITEM.toConfigSection());
         for (String itemKey : config.getKeys(false)) {

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -71,6 +71,7 @@ public enum Settings {
     FIX_FORCE_UNICODE_GLYPHS("Pack.generation.fix_force_unicode_glyphs"),
     VERIFY_PACK_FILES("Pack.generation.verify_pack_files"),
     GENERATE_ATLAS_FILE("Pack.generation.atlas.generate"),
+    TEXTURE_SLICER("Pack.generation.texture_slicer"),
     EXCLUDE_MALFORMED_ATLAS("Pack.generation.atlas.exclude_malformed_from_atlas"),
     ATLAS_GENERATION_TYPE("Pack.generation.atlas.type"),
     GENERATE_MODEL_BASED_ON_TEXTURE_PATH("Pack.generation.auto_generated_models_follow_texture_path"),

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -46,8 +46,8 @@ public class FontEvents implements Listener {
     public FontEvents(FontManager manager) {
         this.manager = manager;
         Bukkit.getPluginManager().registerEvents(
-                VersionUtil.isPaperServer() ? new PaperChatHandler() : new SpigotChatHandler()
-                , OraxenPlugin.get());
+                VersionUtil.isPaperServer() && VersionUtil.isSupportedVersionOrNewer("1.19.1")
+                        ? new PaperChatHandler() : new SpigotChatHandler(), OraxenPlugin.get());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/core/src/main/java/io/th0rgal/oraxen/gestures/GestureManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/gestures/GestureManager.java
@@ -5,7 +5,6 @@ import com.ticxo.playeranimator.api.animation.pack.AnimationPack;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
-import io.th0rgal.oraxen.utils.VersionUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
@@ -18,7 +17,7 @@ public class GestureManager {
 
     public GestureManager() {
         gesturingPlayers = new HashMap<>();
-        if (Settings.GESTURES_ENABLED.toBool() && !VersionUtil.isSupportedVersionOrNewer("1.20.2")) {
+        if (Settings.GESTURES_ENABLED.toBool()) {
             loadGestures();
             Bukkit.getPluginManager().registerEvents(new GestureListener(this), OraxenPlugin.get());
         }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -77,7 +77,7 @@ public class ItemBuilder {
         this(wrapped.build());
     }
 
-    public ItemBuilder(@NotNull final ItemStack itemStack) {
+    public ItemBuilder(@NotNull ItemStack itemStack) {
 
         this.itemStack = itemStack;
 

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -213,11 +213,7 @@ public class ItemParser {
                 if (mechanicSection == null) continue;
                 //if (mechanicID.equals("furniture") && !FurnitureFactory.setDefaultType(mechanicSection)) configUpdated = true;
                 Mechanic mechanic = factory.parse(mechanicSection);
-                if (mechanic instanceof FurnitureMechanic furnitureMechanic)
-                    if (section.getName().equals("table")) {
-                        Logs.debug(mechanicsSection.getConfigurationSection(mechanicID).getBoolean("barrier"));
-                    }
-                    // Apply item modifiers
+                // Apply item modifiers
                 for (Function<ItemBuilder, ItemBuilder> itemModifier : mechanic.getItemModifiers())
                     item = itemModifier.apply(item);
             }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -52,11 +52,10 @@ public class ItemParser {
         else if (ecoItemSection != null) ecoItem = new WrappedEcoItem(ecoItemSection);
         else if (section.isString("ecoitem_id")) ecoItem = new WrappedEcoItem(section.getString("ecoitem_id"));
         else if (mmoSection != null) mmoItem = new WrappedMMOItem(mmoSection);
-        else {
-            Material material = Material.getMaterial(section.getString("material", ""));
-            if (material == null) material = usesTemplate() ? templateItem.type : Material.PAPER;
-            type = material;
-        }
+
+        Material material = Material.getMaterial(section.getString("material", ""));
+        if (material == null) material = usesTemplate() ? templateItem.type : Material.PAPER;
+        type = material;
 
         oraxenMeta = new OraxenMeta();
         if (section.isConfigurationSection("Pack")) {
@@ -70,15 +69,15 @@ public class ItemParser {
     }
 
     public boolean usesMMOItems() {
-        return type == null && crucibleItem == null && ecoItem == null  && mmoItem != null;
+        return crucibleItem == null && ecoItem == null  && mmoItem != null && mmoItem.build() != null;
     }
 
     public boolean usesCrucibleItems() {
-        return type == null && mmoItem == null && ecoItem == null && crucibleItem != null;
+        return mmoItem == null && ecoItem == null && crucibleItem != null && crucibleItem.build() != null;
     }
 
     public boolean usesEcoItems() {
-        return type == null && mmoItem == null && crucibleItem == null && ecoItem != null;
+        return mmoItem == null && crucibleItem == null && ecoItem != null && ecoItem.build() != null;
     }
 
     public boolean usesTemplate() {

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.items;
 
+import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
 import io.th0rgal.oraxen.compatibilities.provided.mmoitems.WrappedMMOItem;
@@ -8,8 +9,10 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.Utils;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -32,7 +35,7 @@ public class ItemParser {
 
     private final OraxenMeta oraxenMeta;
     private final ConfigurationSection section;
-    private Material type;
+    private final Material type;
     private WrappedMMOItem mmoItem;
     private WrappedCrucibleItem crucibleItem;
     private WrappedEcoItem ecoItem;
@@ -204,12 +207,17 @@ public class ItemParser {
         ConfigurationSection mechanicsSection = section.getConfigurationSection("Mechanics");
         if (mechanicsSection != null) for (String mechanicID : mechanicsSection.getKeys(false)) {
             MechanicFactory factory = MechanicsManager.getMechanicFactory(mechanicID);
+
             if (factory != null) {
                 ConfigurationSection mechanicSection = mechanicsSection.getConfigurationSection(mechanicID);
                 if (mechanicSection == null) continue;
                 //if (mechanicID.equals("furniture") && !FurnitureFactory.setDefaultType(mechanicSection)) configUpdated = true;
                 Mechanic mechanic = factory.parse(mechanicSection);
-                // Apply item modifiers
+                if (mechanic instanceof FurnitureMechanic furnitureMechanic)
+                    if (section.getName().equals("table")) {
+                        Logs.debug(mechanicsSection.getConfigurationSection(mechanicID).getBoolean("barrier"));
+                    }
+                    // Apply item modifiers
                 for (Function<ItemBuilder, ItemBuilder> itemModifier : mechanic.getItemModifiers())
                     item = itemModifier.apply(item);
             }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
@@ -7,6 +7,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.Utils;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
@@ -147,6 +148,10 @@ public class ItemUpdater implements Listener {
 
             if (itemMeta instanceof MapMeta mapMeta && oldMeta instanceof MapMeta oldMapMeta) {
                 mapMeta.setColor(oldMapMeta.getColor());
+            }
+
+            if (VersionUtil.isSupportedVersionOrNewer("1.20") && itemMeta instanceof ArmorMeta armorMeta && oldMeta instanceof ArmorMeta oldArmorMeta) {
+                armorMeta.setTrim(oldArmorMeta.getTrim());
             }
 
             // Parsing with legacy here to fix any inconsistensies caused by server serializers etc

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -37,6 +37,7 @@ import io.th0rgal.oraxen.mechanics.provided.misc.itemtype.ItemTypeMechanicFactor
 import io.th0rgal.oraxen.mechanics.provided.misc.misc.MiscMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.misc.soulbound.SoulBoundMechanicFactory;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -151,7 +152,11 @@ public class MechanicsManager {
     public static void registerListeners(final JavaPlugin plugin, String mechanicId, final Listener... listeners) {
         for (final Listener listener : listeners)
             Bukkit.getPluginManager().registerEvents(listener, plugin);
-        MECHANICS_LISTENERS.put(mechanicId, Arrays.stream(listeners).toList());
+        MECHANICS_LISTENERS.compute(mechanicId, (key, value) -> {
+            if (value == null) value = new ArrayList<>();
+            value.addAll(Arrays.asList(listeners));
+            return value;
+        });
     }
 
     public static void unloadListeners() {
@@ -160,7 +165,7 @@ public class MechanicsManager {
     }
 
     public static void unloadListeners(String mechanicId) {
-        for (Listener listener : MECHANICS_LISTENERS.remove(mechanicId))
+        for (final Listener listener : MECHANICS_LISTENERS.remove(mechanicId))
             HandlerList.unregisterAll(listener);
 
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -107,15 +107,16 @@ public class MechanicsManager {
 
     /**
      * Register a new MechanicFactory
+     *
      * @param mechanicId the id of the mechanic
-     * @param factory the MechanicFactory of the mechanic
-     * @param enabled if the mechanic should be enabled by default or not
+     * @param factory    the MechanicFactory of the mechanic
+     * @param enabled    if the mechanic should be enabled by default or not
      */
     public static void registerMechanicFactory(String mechanicId, MechanicFactory factory, boolean enabled) {
         if (enabled) FACTORIES_BY_MECHANIC_ID.put(mechanicId, factory);
     }
 
-    public static void  unregisterMechanicFactory(String mechanicId) {
+    public static void unregisterMechanicFactory(String mechanicId) {
         FACTORIES_BY_MECHANIC_ID.remove(mechanicId);
         unloadListeners(mechanicId);
     }
@@ -123,7 +124,8 @@ public class MechanicsManager {
     /**
      * This method is deprecated and will be removed in a future release.<br>
      * Use {@link #registerMechanicFactory(String, MechanicFactory, boolean)} instead.
-     * @param mechanicId the id of the mechanic
+     *
+     * @param mechanicId  the id of the mechanic
      * @param constructor the constructor of the mechanic
      */
     @Deprecated(forRemoval = true, since = "1.158.0")
@@ -132,28 +134,23 @@ public class MechanicsManager {
     }
 
     private static void registerFactory(final String mechanicId, final FactoryConstructor constructor) {
-        final Entry<File, YamlConfiguration> mechanicsEntry = new ResourcesManager(OraxenPlugin.get()).getMechanicsEntry();
+        final Entry<File, YamlConfiguration> mechanicsEntry = OraxenPlugin.get().getResourceManager().getMechanicsEntry();
         final YamlConfiguration mechanicsConfig = mechanicsEntry.getValue();
         final boolean updated = false;
-        if (mechanicsConfig.getKeys(false).contains(mechanicId)) {
-            final ConfigurationSection factorySection = mechanicsConfig.getConfigurationSection(mechanicId);
-            if (factorySection.getBoolean("enabled")) {
-                final MechanicFactory factory = constructor.create(factorySection);
-                FACTORIES_BY_MECHANIC_ID.put(mechanicId, factory);
-            }
+        ConfigurationSection factorySection = mechanicsConfig.getConfigurationSection(mechanicId);
+        if (factorySection != null && factorySection.getBoolean("enabled"))
+            FACTORIES_BY_MECHANIC_ID.put(mechanicId, constructor.create(factorySection));
+
+        try {
+            if (updated) mechanicsConfig.save(mechanicsEntry.getKey());
+        } catch (final IOException e) {
+            e.printStackTrace();
         }
-        if (updated)
-            try {
-                mechanicsConfig.save(mechanicsEntry.getKey());
-            } catch (final IOException e) {
-                e.printStackTrace();
-            }
     }
 
     public static void registerListeners(final JavaPlugin plugin, String mechanicId, final Listener... listeners) {
-        for (final Listener listener : listeners) {
+        for (final Listener listener : listeners)
             Bukkit.getPluginManager().registerEvents(listener, plugin);
-        }
         MECHANICS_LISTENERS.put(mechanicId, Arrays.stream(listeners).toList());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/spell/energyblast/EnergyBlastMechanicManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/spell/energyblast/EnergyBlastMechanicManager.java
@@ -4,6 +4,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.VectorUtils;
 import io.th0rgal.oraxen.utils.timers.Timer;
 import io.th0rgal.protectionlib.ProtectionLib;
@@ -116,7 +117,7 @@ public class EnergyBlastMechanicManager implements Listener {
                     for (Entity entity : playerLoc.getWorld().getNearbyEntities(playerLoc, 0.5, 0.5, 0.5))
                         if (entity instanceof LivingEntity livingEntity && entity != player) {
                             EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(player, entity, EntityDamageEvent.DamageCause.MAGIC, mechanic.getDamage() * 3.0);
-                            if (entity.isDead() || event.callEvent()) continue;
+                            if (entity.isDead() || EventUtils.callEvent(event)) continue;
                             entity.setLastDamageCause(event);
                             livingEntity.damage(mechanic.getDamage() * 3.0, player);
                         }
@@ -128,7 +129,7 @@ public class EnergyBlastMechanicManager implements Listener {
                 for (Entity entity : playerLoc.getWorld().getNearbyEntities(playerLoc, radius, radius, radius))
                     if (entity instanceof LivingEntity livingEntity && entity != player) {
                         EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(player, livingEntity, EntityDamageEvent.DamageCause.MAGIC, mechanic.getDamage());
-                        if (livingEntity.isDead() || !event.callEvent()) continue;
+                        if (livingEntity.isDead() || !EventUtils.callEvent(event)) continue;
                         livingEntity.setLastDamageCause(event);
                         livingEntity.damage(mechanic.getDamage(), player);
                     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/hat/HatMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/hat/HatMechanicListener.java
@@ -2,8 +2,8 @@ package io.th0rgal.oraxen.mechanics.provided.cosmetic.hat;
 
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.armorequipevent.ArmorEquipEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
@@ -70,7 +70,7 @@ public class HatMechanicListener implements Listener {
         if (inventory.getHelmet() != null) return;
 
         event.setCancelled(true);
-        if (!ArmorEquipEvent.OraxenHatEquipEvent(player, null, item).callEvent()) return;
+        if (!EventUtils.callEvent(ArmorEquipEvent.OraxenHatEquipEvent(player, null, item))) return;
 
         final ItemStack helmet = item.clone();
         helmet.setAmount(1);
@@ -106,7 +106,7 @@ public class HatMechanicListener implements Listener {
                 itemID = OraxenItems.getIdByItem(currentItem);
                 if (factory.isNotImplementedIn(itemID)) return;
 
-                if (!ArmorEquipEvent.OraxenHatEquipEvent(player, currentItem, cursor).callEvent())
+                if (!EventUtils.callEvent(ArmorEquipEvent.OraxenHatEquipEvent(player, currentItem, cursor)))
                     e.setCancelled(true);
             }
         } else {
@@ -118,8 +118,7 @@ public class HatMechanicListener implements Listener {
 
             if (currentItem == null || currentItem.getType() == Material.AIR) {
                 final ArmorEquipEvent armorEquipEvent = ArmorEquipEvent.OraxenHatEquipEvent(player, currentItem, clone);
-                Bukkit.getServer().getPluginManager().callEvent(armorEquipEvent);
-                if (armorEquipEvent.isCancelled()) return;
+                if (!EventUtils.callEvent(armorEquipEvent)) return;
 
                 e.setCancelled(true);
                 player.getInventory().setHelmet(armorEquipEvent.getNewArmorPiece());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bigmining/BigMiningMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bigmining/BigMiningMechanicListener.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.mechanics.provided.farming.bigmining;
 
 import io.th0rgal.oraxen.utils.Constants;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -67,7 +68,7 @@ public class BigMiningMechanicListener implements Listener {
         blocksToProcess += 1; // to avoid this method to call itself <- need other way to handle players using
         // the same tool at the same time
         final BlockBreakEvent event = new BlockBreakEvent(block, player);
-        if (!factory.callEvents() || !event.callEvent()) return;
+        if (!factory.callEvents() || !EventUtils.callEvent(event)) return;
         if (event.isDropItems()) block.breakNaturally(itemStack, true);
         else block.setType(Material.AIR);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bottledexp/BottledExpMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bottledexp/BottledExpMechanicListener.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.mechanics.provided.farming.bottledexp;
 
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Message;
+import io.th0rgal.oraxen.utils.EventUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -38,7 +39,7 @@ public class BottledExpMechanicListener implements Listener {
             player.setLevel(0);
             player.setExp(0);
 
-            new PlayerItemDamageEvent(player, item, factory.getDurabilityCost()).callEvent();
+            EventUtils.callEvent(new PlayerItemDamageEvent(player, item, factory.getDurabilityCost()));
         }
         else Message.NOT_ENOUGH_EXP.send(player);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/harvesting/HarvestingMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/harvesting/HarvestingMechanicListener.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.mechanics.provided.farming.harvesting;
 
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.timers.Timer;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.Location;
@@ -94,7 +95,7 @@ public class HarvestingMechanicListener implements Listener {
         }
 
         if (mechanic.shouldLowerItemDurability() && item.getItemMeta() instanceof Damageable && durabilityDamage > 0) {
-            new PlayerItemDamageEvent(player, item, durabilityDamage).callEvent();
+            EventUtils.callEvent(new PlayerItemDamageEvent(player, item, durabilityDamage));
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/block/BlockMechanicListener.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.limitedplacing.LimitedPlacing;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.Bukkit;
@@ -132,7 +133,7 @@ public class BlockMechanicListener implements Listener {
         target.setBlockData(newBlockData); // false to cancel physic
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(target, currentBlockState, placedAgainst, item, player, true, event.getHand());
         if (player.getGameMode() == GameMode.ADVENTURE) blockPlaceEvent.setCancelled(true);
-        if (!blockPlaceEvent.callEvent() || !blockPlaceEvent.canBuild()) {
+        if (!EventUtils.callEvent(blockPlaceEvent) || !blockPlaceEvent.canBuild()) {
             target.setBlockData(curentBlockData, false); // false to cancel physic
             return;
         }
@@ -153,7 +154,7 @@ public class BlockMechanicListener implements Listener {
         BlockMechanic mechanic = OraxenBlocks.getBlockMechanic(block);
         if (mechanic == null || !mechanic.canIgnite()) return;
         if (item.getType() != Material.FLINT_AND_STEEL && item.getType() != Material.FIRE_CHARGE) return;
-        new BlockIgniteEvent(block, BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL, event.getPlayer()).callEvent();
+        EventUtils.callEvent(new BlockIgniteEvent(block, BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL, event.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanic.java
@@ -34,24 +34,19 @@ public class DurabilityMechanic extends Mechanic {
 
     public void changeDurability(ItemStack item, int amount) {
         DurabilityMechanic durabilityMechanic = this;
-        AtomicBoolean check = new AtomicBoolean(false);
 
         Utils.editItemMeta(item, (itemMeta) -> {
             PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-            check.set(pdc.has(DurabilityMechanic.DURABILITY_KEY, PersistentDataType.INTEGER));
 
-            if (check.get()) {
-                if(!(itemMeta instanceof Damageable damageable)) {
-                    check.set(true);
-                    return;
-                }
+            if (pdc.has(DurabilityMechanic.DURABILITY_KEY, PersistentDataType.INTEGER)) {
+                if(!(itemMeta instanceof Damageable damageable)) return;
 
                 int baseMaxDurab = item.getType().getMaxDurability();
                 int realMaxDurab = durabilityMechanic.getItemMaxDurability(); // because int rounded values suck
                 int realDurabRemain = pdc.getOrDefault(DURABILITY_KEY, PersistentDataType.INTEGER, realMaxDurab);
 
                 // If item was max durab before damage, set the fake one
-                if (damageable.getDamage() != 0 && realDurabRemain == realMaxDurab) {
+                if (damageable.hasDamage() && realDurabRemain == realMaxDurab) {
                     pdc.set(DURABILITY_KEY, PersistentDataType.INTEGER,
                             (int) (realMaxDurab - (((double) damageable.getDamage() / (double) baseMaxDurab) * realMaxDurab)));
                     item.setItemMeta(itemMeta);
@@ -67,6 +62,5 @@ public class DurabilityMechanic extends Mechanic {
                 }
             }
         });
-        check.get();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanic.java
@@ -32,35 +32,38 @@ public class DurabilityMechanic extends Mechanic {
         return itemDurability;
     }
 
-    public void changeDurability(ItemStack item, int amount) {
+    public boolean changeDurability(ItemStack item, int amount) {
         DurabilityMechanic durabilityMechanic = this;
+        AtomicBoolean check = new AtomicBoolean(false);
 
         Utils.editItemMeta(item, (itemMeta) -> {
             PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            check.set(pdc.has(DurabilityMechanic.DURABILITY_KEY, PersistentDataType.INTEGER));
 
-            if (pdc.has(DurabilityMechanic.DURABILITY_KEY, PersistentDataType.INTEGER)) {
-                if(!(itemMeta instanceof Damageable damageable)) return;
+            if (check.get()) {
+                if(!(itemMeta instanceof Damageable damageable)) check.set(true);
+                else {
+                    int baseMaxDurab = item.getType().getMaxDurability();
+                    int realMaxDurab = durabilityMechanic.getItemMaxDurability(); // because int rounded values suck
+                    int realDurabRemain = pdc.getOrDefault(DURABILITY_KEY, PersistentDataType.INTEGER, realMaxDurab);
 
-                int baseMaxDurab = item.getType().getMaxDurability();
-                int realMaxDurab = durabilityMechanic.getItemMaxDurability(); // because int rounded values suck
-                int realDurabRemain = pdc.getOrDefault(DURABILITY_KEY, PersistentDataType.INTEGER, realMaxDurab);
-
-                // If item was max durab before damage, set the fake one
-                if (damageable.hasDamage() && realDurabRemain == realMaxDurab) {
-                    pdc.set(DURABILITY_KEY, PersistentDataType.INTEGER,
-                            (int) (realMaxDurab - (((double) damageable.getDamage() / (double) baseMaxDurab) * realMaxDurab)));
-                    item.setItemMeta(itemMeta);
-                    // Call function again to have itemmeta stick and run below part aswell
-                    changeDurability(item, amount);
-                } else {
-                    realDurabRemain = realDurabRemain + amount;
-                    if (realDurabRemain > 0) {
-                        pdc.set(DURABILITY_KEY, PersistentDataType.INTEGER, realDurabRemain);
-                        //TODO Figure out why when mending this sets the durability abit too high in the actual Damagable meta
-                        (damageable).setDamage((int) ((double) baseMaxDurab - (((double) realDurabRemain / realMaxDurab) * (double) baseMaxDurab)));
-                    } else item.setAmount(0);
+                    // If item was max durab before damage, set the fake one
+                    if (damageable.hasDamage() && realDurabRemain == realMaxDurab) {
+                        pdc.set(DURABILITY_KEY, PersistentDataType.INTEGER,
+                                (int) (realMaxDurab - (((double) damageable.getDamage() / (double) baseMaxDurab) * realMaxDurab)));
+                        item.setItemMeta(itemMeta);
+                        // Call function again to have itemmeta stick and run below part aswell
+                        changeDurability(item, amount);
+                    } else {
+                        realDurabRemain = realDurabRemain + amount;
+                        if (realDurabRemain > 0) {
+                            pdc.set(DURABILITY_KEY, PersistentDataType.INTEGER, realDurabRemain);
+                            (damageable).setDamage((int) ((double) baseMaxDurab - (((double) realDurabRemain / realMaxDurab) * (double) baseMaxDurab)));
+                        } else item.setAmount(0);
+                    }
                 }
             }
         });
+        return check.get();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicFactory.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
 
 public class DurabilityMechanicFactory extends MechanicFactory {
 
@@ -25,5 +26,15 @@ public class DurabilityMechanicFactory extends MechanicFactory {
 
     public static DurabilityMechanicFactory get() {
         return instance;
+    }
+
+    @Override
+    public DurabilityMechanic getMechanic(String itemId) {
+        return (DurabilityMechanic) super.getMechanic(itemId);
+    }
+
+    @Override
+    public DurabilityMechanic getMechanic(ItemStack itemStack) {
+        return (DurabilityMechanic) super.getMechanic(itemStack);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
@@ -17,7 +17,7 @@ public class DurabilityMechanicManager implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onItemDamaged(PlayerItemDamageEvent event) {
-        DurabilityMechanic mechanic = (DurabilityMechanic) factory.getMechanic(OraxenItems.getIdByItem(event.getItem()));
+        DurabilityMechanic mechanic = factory.getMechanic(event.getItem());
         if (mechanic == null) return;
         mechanic.changeDurability(event.getItem(), -event.getDamage());
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
@@ -19,13 +19,18 @@ public class DurabilityMechanicManager implements Listener {
     public void onItemDamaged(PlayerItemDamageEvent event) {
         DurabilityMechanic mechanic = factory.getMechanic(event.getItem());
         if (mechanic == null) return;
-        mechanic.changeDurability(event.getItem(), -event.getDamage());
+        if (mechanic.changeDurability(event.getItem(), -event.getDamage())) {
+            event.setDamage(0);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onItemMend(PlayerItemMendEvent event) {
         DurabilityMechanic mechanic = (DurabilityMechanic) factory.getMechanic(OraxenItems.getIdByItem(event.getItem()));
         if (mechanic == null) return;
-        mechanic.changeDurability(event.getItem(), event.getRepairAmount());
+
+        if (mechanic.changeDurability(event.getItem(), event.getRepairAmount())) {
+            event.setRepairAmount(0);
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -31,7 +31,7 @@ public class FurnitureFactory extends MechanicFactory {
         toolTypes = section.getStringList("tool_types");
         evolutionCheckDelay = section.getInt("evolution_check_delay");
         MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(),
-                new FurnitureListener(this),
+                new FurnitureListener(),
                 new FurnitureUpdater(),
                 new EvolutionListener(),
                 new JukeboxListener()

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -85,4 +85,14 @@ public class FurnitureFactory extends MechanicFactory {
             evolutionTask.cancel();
     }
 
+    @Override
+    public FurnitureMechanic getMechanic(String itemID) {
+        return (FurnitureMechanic) super.getMechanic(itemID);
+    }
+
+    @Override
+    public FurnitureMechanic getMechanic(org.bukkit.inventory.ItemStack itemStack) {
+        return (FurnitureMechanic) super.getMechanic(itemStack);
+    }
+
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -53,7 +53,7 @@ import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureM
 
 public class FurnitureListener implements Listener {
 
-    public FurnitureListener(final MechanicFactory factory) {
+    public FurnitureListener() {
         BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -13,6 +13,7 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.limitedplacing.LimitedPlaci
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.storage.StorageMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
@@ -180,7 +181,7 @@ public class FurnitureListener implements Listener {
         Utils.swingHand(player, event.getHand());
 
         final OraxenFurniturePlaceEvent furniturePlaceEvent = new OraxenFurniturePlaceEvent(mechanic, block, baseEntity, player, item, hand);
-        if (!furniturePlaceEvent.callEvent()) {
+        if (!EventUtils.callEvent(furniturePlaceEvent)) {
             OraxenFurniture.remove(baseEntity, null);
             block.setBlockData(currentBlockData);
             return;
@@ -250,7 +251,7 @@ public class FurnitureListener implements Listener {
         if (entity == null) return;
         if (!ProtectionLib.canBreak(player, entity.getLocation())) return;
         OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, entity, player, entity.getLocation().getBlock());
-        if (!furnitureBreakEvent.callEvent()) return;
+        if (!EventUtils.callEvent(furnitureBreakEvent)) return;
         OraxenFurniture.remove(entity, player, furnitureBreakEvent.getDrop());
     }
 
@@ -268,7 +269,7 @@ public class FurnitureListener implements Listener {
         if (baseEntity == null) return;
 
         OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, baseEntity, player, block);
-        if (!furnitureBreakEvent.callEvent()) {
+        if (!EventUtils.callEvent(furnitureBreakEvent)) {
             event.setCancelled(true);
             return;
         }
@@ -334,7 +335,7 @@ public class FurnitureListener implements Listener {
         }
 
         ItemStack itemInHand = hand == EquipmentSlot.HAND ? player.getInventory().getItemInMainHand() : player.getInventory().getItemInOffHand();
-        new OraxenFurnitureInteractEvent(mechanic, baseEntity, player, itemInHand, hand).callEvent();
+        EventUtils.callEvent(new OraxenFurnitureInteractEvent(mechanic, baseEntity, player, itemInHand, hand));
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -353,7 +354,7 @@ public class FurnitureListener implements Listener {
         final Entity baseEntity = mechanic.getBaseEntity(block);
         if (baseEntity == null) return;
 
-        new OraxenFurnitureInteractEvent(mechanic, baseEntity, player, event.getItem(), hand, block, event.getBlockFace()).callEvent();
+        EventUtils.callEvent(new OraxenFurnitureInteractEvent(mechanic, baseEntity, player, event.getItem(), hand, block, event.getBlockFace()));
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -17,6 +17,7 @@ import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -52,11 +53,7 @@ import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureM
 
 public class FurnitureListener implements Listener {
 
-    private final MechanicFactory factory;
-
-
     public FurnitureListener(final MechanicFactory factory) {
-        this.factory = factory;
         BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 
@@ -207,11 +204,11 @@ public class FurnitureListener implements Listener {
     private FurnitureMechanic getMechanic(ItemStack item, Player player, Block placed) {
         final String itemID = OraxenItems.getIdByItem(item);
         if (placed == null || itemID == null) return null;
-        if (factory.isNotImplementedIn(itemID) || BlockHelpers.isStandingInside(player, placed)) return null;
+        if (FurnitureFactory.getInstance().isNotImplementedIn(itemID) || BlockHelpers.isStandingInside(player, placed)) return null;
         if (!ProtectionLib.canBuild(player, placed.getLocation())) return null;
         if (OraxenFurniture.isFurniture(placed)) return null;
 
-        return (FurnitureMechanic) factory.getMechanic(itemID);
+        return FurnitureFactory.getInstance().getMechanic(item);
     }
 
     private Rotation getRotation(final double yaw, final boolean restricted) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/limitedplacing/LimitedPlacing.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/limitedplacing/LimitedPlacing.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -91,12 +92,10 @@ public class LimitedPlacing {
         Block blockBelow = placedBlock.getRelative(BlockFace.DOWN);
         Block blockAbove = placedBlock.getRelative(BlockFace.UP);
 
-        //TODO isBlock better check perhaps?
         if (wall && block.getType().isSolid()) return false;
         if (floor && (blockFace == BlockFace.UP || blockBelow.getType().isSolid())) return false;
         if (roof && blockFace == BlockFace.DOWN) return false;
-        if (roof && blockAbove.getType().isSolid()) return false;
-        return false;
+        return !roof || !blockAbove.getType().isSolid();
     }
 
     public List<Material> getLimitedBlocks() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -5,7 +5,6 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.directional.DirectionalBlock;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock.FarmBlockTask;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.logstrip.LogStripListener;
@@ -37,6 +36,7 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
     private static FarmBlockTask farmBlockTask;
     public final int farmBlockCheckDelay;
     public final boolean customSounds;
+    private final boolean removeMineableTag;
 
     public NoteBlockMechanicFactory(ConfigurationSection section) {
         super(section);
@@ -47,6 +47,7 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
         farmBlockCheckDelay = section.getInt("farmblock_check_delay");
         farmBlock = false;
         customSounds = OraxenPlugin.get().getConfigsManager().getMechanics().getConfigurationSection("custom_block_sounds").getBoolean("noteblock_and_block", true);
+        removeMineableTag = section.getBoolean("remove_mineable_tag", false);
 
         // this modifier should be executed when all the items have been parsed, just
         // before zipping the pack
@@ -155,6 +156,10 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
 
     public static NoteBlockMechanicFactory getInstance() {
         return instance;
+    }
+
+    public boolean removeMineableTag() {
+        return removeMineableTag;
     }
 
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.directional.DirectionalBlock;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.farmblock.FarmBlockTask;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.logstrip.LogStripListener;
@@ -19,6 +20,7 @@ import org.bukkit.Note;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.NoteBlock;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.List;
@@ -198,6 +200,16 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
         BLOCK_PER_VARIATION.put(mechanic.getCustomVariation(), mechanic);
         addToImplemented(mechanic);
         return mechanic;
+    }
+
+    @Override
+    public NoteBlockMechanic getMechanic(String itemID) {
+        return (NoteBlockMechanic) super.getMechanic(itemID);
+    }
+
+    @Override
+    public NoteBlockMechanic getMechanic(ItemStack itemStack) {
+        return (NoteBlockMechanic) super.getMechanic(itemStack);
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -15,6 +15,7 @@ import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -157,9 +157,8 @@ public class NoteBlockMechanicListener implements Listener {
         LimitedPlacing limitedPlacing = mechanic.getLimitedPlacing();
         Block belowPlaced = block.getRelative(blockFace).getRelative(BlockFace.DOWN);
 
-        if (limitedPlacing.isNotPlacableOn(block, blockFace)) {
-            event.setCancelled(true);
-        } else if (limitedPlacing.isRadiusLimited()) {
+        if (limitedPlacing.isNotPlacableOn(block, blockFace)) event.setCancelled(true);
+        else if (limitedPlacing.isRadiusLimited()) {
             LimitedPlacing.RadiusLimitation radiusLimitation = limitedPlacing.getRadiusLimitation();
             int rad = radiusLimitation.getRadius();
             int amount = radiusLimitation.getAmount();

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -11,11 +11,11 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.limitedplacing.LimitedPlaci
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.directional.DirectionalBlock;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.storage.StorageMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -138,7 +138,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (event.getClickedBlock().getType() != Material.NOTE_BLOCK) return;
         NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
         if (mechanic == null) return;
-        if (!new OraxenNoteBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace()).callEvent())
+        if (!EventUtils.callEvent(new OraxenNoteBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace())))
             event.setCancelled(true);
     }
 
@@ -225,7 +225,7 @@ public class NoteBlockMechanicListener implements Listener {
             mechanic = mechanic.getDirectional().getParentMechanic();
 
         event.setUseInteractedBlock(Event.Result.DENY);
-        if (!new OraxenNoteBlockInteractEvent(mechanic, player, item, hand, block, blockFace).callEvent()) event.setCancelled(true);
+        if (!EventUtils.callEvent(new OraxenNoteBlockInteractEvent(mechanic, player, item, hand, block, blockFace))) event.setCancelled(true);
         if (item == null) return;
 
         Block relative = block.getRelative(blockFace);
@@ -379,7 +379,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (!mechanic.canIgnite()) return;
         if (item.getType() != Material.FLINT_AND_STEEL && item.getType() != Material.FIRE_CHARGE) return;
 
-        new BlockIgniteEvent(block, BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL, event.getPlayer()).callEvent();
+        EventUtils.callEvent(new BlockIgniteEvent(block, BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL, event.getPlayer()));
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -508,7 +508,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (BlockHelpers.isStandingInside(player, target) || !ProtectionLib.canBuild(player, target.getLocation()))
             blockPlaceEvent.setCancelled(true);
 
-        if (!blockPlaceEvent.callEvent() || !blockPlaceEvent.canBuild()) return;
+        if (!EventUtils.callEvent(blockPlaceEvent) || !blockPlaceEvent.canBuild()) return;
 
         // This method is run for placing on custom blocks aswell, so this should not be called for vanilla blocks
         NoteBlockMechanic targetOraxen = OraxenBlocks.getNoteBlockMechanic(newData);
@@ -516,7 +516,7 @@ public class NoteBlockMechanicListener implements Listener {
             BlockData oldData = target.getBlockData();
             OraxenBlocks.place(targetOraxen.getItemID(), target.getLocation());
 
-            if (!new OraxenNoteBlockPlaceEvent(targetOraxen, target, player, item, hand).callEvent()) {
+            if (!EventUtils.callEvent(new OraxenNoteBlockPlaceEvent(targetOraxen, target, player, item, hand))) {
                 target.setBlockData(oldData);
                 return;
             }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.sapling.SaplingListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.sapling.SaplingTask;
@@ -19,6 +20,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Tripwire;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -88,6 +90,7 @@ public class StringBlockMechanicFactory extends MechanicFactory {
                 + ",powered=" + (((id >> 6) & 1) == 1 ? "true" : "false");
     }
 
+    @org.jetbrains.annotations.Nullable
     public static StringBlockMechanic getBlockMechanic(int customVariation) {
         return BLOCK_PER_VARIATION.get(customVariation);
     }
@@ -132,6 +135,16 @@ public class StringBlockMechanicFactory extends MechanicFactory {
         BLOCK_PER_VARIATION.put(mechanic.getCustomVariation(), mechanic);
         addToImplemented(mechanic);
         return mechanic;
+    }
+
+    @Override
+    public StringBlockMechanic getMechanic(String itemID) {
+        return (StringBlockMechanic) super.getMechanic(itemID);
+    }
+
+    @Override
+    public StringBlockMechanic getMechanic(ItemStack itemStack) {
+        return (StringBlockMechanic) super.getMechanic(itemStack);
     }
 
     public static int getCode(final Tripwire blockData) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -396,13 +396,13 @@ public class StringBlockMechanicListener implements Listener {
                                        final Block placedAgainst, final BlockFace face, final BlockData newData) {
         final Block target;
         final Material type = placedAgainst.getType();
-        if (BlockHelpers.isReplaceable(type))
-            target = placedAgainst;
+        if (BlockHelpers.isReplaceable(type)) target = placedAgainst;
         else {
             target = placedAgainst.getRelative(face);
             if (!target.getType().isAir() && target.getType() != Material.WATER && target.getType() != Material.LAVA)
                 return null;
         }
+
         if (BlockHelpers.isStandingInside(player, target) || !ProtectionLib.canBuild(player, target.getLocation())) return null;
         StringBlockMechanic mechanic = OraxenBlocks.getStringMechanic(newData);
         if (mechanic == null) return null;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -167,9 +167,8 @@ public class StringBlockMechanicListener implements Listener {
         LimitedPlacing limitedPlacing = mechanic.getLimitedPlacing();
         Block belowPlaced = block.getRelative(blockFace).getRelative(BlockFace.DOWN);
 
-        if (limitedPlacing.isNotPlacableOn(block, blockFace)) {
-            event.setCancelled(true);
-        } else if (limitedPlacing.isRadiusLimited()) {
+        if (limitedPlacing.isNotPlacableOn(block, blockFace)) event.setCancelled(true);
+        else if (limitedPlacing.isRadiusLimited()) {
             LimitedPlacing.RadiusLimitation radiusLimitation = limitedPlacing.getRadiusLimitation();
             int rad = radiusLimitation.getRadius();
             int amount = radiusLimitation.getAmount();

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -12,6 +12,7 @@ import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.limitedplacing.LimitedPlacing;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.sapling.SaplingMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
 import io.th0rgal.protectionlib.ProtectionLib;
@@ -129,7 +130,7 @@ public class StringBlockMechanicListener implements Listener {
         StringBlockMechanic mechanic = OraxenBlocks.getStringMechanic(block);
         if (mechanic == null) return;
 
-        if (!new OraxenStringBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace()).callEvent())
+        if (!EventUtils.callEvent(new OraxenStringBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace())))
             event.setCancelled(true);
     }
 
@@ -250,7 +251,7 @@ public class StringBlockMechanicListener implements Listener {
         // Call the event
         StringBlockMechanic stringBlockMechanic = OraxenBlocks.getStringMechanic(block);
         if (stringBlockMechanic == null) return;
-        if (!new OraxenStringBlockInteractEvent(stringBlockMechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace()).callEvent())
+        if (!EventUtils.callEvent(new OraxenStringBlockInteractEvent(stringBlockMechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace())))
             event.setUseInteractedBlock(Event.Result.DENY);
     }
 
@@ -418,7 +419,7 @@ public class StringBlockMechanicListener implements Listener {
             } else blockAbove.setType(Material.TRIPWIRE);
         }
         if (player.getGameMode() == GameMode.ADVENTURE) blockPlaceEvent.setCancelled(true);
-        if (!blockPlaceEvent.callEvent() || !blockPlaceEvent.canBuild() || !oraxenBlockPlaceEvent.callEvent()) return null;
+        if (!EventUtils.callEvent(blockPlaceEvent) || !blockPlaceEvent.canBuild() || !EventUtils.callEvent(oraxenBlockPlaceEvent)) return null;
 
         final String sound;
         if (newData.getMaterial() == Material.WATER || newData.getMaterial() == Material.LAVA) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/commands/CommandsMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/commands/CommandsMechanic.java
@@ -18,7 +18,7 @@ public class CommandsMechanic extends Mechanic {
     public CommandsMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
         super(mechanicFactory, section);
 
-        commandsParser = new CommandsParser(section);
+        commandsParser = new CommandsParser(section, null);
 
         if (section.isBoolean("one_usage"))
             oneUsage = section.getBoolean("one_usage");

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
@@ -2,6 +2,9 @@ package io.th0rgal.oraxen.mechanics.provided.misc.food;
 
 import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
+import io.th0rgal.oraxen.compatibilities.provided.mmoitems.WrappedMMOItem;
+import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.utils.logs.Logs;
@@ -70,9 +73,11 @@ public class FoodMechanic extends Mechanic {
         } else if (section.isString("oraxen_item"))
             replacementItem = OraxenItems.getItemById(section.getString("oraxen_item")).build();
         else if (section.isString("crucible_item"))
-            replacementItem = MythicCrucible.core().getItemManager().getItemStack(section.getString("crucible_item"));
+            replacementItem = new WrappedCrucibleItem(section.getString("crucible_item")).build();
         else if (section.isString("mmoitems_id") && section.isString("mmoitems_type"))
             replacementItem = MMOItems.plugin.getItem(section.getString("mmoitems_type"), section.getString("mmoitems_id"));
+        else if (section.isString("ecoitem_id"))
+            replacementItem = new WrappedEcoItem(section.getString("ecoitem_id")).build();
         else replacementItem = null;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
@@ -6,7 +6,9 @@ import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.Indyuce.mmoitems.MMOItems;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -30,30 +32,26 @@ public class FoodMechanic extends Mechanic {
         saturation = section.getInt("saturation");
         effectProbability = Math.min(section.getDouble("effect_probability", 1.0), 1.0);
 
-        if (section.isConfigurationSection("replacement")) {
-            ConfigurationSection replacementSection = section.getConfigurationSection("replacement");
-            assert replacementSection != null;
-            registerReplacement(replacementSection);
-        } else replacementItem = null;
+        // This must be initialized in OraxenItemsLoadedEvent due to OraxenItems not being loaded yet
+        replacementItem = section.isConfigurationSection("replacement") ? new ItemStack(Material.AIR) : null;
 
-        if (section.isConfigurationSection("effects")) {
-            ConfigurationSection effectsSection = section.getConfigurationSection("effects");
-            assert effectsSection != null;
-            for (String effectSection : effectsSection.getKeys(false))
-                if (section.isConfigurationSection(effectSection)) {
-                    ConfigurationSection effect = section.getConfigurationSection("effectSection");
-                    assert effect != null;
-                    registerEffects(effect);
-                }
+        ConfigurationSection effectsSection = section.getConfigurationSection("effects");
+        if (effectsSection != null) for (String effect : effectsSection.getKeys(false)) {
+            ConfigurationSection effectSection = effectsSection.getConfigurationSection(effect);
+            if (effectSection != null) registerEffects(effectSection);
         }
     }
 
     private void registerEffects(ConfigurationSection section) {
-        PotionEffectType effectType = PotionEffectType.getByName(section.getName());
+        String type = section.getName().toLowerCase();
+        PotionEffectType effectType = PotionEffectType.getByName(type);
+        if (effectType == null)
+            effectType = PotionEffectType.getByKey(type.contains(":") ? NamespacedKey.fromString(type) : NamespacedKey.minecraft(type));
         if (effectType == null) {
-            Logs.logError("Invalid effect type: " + section.getName() + " in " + getItemID());
+            Logs.logError("Invalid potion effect: " + section.getName() + ", in " + StringUtils.substringBefore(section.getCurrentPath(), ".") + "!");
             return;
         }
+
         effects.add(new PotionEffect(effectType,
                 section.getInt("duration", 1) * 20,
                 section.getInt("amplifier", 0),
@@ -62,14 +60,13 @@ public class FoodMechanic extends Mechanic {
                 section.getBoolean("has_icon", true)));
     }
 
-    private void registerReplacement(ConfigurationSection section) {
+    public void registerReplacement(ConfigurationSection section) {
         if (section.isString("minecraft_type")) {
             Material material = Material.getMaterial(Objects.requireNonNull(section.getString("minecraft_type")));
             if (material == null) {
                 Logs.logError("Invalid material: " + section.getString("minecraft_type"));
                 replacementItem = null;
-            }
-            else replacementItem = new ItemStack(material);
+            } else replacementItem = new ItemStack(material);
         } else if (section.isString("oraxen_item"))
             replacementItem = OraxenItems.getItemById(section.getString("oraxen_item")).build();
         else if (section.isString("crucible_item"))
@@ -95,8 +92,13 @@ public class FoodMechanic extends Mechanic {
         return replacementItem;
     }
 
-    public boolean hasEffects() { return !effects.isEmpty(); }
-    public Set<PotionEffect> getEffects() { return effects; }
+    public boolean hasEffects() {
+        return !effects.isEmpty();
+    }
+
+    public Set<PotionEffect> getEffects() {
+        return effects;
+    }
 
     public double getEffectProbability() {
         return effectProbability;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
@@ -1,9 +1,13 @@
 package io.th0rgal.oraxen.mechanics.provided.misc.food;
 
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.GameMode;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.PlayerInventory;
@@ -15,6 +19,16 @@ public class FoodMechanicListener implements Listener {
         this.factory = factory;
     }
 
+    @EventHandler(priority = EventPriority.LOWEST)
+    private void registerReplacements(OraxenItemsLoadedEvent event) {
+        for (String itemID : factory.getItems()) {
+            FoodMechanic foodMechanic = (FoodMechanic) factory.getMechanic(itemID);
+            ConfigurationSection replacementSection = foodMechanic.getSection().getConfigurationSection("replacement");
+            if (replacementSection == null) continue;
+            foodMechanic.registerReplacement(replacementSection);
+        }
+    }
+
     @EventHandler
     public void onEatingFood(PlayerItemConsumeEvent event) {
         Player player = event.getPlayer();
@@ -23,7 +37,7 @@ public class FoodMechanicListener implements Listener {
         if (itemID == null || factory.isNotImplementedIn(itemID)) return;
         FoodMechanic mechanic = (FoodMechanic) factory.getMechanic(itemID);
         event.setCancelled(true);
-
+        Logs.debug(mechanic.hasEffects());
         if (player.getGameMode() != GameMode.CREATIVE) {
             if (mechanic.hasReplacement())
                 inventory.setItemInMainHand(mechanic.getReplacement());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
@@ -37,7 +37,7 @@ public class FoodMechanicListener implements Listener {
         if (itemID == null || factory.isNotImplementedIn(itemID)) return;
         FoodMechanic mechanic = (FoodMechanic) factory.getMechanic(itemID);
         event.setCancelled(true);
-        Logs.debug(mechanic.hasEffects());
+
         if (player.getGameMode() != GameMode.CREATIVE) {
             if (mechanic.hasReplacement())
                 inventory.setItemInMainHand(mechanic.getReplacement());

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -19,7 +19,7 @@ import java.util.Set;
 public interface NMSHandler {
 
     @Nullable
-    ConfigurationSection paperSection = OraxenYaml.loadConfiguration(OraxenPlugin.get().getDataFolder().toPath().toAbsolutePath().getParent().getParent().resolve("config").resolve("paper-global.yml").toFile()).getConfigurationSection("block-updates");
+    ConfigurationSection paperSection = VersionUtil.isPaperServer() ? OraxenYaml.loadConfiguration(OraxenPlugin.get().getDataFolder().toPath().toAbsolutePath().getParent().getParent().resolve("config").resolve("paper-global.yml").toFile()).getConfigurationSection("block-updates") : null;
 
     default boolean noteblockUpdatesDisabled() {
         return VersionUtil.isPaperServer() && paperSection != null && paperSection.getBoolean("disable-noteblock-updates", false);

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -53,6 +53,9 @@ public interface NMSHandler {
     @Nullable BlockData correctBlockStates(Player player, EquipmentSlot slot, ItemStack itemStack, Block blockAgainst, BlockFace blockFace);
     @Nullable BlockHitResult getBlockHitResult(Player player, Block block, BlockFace blockFace);
 
+    /**Removes mineable/axe tag from noteblocks for custom blocks */
+    void customBlockDefaultTools(Player player);
+
     /**
      * Keys that are used by vanilla Minecraft and should therefore be skipped
      * Some are accessed through API methods, others are just used internally

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSListeners.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSListeners.java
@@ -1,6 +1,10 @@
 package io.th0rgal.oraxen.nms;
 
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -9,7 +13,11 @@ public class NMSListeners implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (NMSHandlers.getHandler() != null && Settings.NMS_GLYPHS.toBool())
-            NMSHandlers.getHandler().inject(event.getPlayer());
+        Player player = event.getPlayer();
+        if (NMSHandlers.getHandler() == null) return;
+
+        if (Settings.NMS_GLYPHS.toBool()) NMSHandlers.getHandler().inject(player);
+        if (NoteBlockMechanicFactory.isEnabled() && NoteBlockMechanicFactory.getInstance().removeMineableTag())
+            NMSHandlers.getHandler().customBlockDefaultTools(player);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
@@ -33,7 +33,7 @@ public class BukkitPackSender extends PackSender implements Listener {
     @Override
     public void sendPack(Player player) {
         if (VersionUtil.isPaperServer()) player.setResourcePack(hostingProvider.getMinecraftPackURL(), hostingProvider.getSHA1(), AdventureUtils.MINI_MESSAGE.deserialize(prompt), mandatory);
-        else player.setResourcePack(hostingProvider.getMinecraftPackURL(), hostingProvider.getSHA1(), AdventureUtils.LEGACY_SERIALIZER.deserialize(prompt), mandatory);
+        else player.setResourcePack(hostingProvider.getMinecraftPackURL(), hostingProvider.getSHA1(), AdventureUtils.parseLegacy(prompt), mandatory);
     }
 
     @EventHandler(priority = EventPriority.NORMAL)

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -231,7 +231,7 @@ public class DuplicationHandler {
             else duplicateFile = packFolder.resolve(name.replace("assets/minecraft/", "")).toFile();
             List<String> lines = null;
             try {
-                lines = FileUtils.readLines(duplicateFile, StandardCharsets.UTF_8);
+                if (duplicateFile.getName().endsWith(".json")) lines = FileUtils.readLines(duplicateFile, StandardCharsets.UTF_8);
             } catch (IOException ex) {
                 if (Settings.DEBUG.toBool()) ex.printStackTrace();
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackSlicer.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackSlicer.java
@@ -1,0 +1,588 @@
+package io.th0rgal.oraxen.pack.generation;
+
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.pack.generation.slicer.Box;
+import io.th0rgal.oraxen.pack.generation.slicer.InputFile;
+import io.th0rgal.oraxen.pack.generation.slicer.OutputFile;
+import io.th0rgal.oraxen.pack.generation.slicer.Slicer;
+import io.th0rgal.oraxen.utils.logs.Logs;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.ImageObserver;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+public class PackSlicer extends Slicer {
+
+    private static final Path packFolder = OraxenPlugin.get().getResourcePack().getPackFolder().toPath();
+    private static final Path assetsFolder = packFolder.resolve("assets/minecraft");
+    private static final Box STANDARD_CONTAINER_BOX = new Box(0, 0, 176, 166, 256, 256);
+    private static final List<InputFile> INPUTS;
+
+    public PackSlicer(Path rootPath) {
+        super(rootPath, rootPath, null);
+    }
+
+    public static void slicePackFiles() {
+        Logs.logInfo("Slicing gui-textures to 1.20.2-format...");
+        try {
+            new PackSlicer(packFolder).process(INPUTS);
+            if (assetsFolder.toFile().exists()) new PackSlicer(assetsFolder).process(INPUTS);
+            Logs.logSuccess("Successfully sliced gui-textures for 1.20.2");
+        } catch (Exception e) {
+            Logs.logWarning("Failed to properly slice textures for 1.20.2");
+            if (Settings.DEBUG.toBool()) e.printStackTrace();
+        }
+    }
+
+    private static InputFile input(String path, OutputFile... outputs) {
+        return (new InputFile(path)).outputs(outputs);
+    }
+
+    private static InputFile copy(String name) {
+        String path = nameToPath("minecraft", name);
+        return move(path, path);
+    }
+
+    private static InputFile clip(String name, Box box) {
+        return clip(name, name, box);
+    }
+
+    private static InputFile clip(String inputName, String outputName, Box box) {
+        String inputPath = nameToPath("minecraft", inputName);
+        String outputPath = nameToPath("minecraft", outputName);
+        Box imageBox = new Box(0, 0, box.totalW(), box.totalH(), box.totalW(), box.totalH());
+        return (new InputFile(inputPath)).outputs((new OutputFile(outputPath, imageBox)).apply((image) -> {
+            int imageWidth = image.getWidth();
+            int imageHeight = image.getHeight();
+            int x = box.scaleX(imageWidth);
+            int y = box.scaleY(imageHeight);
+            int width = box.scaleW(imageWidth);
+            int height = box.scaleH(imageHeight);
+            BufferedImage subImage = image.getSubimage(x, y, width, height);
+            BufferedImage clippedImage = new BufferedImage(imageWidth, imageHeight, 2);
+            clippedImage.getGraphics().drawImage(subImage, x, y, null);
+            return clippedImage;
+        }));
+    }
+
+    private static InputFile move(String inputPath, String outputPath) {
+        return (new InputFile(inputPath)).outputs(new OutputFile[]{new OutputFile(outputPath, new Box(0, 0, 1, 1, 1, 1))});
+    }
+
+    private static InputFile moveRealmsToMinecraft(String name) {
+        return move(nameToPath("realms", name), nameToPath("minecraft", name));
+    }
+
+    private static String nameToPath(String namespace, String name) {
+        return "assets/" + namespace + "/textures/gui/" + name + ".png";
+    }
+
+    private static UnaryOperator<BufferedImage> flipFrameAxis() {
+        return (image) -> {
+            int frameWidth = image.getWidth() / 2;
+            int frameHeight = image.getHeight();
+            BufferedImage newImage = new BufferedImage(frameWidth, frameHeight * 2, 2);
+            Graphics graphics = newImage.getGraphics();
+
+            for (int frame = 0; frame < 2; ++frame)
+                graphics.drawImage(image.getSubimage(frame * frameWidth, 0, frameWidth, frameHeight), 0, frame * frameHeight, null);
+
+            graphics.dispose();
+            return newImage;
+        };
+    }
+
+    private static UnaryOperator<BufferedImage> spriteExtender() {
+        return (image) -> {
+            int imageWidth = image.getWidth();
+            int imageHeight = image.getHeight();
+            int x = 3 * imageWidth / 17;
+            int y = 4 * imageHeight / 16;
+            int width = 26 * imageWidth / 17;
+            int height = 26 * imageHeight / 16;
+            BufferedImage extendedImage = new BufferedImage(width, height, 2);
+            extendedImage.getGraphics().drawImage(image, x, y, null);
+            return extendedImage;
+        };
+    }
+
+    static {
+        INPUTS = List.of(
+                input("textures/gui/chat_tags.png",
+                        new OutputFile("textures/gui/sprites/icon/chat_modified.png", new Box(0, 0, 9, 9, 32, 32))
+                ),
+                input("textures/gui/container/creative_inventory/tabs.png",
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/scroller.png", new Box(232, 0, 12, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/scroller_disabled.png", new Box(244, 0, 12, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_1.png", new Box(0, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_2.png", new Box(26, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_3.png", new Box(52, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_4.png", new Box(78, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_5.png", new Box(104, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_6.png", new Box(130, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_unselected_7.png", new Box(156, 0, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_1.png", new Box(0, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_2.png", new Box(26, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_3.png", new Box(52, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_4.png", new Box(78, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_5.png", new Box(104, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_6.png", new Box(130, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_top_selected_7.png", new Box(156, 32, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_1.png", new Box(0, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_2.png", new Box(26, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_3.png", new Box(52, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_4.png", new Box(78, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_5.png", new Box(104, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_6.png", new Box(130, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_unselected_7.png", new Box(156, 64, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_1.png", new Box(0, 96, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_2.png", new Box(26, 96, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_3.png", new Box(52, 96, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_4.png", new Box(78, 96, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_5.png", new Box(104, 96, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_6.png", new Box(130, 96, 26, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/creative_inventory/tab_bottom_selected_7.png", new Box(156, 96, 26, 32, 256, 256))
+                ),
+                input("textures/gui/advancements/tabs.png",
+                        new OutputFile("textures/gui/sprites/advancements/tab_above_left_selected.png", new Box(0, 32, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_above_middle_selected.png", new Box(28, 32, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_above_right_selected.png", new Box(56, 32, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_above_left.png", new Box(0, 0, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_above_middle.png", new Box(28, 0, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_above_right.png", new Box(56, 0, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_below_left_selected.png", new Box(84, 32, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_below_middle_selected.png", new Box(112, 32, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_below_right_selected.png", new Box(140, 32, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_below_left.png", new Box(84, 0, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_below_middle.png", new Box(112, 0, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_below_right.png", new Box(140, 0, 28, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_left_top_selected.png", new Box(0, 92, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_left_middle_selected.png", new Box(32, 92, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_left_bottom_selected.png", new Box(64, 92, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_left_top.png", new Box(0, 64, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_left_middle.png", new Box(32, 64, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_left_bottom.png", new Box(64, 64, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_right_top_selected.png", new Box(96, 92, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_right_middle_selected.png", new Box(128, 92, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_right_bottom_selected.png", new Box(160, 92, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_right_top.png", new Box(96, 64, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_right_middle.png", new Box(128, 64, 32, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/tab_right_bottom.png", new Box(160, 64, 32, 28, 256, 256))
+                ),
+                input("textures/gui/checkbox.png",
+                        new OutputFile("textures/gui/sprites/widget/checkbox_selected_highlighted.png", new Box(20, 20, 20, 20, 64, 64)),
+                        new OutputFile("textures/gui/sprites/widget/checkbox_selected.png", new Box(0, 20, 20, 20, 64, 64)),
+                        new OutputFile("textures/gui/sprites/widget/checkbox_highlighted.png", new Box(20, 0, 20, 20, 64, 64)),
+                        new OutputFile("textures/gui/sprites/widget/checkbox.png", new Box(0, 0, 20, 20, 64, 64))
+                ),
+                input("textures/gui/container/blast_furnace.png",
+                        new OutputFile("textures/gui/sprites/container/blast_furnace/lit_progress.png", new Box(176, 0, 14, 14, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/blast_furnace/burn_progress.png", new Box(176, 14, 24, 16, 256, 256))),
+                input("assets/realms/textures/gui/realms/expired_icon.png",
+                        new OutputFile("textures/gui/sprites/realm_status/expired.png", new Box(0, 0, 10, 28, 10, 28))),
+                input("textures/gui/server_selection.png",
+                        new OutputFile("textures/gui/sprites/server_list/join_highlighted.png", new Box(0, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/join.png", new Box(0, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/move_up_highlighted.png", new Box(96, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/move_up.png", new Box(96, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/move_down_highlighted.png", new Box(64, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/move_down.png", new Box(64, 0, 32, 32, 256, 256))),
+                input("textures/gui/widgets.png",
+                        (new OutputFile("textures/gui/sprites/widget/button.png", new Box(0, 66, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/button_disabled.png", new Box(0, 46, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/button_highlighted.png", new Box(0, 86, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n"),
+                        new OutputFile("textures/gui/sprites/widget/locked_button.png", new Box(0, 146, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/locked_button_highlighted.png", new Box(0, 166, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/locked_button_disabled.png", new Box(0, 186, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/unlocked_button.png", new Box(20, 146, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/unlocked_button_highlighted.png", new Box(20, 166, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/unlocked_button_disabled.png", new Box(20, 186, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/hotbar.png", new Box(0, 0, 182, 22, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/hotbar_selection.png", new Box(0, 22, 24, 23, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/hotbar_offhand_left.png", new Box(24, 22, 29, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/hotbar_offhand_right.png", new Box(53, 22, 29, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/icon/draft_report.png", new Box(182, 24, 15, 15, 256, 256))),
+                input("assets/realms/textures/gui/realms/cross_icon.png",
+                        new OutputFile("textures/gui/sprites/widget/cross_button_highlighted.png", new Box(0, 14, 14, 14, 14, 28)),
+                        new OutputFile("textures/gui/sprites/widget/cross_button.png", new Box(0, 0, 14, 14, 14, 28))),
+                input("textures/gui/info_icon.png",
+                        new OutputFile("textures/gui/sprites/icon/info.png", new Box(0, 0, 20, 20, 20, 20))),
+                input("textures/gui/advancements/widgets.png",
+                        (new OutputFile("textures/gui/sprites/advancements/title_box.png", new Box(0, 52, 200, 26, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 26,\n            \"border\": 10\n        }\n    }\n}\n"),
+                        new OutputFile("textures/gui/sprites/advancements/box_obtained.png", new Box(0, 0, 200, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/task_frame_obtained.png", new Box(0, 128, 26, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/challenge_frame_obtained.png", new Box(26, 128, 26, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/goal_frame_obtained.png", new Box(52, 128, 26, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/box_unobtained.png", new Box(0, 26, 200, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/task_frame_unobtained.png", new Box(0, 154, 26, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/challenge_frame_unobtained.png", new Box(26, 154, 26, 26, 256, 256)),
+                        new OutputFile("textures/gui/sprites/advancements/goal_frame_unobtained.png", new Box(52, 154, 26, 26, 256, 256))),
+                input("textures/gui/tab_button.png",
+                        (new OutputFile("textures/gui/sprites/widget/tab_selected.png", new Box(0, 0, 130, 24, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 130,\n            \"height\": 24,\n            \"border\": {\n                \"left\": 2,\n                \"top\": 2,\n                \"right\": 2,\n                \"bottom\": 0\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/tab.png", new Box(0, 48, 130, 24, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 130,\n            \"height\": 24,\n            \"border\": {\n                \"left\": 2,\n                \"top\": 2,\n                \"right\": 2,\n                \"bottom\": 0\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/tab_selected_highlighted.png", new Box(0, 24, 130, 24, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 130,\n            \"height\": 24,\n            \"border\": {\n                \"left\": 2,\n                \"top\": 2,\n                \"right\": 2,\n                \"bottom\": 0\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/tab_highlighted.png", new Box(0, 72, 130, 24, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 130,\n            \"height\": 24,\n            \"border\": {\n                \"left\": 2,\n                \"top\": 2,\n                \"right\": 2,\n                \"bottom\": 0\n            }\n        }\n    }\n}\n")),
+                input("textures/gui/container/furnace.png",
+                        new OutputFile("textures/gui/sprites/container/furnace/lit_progress.png", new Box(176, 0, 14, 14, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/furnace/burn_progress.png", new Box(176, 14, 24, 16, 256, 256))),
+                input("textures/gui/container/brewing_stand.png",
+                        new OutputFile("textures/gui/sprites/container/brewing_stand/fuel_length.png", new Box(176, 29, 18, 4, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/brewing_stand/brew_progress.png", new Box(176, 0, 9, 28, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/brewing_stand/bubbles.png", new Box(185, 0, 12, 29, 256, 256))),
+                input("textures/gui/sprites/language.png",
+                        new OutputFile("textures/gui/sprites/icon/language.png", new Box(0, 0, 15, 15, 15, 15))),
+                input("assets/realms/textures/gui/realms/off_icon.png",
+                        new OutputFile("textures/gui/sprites/realm_status/closed.png", new Box(0, 0, 10, 28, 10, 28))),
+                input("textures/gui/resource_packs.png",
+                        new OutputFile("textures/gui/sprites/transferable_list/select_highlighted.png", new Box(0, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/select.png", new Box(0, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/unselect_highlighted.png", new Box(32, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/unselect.png", new Box(32, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/move_up_highlighted.png", new Box(96, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/move_up.png", new Box(96, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/move_down_highlighted.png", new Box(64, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/transferable_list/move_down.png", new Box(64, 0, 32, 32, 256, 256))),
+                input("assets/realms/textures/gui/realms/user_icon.png",
+                        new OutputFile("textures/gui/sprites/player_list/make_operator.png", new Box(0, 0, 8, 7, 8, 14)),
+                        new OutputFile("textures/gui/sprites/player_list/make_operator_highlighted.png", new Box(0, 7, 8, 7, 8, 14))),
+                input("textures/gui/container/beacon.png",
+                        new OutputFile("textures/gui/sprites/container/beacon/button_disabled.png", new Box(44, 219, 22, 22, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/beacon/button_selected.png", new Box(22, 219, 22, 22, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/beacon/button_highlighted.png", new Box(66, 219, 22, 22, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/beacon/button.png", new Box(0, 219, 22, 22, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/beacon/confirm.png", new Box(90, 220, 18, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/beacon/cancel.png", new Box(112, 220, 18, 18, 256, 256))),
+                input("textures/gui/container/bundle_background.png",
+                        (new OutputFile("textures/gui/sprites/container/bundle/background.png", new Box(0, 0, 32, 32, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 32,\n            \"height\": 32,\n            \"border\": 4\n        }\n    }\n}\n")),
+                input("textures/gui/toasts.png",
+                        new OutputFile("textures/gui/sprites/toast/advancement.png", new Box(0, 0, 160, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/recipe.png", new Box(0, 32, 160, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/system.png", new Box(0, 64, 160, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/tutorial.png", new Box(0, 96, 160, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/movement_keys.png", new Box(176, 0, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/mouse.png", new Box(196, 0, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/tree.png", new Box(216, 0, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/recipe_book.png", new Box(176, 20, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/wooden_planks.png", new Box(196, 20, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/social_interactions.png", new Box(216, 20, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/toast/right_click.png", new Box(236, 20, 20, 20, 256, 256))),
+                input("assets/realms/textures/gui/realms/reject_icon.png",
+                        new OutputFile("textures/gui/sprites/pending_invite/reject_highlighted.png", new Box(19, 0, 18, 18, 37, 18)),
+                        new OutputFile("textures/gui/sprites/pending_invite/reject.png", new Box(0, 0, 18, 18, 37, 18))),
+                input("textures/gui/book.png",
+                        new OutputFile("textures/gui/sprites/widget/page_forward_highlighted.png", new Box(23, 192, 23, 13, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/page_forward.png", new Box(0, 192, 23, 13, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/page_backward_highlighted.png", new Box(23, 205, 23, 13, 256, 256)),
+                        new OutputFile("textures/gui/sprites/widget/page_backward.png", new Box(0, 205, 23, 13, 256, 256))),
+                input("assets/realms/textures/gui/realms/accept_icon.png",
+                        new OutputFile("textures/gui/sprites/pending_invite/accept_highlighted.png", new Box(19, 0, 18, 18, 37, 18)),
+                        new OutputFile("textures/gui/sprites/pending_invite/accept.png", new Box(0, 0, 18, 18, 37, 18))),
+                input("assets/realms/textures/gui/realms/world_icon.png",
+                        new OutputFile("textures/gui/sprites/icon/new_realm.png", new Box(0, 0, 40, 20, 40, 20))),
+                input("assets/realms/textures/gui/realms/expires_soon_icon.png",
+                        (new OutputFile("textures/gui/sprites/realm_status/expires_soon.png", new Box(0, 0, 20, 28, 20, 28))).metadata("{\n    \"animation\": {\n        \"frametime\": 10,\n        \"height\": 28\n    }\n}\n").apply(flipFrameAxis())),
+                input("textures/gui/report_button.png",
+                        new OutputFile("textures/gui/sprites/social_interactions/report_button.png", new Box(0, 0, 20, 20, 64, 64)),
+                        new OutputFile("textures/gui/sprites/social_interactions/report_button_disabled.png", new Box(0, 40, 20, 20, 64, 64)),
+                        new OutputFile("textures/gui/sprites/social_interactions/report_button_highlighted.png", new Box(0, 20, 20, 20, 64, 64))),
+                input("assets/realms/textures/gui/realms/news_notification_mainscreen.png",
+                        new OutputFile("textures/gui/sprites/icon/news.png", new Box(0, 0, 40, 40, 40, 40))),
+                input("assets/realms/textures/gui/realms/trial_icon.png",
+                        (new OutputFile("textures/gui/sprites/icon/trial_available.png", new Box(0, 0, 8, 16, 8, 16))).metadata("{\n    \"animation\": {\n        \"frametime\": 20\n    }\n}\n")),
+                input("textures/gui/container/grindstone.png",
+                        new OutputFile("textures/gui/sprites/container/grindstone/error.png", new Box(176, 0, 28, 21, 256, 256))),
+                input("assets/realms/textures/gui/realms/restore_icon.png",
+                        new OutputFile("textures/gui/sprites/backup/restore.png", new Box(0, 0, 17, 10, 17, 20)),
+                        new OutputFile("textures/gui/sprites/backup/restore_highlighted.png", new Box(0, 10, 17, 10, 17, 20))),
+                input("textures/gui/container/villager2.png",
+                        new OutputFile("textures/gui/sprites/container/villager/out_of_stock.png", new Box(311, 0, 28, 21, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/experience_bar_background.png", new Box(0, 186, 102, 5, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/experience_bar_current.png", new Box(0, 191, 102, 5, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/experience_bar_result.png", new Box(0, 181, 102, 5, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/scroller.png", new Box(0, 199, 6, 27, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/scroller_disabled.png", new Box(6, 199, 6, 27, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/trade_arrow_out_of_stock.png", new Box(25, 171, 10, 9, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/trade_arrow.png", new Box(15, 171, 10, 9, 512, 256)),
+                        new OutputFile("textures/gui/sprites/container/villager/discount_strikethrough.png", new Box(0, 176, 9, 2, 512, 256))),
+                input("assets/realms/textures/gui/realms/link_icons.png",
+                        new OutputFile("textures/gui/sprites/icon/link_highlighted.png", new Box(15, 0, 15, 15, 30, 15)),
+                        new OutputFile("textures/gui/sprites/icon/link.png", new Box(0, 0, 15, 15, 30, 15))),
+                input("assets/realms/textures/gui/realms/trailer_icons.png",
+                        new OutputFile("textures/gui/sprites/icon/video_link_highlighted.png", new Box(15, 0, 15, 15, 30, 15)),
+                        new OutputFile("textures/gui/sprites/icon/video_link.png", new Box(0, 0, 15, 15, 30, 15))),
+                input("assets/realms/textures/gui/realms/slot_frame.png",
+                        new OutputFile("textures/gui/sprites/widget/slot_frame.png", new Box(0, 0, 80, 80, 80, 80))),
+                input("textures/gui/bars.png",
+                        new OutputFile("textures/gui/sprites/boss_bar/pink_background.png", new Box(0, 0, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/blue_background.png", new Box(0, 10, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/red_background.png", new Box(0, 20, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/green_background.png", new Box(0, 30, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/yellow_background.png", new Box(0, 40, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/purple_background.png", new Box(0, 50, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/white_background.png", new Box(0, 60, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/pink_progress.png", new Box(0, 5, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/blue_progress.png", new Box(0, 15, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/red_progress.png", new Box(0, 25, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/green_progress.png", new Box(0, 35, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/yellow_progress.png", new Box(0, 45, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/purple_progress.png", new Box(0, 55, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/white_progress.png", new Box(0, 65, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_6_background.png", new Box(0, 80, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_10_background.png", new Box(0, 90, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_12_background.png", new Box(0, 100, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_20_background.png", new Box(0, 110, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_6_progress.png", new Box(0, 85, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_10_progress.png", new Box(0, 95, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_12_progress.png", new Box(0, 105, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/boss_bar/notched_20_progress.png", new Box(0, 115, 182, 5, 256, 256))),
+                input("textures/gui/container/smithing.png",
+                        new OutputFile("textures/gui/sprites/container/smithing/error.png", new Box(176, 0, 28, 21, 256, 256))),
+                input("textures/gui/container/stonecutter.png",
+                        new OutputFile("textures/gui/sprites/container/stonecutter/scroller.png", new Box(176, 0, 12, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/stonecutter/scroller_disabled.png", new Box(188, 0, 12, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/stonecutter/recipe_selected.png", new Box(0, 184, 16, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/stonecutter/recipe_highlighted.png", new Box(0, 202, 16, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/stonecutter/recipe.png", new Box(0, 166, 16, 18, 256, 256))),
+                input("textures/gui/slider.png",
+                        (new OutputFile("textures/gui/sprites/widget/slider_highlighted.png", new Box(0, 20, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/slider.png", new Box(0, 0, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/slider_handle_highlighted.png", new Box(0, 60, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n"),
+                        (new OutputFile("textures/gui/sprites/widget/slider_handle.png", new Box(0, 40, 200, 20, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 200,\n            \"height\": 20,\n            \"border\": {\n                \"left\": 20,\n                \"top\": 4,\n                \"right\": 20,\n                \"bottom\": 4\n            }\n        }\n    }\n}\n")),
+                input("textures/gui/container/gamemode_switcher.png",
+                        new OutputFile("textures/gui/sprites/gamemode_switcher/slot.png", new Box(0, 75, 26, 26, 128, 128)),
+                        new OutputFile("textures/gui/sprites/gamemode_switcher/selection.png", new Box(26, 75, 26, 26, 128, 128))),
+                input("textures/gui/world_selection.png",
+                        new OutputFile("textures/gui/sprites/world_list/error_highlighted.png", new Box(96, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/error.png", new Box(96, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/marked_join_highlighted.png", new Box(32, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/marked_join.png", new Box(32, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/warning_highlighted.png", new Box(64, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/warning.png", new Box(64, 0, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/join_highlighted.png", new Box(0, 32, 32, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/world_list/join.png", new Box(0, 0, 32, 32, 256, 256))),
+                input("assets/realms/textures/gui/realms/op_icon.png",
+                        new OutputFile("textures/gui/sprites/player_list/remove_operator.png", new Box(0, 0, 8, 7, 8, 14)),
+                        new OutputFile("textures/gui/sprites/player_list/remove_operator_highlighted.png", new Box(0, 7, 8, 7, 8, 14))),
+                input("assets/realms/textures/gui/realms/plus_icon.png",
+                        new OutputFile("textures/gui/sprites/backup/changes.png", new Box(0, 0, 9, 9, 9, 18)),
+                        new OutputFile("textures/gui/sprites/backup/changes_highlighted.png", new Box(0, 9, 9, 9, 9, 18))),
+                input("textures/gui/container/enchanting_table.png",
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/level_1.png", new Box(0, 223, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/level_2.png", new Box(16, 223, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/level_3.png", new Box(32, 223, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/level_1_disabled.png", new Box(0, 239, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/level_2_disabled.png", new Box(16, 239, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/level_3_disabled.png", new Box(32, 239, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/enchantment_slot_disabled.png", new Box(0, 185, 108, 19, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/enchantment_slot_highlighted.png", new Box(0, 204, 108, 19, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/enchanting_table/enchantment_slot.png", new Box(0, 166, 108, 19, 256, 256))),
+                input("textures/gui/checkmark.png",
+                        new OutputFile("textures/gui/sprites/icon/checkmark.png", new Box(0, 0, 9, 8, 9, 8))),
+                input("textures/gui/container/bundle.png",
+                        new OutputFile("textures/gui/sprites/container/bundle/blocked_slot.png", new Box(0, 40, 18, 20, 128, 128)),
+                        new OutputFile("textures/gui/sprites/container/bundle/slot.png", new Box(0, 0, 18, 20, 128, 128))),
+                input("textures/gui/container/horse.png",
+                        new OutputFile("textures/gui/sprites/container/horse/chest_slots.png", new Box(0, 166, 90, 54, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/horse/saddle_slot.png", new Box(18, 220, 18, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/horse/llama_armor_slot.png", new Box(36, 220, 18, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/horse/armor_slot.png", new Box(0, 220, 18, 18, 256, 256))),
+                input("assets/realms/textures/gui/realms/on_icon.png",
+                        new OutputFile("textures/gui/sprites/realm_status/open.png", new Box(0, 0, 10, 28, 10, 28))),
+                input("textures/gui/container/anvil.png",
+                        new OutputFile("textures/gui/sprites/container/anvil/text_field.png", new Box(0, 166, 110, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/anvil/text_field_disabled.png", new Box(0, 182, 110, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/anvil/error.png", new Box(176, 0, 28, 21, 256, 256))),
+                input("assets/realms/textures/gui/realms/news_icon.png",
+                        new OutputFile("textures/gui/sprites/widget/news_button_highlighted.png", new Box(20, 0, 20, 20, 40, 20)),
+                        new OutputFile("textures/gui/sprites/widget/news_button.png", new Box(0, 0, 20, 20, 40, 20))),
+                input("assets/realms/textures/gui/realms/invitation_icons.png",
+                        new OutputFile("textures/gui/sprites/notification/1.png", new Box(0, 0, 8, 8, 48, 16)),
+                        new OutputFile("textures/gui/sprites/notification/2.png", new Box(8, 0, 8, 8, 48, 16)),
+                        new OutputFile("textures/gui/sprites/notification/3.png", new Box(16, 0, 8, 8, 48, 16)),
+                        new OutputFile("textures/gui/sprites/notification/4.png", new Box(24, 0, 8, 8, 48, 16)),
+                        new OutputFile("textures/gui/sprites/notification/5.png", new Box(32, 0, 8, 8, 48, 16)),
+                        new OutputFile("textures/gui/sprites/notification/more.png", new Box(40, 0, 8, 8, 48, 16))),
+                input("textures/gui/recipe_book.png",
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_filter_enabled.png", new Box(180, 182, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_filter_disabled.png", new Box(152, 182, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_filter_enabled_highlighted.png", new Box(180, 200, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_filter_disabled_highlighted.png", new Box(152, 200, 26, 16, 256, 256)),
+                        (new OutputFile("textures/gui/sprites/recipe_book/overlay_recipe.png", new Box(82, 208, 32, 32, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 32,\n            \"height\": 32,\n            \"border\": 4\n        }\n    }\n}\n"),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_overlay_highlighted.png", new Box(152, 156, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_overlay.png", new Box(152, 130, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/crafting_overlay_highlighted.png", new Box(152, 104, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/crafting_overlay.png", new Box(152, 78, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_overlay_disabled_highlighted.png", new Box(178, 156, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/furnace_overlay_disabled.png", new Box(178, 130, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/crafting_overlay_disabled_highlighted.png", new Box(178, 104, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/crafting_overlay_disabled.png", new Box(178, 78, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/filter_enabled.png", new Box(180, 41, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/filter_disabled.png", new Box(152, 41, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/filter_enabled_highlighted.png", new Box(180, 59, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/filter_disabled_highlighted.png", new Box(152, 59, 26, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/page_forward.png", new Box(1, 208, 12, 17, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/page_forward_highlighted.png", new Box(1, 226, 12, 17, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/page_backward.png", new Box(14, 208, 12, 17, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/page_backward_highlighted.png", new Box(14, 226, 12, 17, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/tab.png", new Box(153, 2, 35, 27, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/tab_selected.png", new Box(188, 2, 35, 27, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/slot_many_craftable.png", new Box(29, 231, 25, 25, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/slot_craftable.png", new Box(29, 206, 25, 25, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/slot_many_uncraftable.png", new Box(54, 231, 25, 25, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/slot_uncraftable.png", new Box(54, 206, 25, 25, 256, 256))),
+                input("textures/gui/social_interactions.png",
+                        new OutputFile("textures/gui/sprites/social_interactions/mute_button.png", new Box(0, 38, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/social_interactions/mute_button_highlighted.png", new Box(0, 58, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/social_interactions/unmute_button.png", new Box(20, 38, 20, 20, 256, 256)),
+                        new OutputFile("textures/gui/sprites/social_interactions/unmute_button_highlighted.png", new Box(20, 58, 20, 20, 256, 256)),
+                        (new OutputFile("textures/gui/sprites/social_interactions/background.png", new Box(1, 1, 236, 34, 256, 256))).metadata("{\n    \"gui\": {\n        \"scaling\": {\n            \"type\": \"nine_slice\",\n            \"width\": 236,\n            \"height\": 34,\n            \"border\": 8\n        }\n    }\n}\n"),
+                        new OutputFile("textures/gui/sprites/icon/search.png", new Box(243, 1, 12, 12, 256, 256))),
+                input("textures/gui/spectator_widgets.png",
+                        new OutputFile("textures/gui/sprites/spectator/teleport_to_player.png", new Box(0, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/spectator/teleport_to_team.png", new Box(16, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/spectator/close.png", new Box(128, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/spectator/scroll_left.png", new Box(144, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/spectator/scroll_right.png", new Box(160, 0, 16, 16, 256, 256))),
+                input("textures/gui/container/smoker.png",
+                        new OutputFile("textures/gui/sprites/container/smoker/lit_progress.png", new Box(176, 0, 14, 14, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/smoker/burn_progress.png", new Box(176, 14, 24, 16, 256, 256))),
+                input("textures/gui/recipe_button.png",
+                        new OutputFile("textures/gui/sprites/recipe_book/button.png", new Box(0, 0, 20, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/recipe_book/button_highlighted.png", new Box(0, 19, 20, 18, 256, 256))),
+                input("textures/gui/icons.png",
+                        new OutputFile("textures/gui/sprites/icon/ping_unknown.png", new Box(0, 216, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/icon/ping_5.png", new Box(0, 176, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/icon/ping_4.png", new Box(0, 184, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/icon/ping_3.png", new Box(0, 192, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/icon/ping_2.png", new Box(0, 200, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/icon/ping_1.png", new Box(0, 208, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/container_blinking.png", new Box(25, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/container.png", new Box(16, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/full_blinking.png", new Box(70, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/half_blinking.png", new Box(79, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_full_blinking.png", new Box(160, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/full.png", new Box(52, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_half_blinking.png", new Box(169, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/half.png", new Box(61, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/crosshair.png", new Box(0, 0, 15, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/crosshair_attack_indicator_full.png", new Box(68, 94, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/crosshair_attack_indicator_background.png", new Box(36, 94, 16, 4, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/crosshair_attack_indicator_progress.png", new Box(52, 94, 16, 4, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/hotbar_attack_indicator_background.png", new Box(0, 94, 18, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/hotbar_attack_indicator_progress.png", new Box(18, 94, 18, 18, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/jump_bar_background.png", new Box(0, 84, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/jump_bar_cooldown.png", new Box(0, 74, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/jump_bar_progress.png", new Box(0, 89, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/experience_bar_background.png", new Box(0, 64, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/experience_bar_progress.png", new Box(0, 69, 182, 5, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/armor_full.png", new Box(34, 9, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/armor_half.png", new Box(25, 9, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/armor_empty.png", new Box(16, 9, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/food_empty_hunger.png", new Box(133, 27, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/food_half_hunger.png", new Box(97, 27, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/food_full_hunger.png", new Box(88, 27, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/food_empty.png", new Box(16, 27, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/food_half.png", new Box(61, 27, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/food_full.png", new Box(52, 27, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/air.png", new Box(16, 18, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/air_bursting.png", new Box(25, 18, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/container_hardcore.png", new Box(16, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/container_hardcore_blinking.png", new Box(25, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/hardcore_full.png", new Box(52, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/hardcore_full_blinking.png", new Box(70, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/hardcore_half.png", new Box(61, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/hardcore_half_blinking.png", new Box(79, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_full.png", new Box(88, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_full_blinking.png", new Box(106, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_half.png", new Box(97, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_half_blinking.png", new Box(115, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_hardcore_full.png", new Box(88, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_hardcore_full_blinking.png", new Box(106, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_hardcore_half.png", new Box(97, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/poisoned_hardcore_half_blinking.png", new Box(115, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_full.png", new Box(124, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_full_blinking.png", new Box(142, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_half.png", new Box(133, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_half_blinking.png", new Box(151, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_hardcore_full.png", new Box(124, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_hardcore_full_blinking.png", new Box(142, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_hardcore_half.png", new Box(133, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/withered_hardcore_half_blinking.png", new Box(151, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_full.png", new Box(160, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_half.png", new Box(169, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_hardcore_full.png", new Box(160, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_hardcore_full_blinking.png", new Box(160, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_hardcore_half.png", new Box(169, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/absorbing_hardcore_half_blinking.png", new Box(169, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_full.png", new Box(178, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_full_blinking.png", new Box(178, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_half.png", new Box(187, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_half_blinking.png", new Box(187, 0, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_hardcore_full.png", new Box(178, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_hardcore_full_blinking.png", new Box(178, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_hardcore_half.png", new Box(187, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/frozen_hardcore_half_blinking.png", new Box(187, 45, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/vehicle_container.png", new Box(52, 9, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/vehicle_full.png", new Box(88, 9, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/heart/vehicle_half.png", new Box(97, 9, 9, 9, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/incompatible.png", new Box(0, 216, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/unreachable.png", new Box(0, 216, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/ping_5.png", new Box(0, 176, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/ping_4.png", new Box(0, 184, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/ping_3.png", new Box(0, 192, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/ping_2.png", new Box(0, 200, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/ping_1.png", new Box(0, 208, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/pinging_1.png", new Box(10, 176, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/pinging_2.png", new Box(10, 184, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/pinging_3.png", new Box(10, 192, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/pinging_4.png", new Box(10, 200, 10, 8, 256, 256)),
+                        new OutputFile("textures/gui/sprites/server_list/pinging_5.png", new Box(10, 208, 10, 8, 256, 256))),
+                input("textures/gui/container/inventory.png",
+                        new OutputFile("textures/gui/sprites/hud/effect_background_ambient.png", new Box(165, 166, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/hud/effect_background.png", new Box(141, 166, 24, 24, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/inventory/effect_background_large.png", new Box(0, 166, 120, 32, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/inventory/effect_background_small.png", new Box(0, 198, 32, 32, 256, 256))),
+                input("textures/gui/unseen_notification.png",
+                        new OutputFile("textures/gui/sprites/icon/unseen_notification.png", new Box(0, 0, 10, 10, 10, 10))),
+                input("textures/gui/container/loom.png",
+                        new OutputFile("textures/gui/sprites/container/loom/banner_slot.png", new Box(176, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/dye_slot.png", new Box(192, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/pattern_slot.png", new Box(208, 0, 16, 16, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/scroller.png", new Box(232, 0, 12, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/scroller_disabled.png", new Box(244, 0, 12, 15, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/pattern_selected.png", new Box(0, 180, 14, 14, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/pattern_highlighted.png", new Box(0, 194, 14, 14, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/loom/pattern.png", new Box(0, 166, 14, 14, 256, 256)),
+                        (new OutputFile("textures/gui/sprites/container/loom/error.png", new Box(176, 17, 17, 16, 256, 256))).apply(spriteExtender())),
+                input("assets/realms/textures/gui/realms/invite_icon.png",
+                        new OutputFile("textures/gui/sprites/icon/invite.png", new Box(0, 0, 18, 15, 18, 30)),
+                        new OutputFile("textures/gui/sprites/icon/invite_highlighted.png", new Box(0, 15, 18, 15, 18, 30))),
+                input("textures/gui/container/cartography_table.png",
+                        new OutputFile("textures/gui/sprites/container/cartography_table/error.png", new Box(226, 132, 28, 21, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/cartography_table/scaled_map.png", new Box(176, 66, 66, 66, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/cartography_table/duplicated_map.png", new Box(176, 132, 50, 66, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/cartography_table/map.png", new Box(176, 0, 66, 66, 256, 256)),
+                        new OutputFile("textures/gui/sprites/container/cartography_table/locked.png", new Box(52, 214, 10, 14, 256, 256))),
+                input("assets/realms/textures/gui/realms/cross_player_icon.png",
+                        new OutputFile("textures/gui/sprites/player_list/remove_player.png", new Box(0, 0, 8, 7, 8, 14)),
+                        new OutputFile("textures/gui/sprites/player_list/remove_player_highlighted.png", new Box(0, 7, 8, 7, 8, 14))),
+                input("textures/gui/sprites/accessibility.png",
+                        new OutputFile("textures/gui/sprites/icon/accessibility.png", new Box(0, 0, 15, 15, 15, 15))),
+                input("textures/gui/container/stats_icons.png",
+                        new OutputFile("textures/gui/sprites/container/slot.png", new Box(0, 0, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/block_mined.png", new Box(54, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/item_broken.png", new Box(72, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/item_crafted.png", new Box(18, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/item_used.png", new Box(36, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/item_picked_up.png", new Box(90, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/item_dropped.png", new Box(108, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/header.png", new Box(0, 18, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/sort_up.png", new Box(36, 0, 18, 18, 128, 128)),
+                        new OutputFile("textures/gui/sprites/statistics/sort_down.png", new Box(18, 0, 18, 18, 128, 128))), moveRealmsToMinecraft("realms/adventure"), moveRealmsToMinecraft("realms/darken"), moveRealmsToMinecraft("realms/empty_frame"), moveRealmsToMinecraft("realms/experience"), moveRealmsToMinecraft("realms/inspiration"), moveRealmsToMinecraft("realms/new_world"), moveRealmsToMinecraft("realms/popup"), moveRealmsToMinecraft("realms/survival_spawn"), moveRealmsToMinecraft("realms/upload"), moveRealmsToMinecraft("title/realms"), copy("advancements/backgrounds/adventure"), copy("advancements/backgrounds/end"), copy("advancements/backgrounds/husbandry"), copy("advancements/backgrounds/nether"), copy("advancements/backgrounds/stone"), copy("advancements/backgrounds/window"), copy("advancements/window"), copy("container/creative_inventory/tab_inventory"), copy("container/creative_inventory/tab_item_search"), copy("container/creative_inventory/tab_items"), clip("container/anvil", STANDARD_CONTAINER_BOX), clip("container/beacon", new Box(0, 0, 230, 219, 256, 256)), clip("container/blast_furnace", STANDARD_CONTAINER_BOX), clip("container/brewing_stand", STANDARD_CONTAINER_BOX), clip("container/cartography_table", STANDARD_CONTAINER_BOX), clip("container/crafting_table", STANDARD_CONTAINER_BOX), clip("container/dispenser", STANDARD_CONTAINER_BOX), clip("container/enchanting_table", STANDARD_CONTAINER_BOX), clip("container/furnace", STANDARD_CONTAINER_BOX), clip("container/gamemode_switcher", new Box(0, 0, 125, 75, 128, 128)), copy("container/generic_54"), clip("container/grindstone", STANDARD_CONTAINER_BOX), clip("container/hopper", new Box(0, 0, 176, 133, 256, 256)), clip("container/horse", STANDARD_CONTAINER_BOX), clip("container/inventory", STANDARD_CONTAINER_BOX), clip("container/loom", STANDARD_CONTAINER_BOX), clip("container/shulker_box", STANDARD_CONTAINER_BOX), clip("container/smithing", STANDARD_CONTAINER_BOX), clip("container/smoker", STANDARD_CONTAINER_BOX), clip("container/stonecutter", STANDARD_CONTAINER_BOX), clip("container/villager2", "container/villager", new Box(0, 0, 276, 166, 512, 256)), copy("hanging_signs/acacia"), copy("hanging_signs/bamboo"), copy("hanging_signs/birch"), copy("hanging_signs/cherry"), copy("hanging_signs/crimson"), copy("hanging_signs/dark_oak"), copy("hanging_signs/jungle"), copy("hanging_signs/mangrove"), copy("hanging_signs/oak"), copy("hanging_signs/spruce"), copy("hanging_signs/warped"), copy("presets/isles"), copy("title/background/panorama_0"), copy("title/background/panorama_1"), copy("title/background/panorama_2"), copy("title/background/panorama_3"), copy("title/background/panorama_4"), copy("title/background/panorama_5"), copy("title/background/panorama_overlay"), copy("title/edition"), copy("title/minceraft"), copy("title/minecraft"), copy("title/mojangstudios"), clip("book", new Box(20, 1, 146, 180, 256, 256)), copy("demo_background"), copy("footer_separator"), copy("header_separator"), copy("light_dirt_background"), copy("options_background"), clip("recipe_book", new Box(0, 0, 149, 168, 256, 256)));
+    }
+
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -83,6 +83,7 @@ public class ResourcePack {
         if (Settings.HIDE_SCOREBOARD_NUMBERS.toBool()) generateScoreboardHideNumbers();
         if (Settings.HIDE_SCOREBOARD_BACKGROUND.toBool()) generateScoreboardHideBackground();
         if (Settings.GENERATE_ARMOR_SHADER_FILES.toBool()) CustomArmorsTextures.generateArmorShaderFiles();
+        if (Settings.TEXTURE_SLICER.toBool()) PackSlicer.slicePackFiles();
 
         for (final Collection<Consumer<File>> packModifiers : packModifiers.values())
             for (Consumer<File> packModifier : packModifiers)
@@ -368,6 +369,10 @@ public class ResourcePack {
 
     public File getFile() {
         return pack;
+    }
+
+    public File getPackFolder() {
+        return packFolder;
     }
 
     private void extractInPackIfNotExists(final File file) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -145,7 +145,7 @@ public class ResourcePack {
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> {
             OraxenPackGeneratedEvent event = new OraxenPackGeneratedEvent(output);
-            event.callEvent();
+            EventUtils.callEvent(event);
             ZipUtils.writeZipFile(pack, event.getOutput());
 
             UploadManager uploadManager = new UploadManager(OraxenPlugin.get());

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -278,9 +278,8 @@ public class ResourcePack {
         final ZipInputStream zip = ResourcesManager.browse();
         try {
             ZipEntry entry = zip.getNextEntry();
-            final ResourcesManager resourcesManager = new ResourcesManager(OraxenPlugin.get());
             while (entry != null) {
-                extract(entry, resourcesManager, isSuitable(entry.getName()));
+                extract(entry, OraxenPlugin.get().getResourceManager(), isSuitable(entry.getName()));
                 entry = zip.getNextEntry();
             }
             zip.closeEntry();
@@ -305,10 +304,9 @@ public class ResourcePack {
         final ZipInputStream zip = ResourcesManager.browse();
         try {
             ZipEntry entry = zip.getNextEntry();
-            final ResourcesManager resourcesManager = new ResourcesManager(OraxenPlugin.get());
             while (entry != null) {
                 if (entry.getName().startsWith("pack/textures/models/armor/leather_layer_") || entry.getName().startsWith("pack/textures/required") || entry.getName().startsWith("pack/models/required")) {
-                    resourcesManager.extractFileIfTrue(entry, !OraxenPlugin.get().getDataFolder().toPath().resolve(entry.getName()).toFile().exists());
+                    OraxenPlugin.get().getResourceManager().extractFileIfTrue(entry, !OraxenPlugin.get().getDataFolder().toPath().resolve(entry.getName()).toFile().exists());
                 }
                 entry = zip.getNextEntry();
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/Box.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/Box.java
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package io.th0rgal.oraxen.pack.generation.slicer;
+
+public record Box(int x, int y, int w, int h, int totalW, int totalH) {
+    public int scaleX(final int imgWidth) {
+        return x * imgWidth / totalW;
+    }
+
+    public int scaleY(final int imgHeight) {
+        return y * imgHeight / totalH;
+    }
+
+    public int scaleW(final int imgWidth) {
+        return w * imgWidth / totalW;
+    }
+
+    public int scaleH(final int imgHeight) {
+        return h * imgHeight / totalH;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/InputFile.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/InputFile.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package io.th0rgal.oraxen.pack.generation.slicer;
+
+import io.th0rgal.oraxen.utils.logs.Logs;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@ParametersAreNonnullByDefault
+public class InputFile {
+    private final String path;
+    private final List<OutputFile> outputs = new ArrayList<>();
+
+    public InputFile(final String path) {
+        this.path = path;
+    }
+
+    public InputFile outputs(final OutputFile... files) {
+        Collections.addAll(outputs, files);
+        return this;
+    }
+
+    public void process(final Path inputRoot, final Path outputRoot, @Nullable final Path leftoverRoot) throws IOException {
+        final Path inputPath = inputRoot.resolve(this.path);
+        if (Files.exists(inputPath)) {
+            try (final InputStream is = Files.newInputStream(inputPath)) {
+                final BufferedImage image = ImageIO.read(is);
+                final BufferedImage leftoverImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
+                final Graphics2D leftoverGraphics = leftoverImage.createGraphics();
+                leftoverGraphics.drawImage(image, 0, 0, null);
+
+                for (final OutputFile outputFile : outputs) {
+                    outputFile.process(outputRoot, inputPath, image, leftoverGraphics);
+                }
+
+                leftoverGraphics.dispose();
+
+                if (leftoverRoot != null) {
+                    final Path leftoverPath = leftoverRoot.resolve(this.path);
+                    Slicer.writeImage(leftoverPath, leftoverImage);
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/OutputFile.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/OutputFile.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package io.th0rgal.oraxen.pack.generation.slicer;
+
+import io.th0rgal.oraxen.utils.logs.Logs;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+@ParametersAreNonnullByDefault
+public class OutputFile {
+    private static final Color REMOVED_MARKER = new Color(128, 0, 0, 128);
+
+    private final String path;
+    private final Box box;
+    private final List<UnaryOperator<BufferedImage>> transformers = new ArrayList<>();
+    @Nullable
+    private String metadata;
+
+    public OutputFile(final String path, final Box box) {
+        this.path = path;
+        this.box = box;
+    }
+
+    public void process(final Path root, final Path imagePath, final BufferedImage image, final Graphics leftover) throws IOException {
+        final int width = image.getWidth();
+        final int height = image.getHeight();
+
+        final Path outputPath = root.resolve(path);
+        final int x = box.scaleX(width);
+        final int y = box.scaleY(height);
+        final int w = box.scaleW(width);
+        final int h = box.scaleH(height);
+
+        Files.createDirectories(outputPath.getParent());
+
+        if (x == 0 && y == 0 && w == width && h == height && transformers.isEmpty())
+            Files.copy(imagePath, outputPath, StandardCopyOption.REPLACE_EXISTING);
+        else {
+            BufferedImage subImage = image.getSubimage(x, y, w, h);
+            for (final UnaryOperator<BufferedImage> op : transformers) subImage = op.apply(subImage);
+            Slicer.writeImage(outputPath, subImage);
+        }
+
+        final Path inputMetaPath = getMetaPath(imagePath);
+        if (Files.exists(inputMetaPath))
+            Files.copy(inputMetaPath, getMetaPath(outputPath), StandardCopyOption.REPLACE_EXISTING);
+        else if (metadata != null)
+            Files.writeString(getMetaPath(outputPath), metadata);
+
+        leftover.setColor(REMOVED_MARKER);
+        leftover.fillRect(x, y, w, h);
+    }
+
+    private static Path getMetaPath(final Path path) {
+        return path.resolveSibling(path.getFileName().toString() + ".mcmeta");
+    }
+
+    public OutputFile apply(final UnaryOperator<BufferedImage> transform) {
+        transformers.add(transform);
+        return this;
+    }
+
+    public OutputFile metadata(final String metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/Slicer.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/Slicer.java
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package io.th0rgal.oraxen.pack.generation.slicer;
+
+import io.th0rgal.oraxen.utils.logs.Logs;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.*;
+import java.util.Collection;
+import java.util.Collections;
+
+@ParametersAreNonnullByDefault
+public class Slicer {
+    private final Path inputPath;
+    private final Path outputPath;
+    @Nullable
+    private final Path leftoverPath;
+
+    public Slicer(final Path inputPath, final Path outputPath, @Nullable final Path leftoverPath) {
+        this.inputPath = inputPath;
+        this.outputPath = outputPath;
+        this.leftoverPath = leftoverPath;
+    }
+
+    public static Slicer parse(final String[] argv) {
+        final int argc = argv.length;
+        if (argc != 2 && argc != 3) {
+            throw new IllegalArgumentException("Usage: <input dir or zip> <output dir> [<leftover dir>]");
+        }
+
+        final Path inputPath = Paths.get(argv[0]);
+        final Path outputPath = Paths.get(argv[1]);
+        final Path leftoverPath = argc == 3 ? Paths.get(argv[2]) : null;
+
+        return new Slicer(inputPath, outputPath, leftoverPath);
+    }
+
+    public static void writeImage(final Path path, final BufferedImage image) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.deleteIfExists(path);
+        try (final OutputStream os = Files.newOutputStream(path)) {
+            ImageIO.write(image, "png", os);
+        }
+    }
+
+    public void process(final Collection<InputFile> inputs) throws IOException {
+        if (Files.isDirectory(inputPath)) process(inputs, inputPath, outputPath, leftoverPath);
+        else if (inputPath.getFileName().toString().endsWith(".zip")) {
+            final URI fsUri = URI.create("jar:" + inputPath.toUri());
+            try (final FileSystem fs = FileSystems.newFileSystem(fsUri, Collections.emptyMap())) {
+                process(inputs, fs.getPath("/"), outputPath, leftoverPath);
+            }
+        } else throw new IllegalStateException("Expected either directory or zip file");
+    }
+
+    private static void process(final Collection<InputFile> inputs, final Path inputPath, final Path outputPath, @Nullable final Path leftoverPath) throws IOException {
+        for (final InputFile input : inputs) {
+            input.process(inputPath, outputPath, leftoverPath);
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/receive/PackAction.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/receive/PackAction.java
@@ -42,7 +42,7 @@ public class PackAction {
             }
         }
 
-        commandsParser = new CommandsParser(configurationSection.getConfigurationSection("commands"));
+        commandsParser = new CommandsParser(configurationSection.getConfigurationSection("commands"), tagResolver);
     }
 
     public int getDelay() {

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/CustomRecipe.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/CustomRecipe.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.recipes;
 
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
@@ -53,10 +54,6 @@ public class CustomRecipe {
         return ordered;
     }
 
-    /*
-     *
-     */
-
     @Override
     public boolean equals(Object object) {
         if (object == null) return false;
@@ -65,44 +62,23 @@ public class CustomRecipe {
         return false;
     }
 
-    /*
-     *
-     */
     @Override
     public int hashCode() {
         return result.hashCode() / 2 + ingredients.hashCode() / 2 + (ordered ? 1 : 0);
     }
 
-    /*
-     *
-     */
-
     private boolean areEqual(List<ItemStack> ingredients1, List<ItemStack> ingredients2) {
-        if (ingredients1.size() != ingredients2.size())
-            return false;
         for (int index = 0; index < ingredients1.size(); index++) {
             ItemStack ingredient1 = ingredients1.get(index);
             if (ordered) {
                 ItemStack ingredient2 = ingredients2.get(index);
-                if (ingredient1 == null && ingredient2 == null)
-                    continue;
-                if (ingredient1 == null || ingredient2 == null)
-                    return false;
-                if (!ingredient1.isSimilar(ingredient2))
-                    return false;
-            } else {
-                if (ingredient1 == null)
-                    continue;
-                if (ingredients2.stream().noneMatch(ingredient1::isSimilar))
-                    return false;
-            }
+                if (ingredient1 == null && ingredient2 == null) continue;
+                if (ingredient1 == null || ingredient2 == null) return false;
+                if (!ingredient1.isSimilar(ingredient2)) return false;
+            } else if (ingredient1 != null && ingredients2.stream().noneMatch(ingredient1::isSimilar)) return false;
         }
         return true;
     }
-
-    /*
-     *
-     */
 
     public static CustomRecipe fromRecipe(Recipe bukkitRecipe) {
         if (bukkitRecipe instanceof ShapedRecipe recipe) {
@@ -123,13 +99,11 @@ public class CustomRecipe {
             List<ItemStack> ingredients = new ArrayList<>(9);
             ingredients.addAll(recipe.getIngredientList());
             return new CustomRecipe(recipe.getKey().getKey(), recipe.getResult(), ingredients, false);
-        } else {
-            return null;
-        }
+        } else return null;
     }
 
     /**
-     * Checks if the recipe is a dye recipe
+     * Checks if the recipe is a dye recipe.
      * This does not ensure the second ingredient is dyeable,
      * only that the ingredient is not CustomArmor and therefore dyeable
      */

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/RecipesManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/RecipesManager.java
@@ -43,7 +43,7 @@ public class RecipesManager {
         if (!recipesFolder.exists()) {
             recipesFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                new ResourcesManager(plugin).extractConfigsInFolder("recipes", "yml");
+                OraxenPlugin.get().getResourceManager().extractConfigsInFolder("recipes", "yml");
             else try {
                 new File(recipesFolder, "furnace.yml").createNewFile();
                 new File(recipesFolder, "shaped.yml").createNewFile();
@@ -76,7 +76,7 @@ public class RecipesManager {
         if (!recipesFolder.exists()) {
             recipesFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                new ResourcesManager(OraxenPlugin.get()).extractConfigsInFolder("recipes", "yml");
+                OraxenPlugin.get().getResourceManager().extractConfigsInFolder("recipes", "yml");
         }
         registerAllConfigRecipesFromFolder(recipesFolder);
         RecipesEventsManager.get().registerEvents();

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/builders/RecipeBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/builders/RecipeBuilder.java
@@ -68,7 +68,7 @@ public abstract class RecipeBuilder {
 
     public YamlConfiguration getConfig() {
         if (configFile == null) {
-            configFile = new ResourcesManager(OraxenPlugin.get())
+            configFile = OraxenPlugin.get().getResourceManager()
                     .extractConfiguration("recipes/" + builderName + ".yml");
             config = OraxenYaml.loadConfiguration(configFile);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
@@ -14,10 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.MerchantInventory;
-import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -61,7 +58,7 @@ public class RecipesEventsManager implements Listener {
         ItemStack result = event.getInventory().getResult();
         if (result == null) return;
 
-        boolean containsOraxenItem = Arrays.stream(event.getInventory().getMatrix()).anyMatch(ingredient -> OraxenItems.exists(OraxenItems.getIdByItem(ingredient)));
+        boolean containsOraxenItem = Arrays.stream(event.getInventory().getMatrix()).anyMatch(OraxenItems::exists);
         if (!containsOraxenItem || recipe == null) return;
 
         CustomRecipe current = new CustomRecipe(null, recipe.getResult(), Arrays.asList(event.getInventory().getMatrix()));

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
@@ -3,6 +3,8 @@ package io.th0rgal.oraxen.recipes.loaders;
 import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
+import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
 import io.th0rgal.oraxen.recipes.listeners.RecipesEventsManager;
@@ -34,13 +36,15 @@ public abstract class RecipeLoader {
         ItemStack result;
         int amount = resultSection.getInt("amount", 1);
 
-        if (resultSection.isString("oraxen_item")) {
+        if (resultSection.isString("oraxen_item"))
             result = ItemUpdater.updateItem(OraxenItems.getItemById(resultSection.getString("oraxen_item")).build());
-        } else if (resultSection.isString("crucible_item")) {
-            result = MythicCrucible.core().getItemManager().getItemStack(resultSection.getString("crucible_item"));
-        } else if (resultSection.isString("mmoitems_id") && resultSection.isString("mmoitems_type")) {
+        else if (resultSection.isString("crucible_item"))
+            result = new WrappedCrucibleItem(resultSection.getString("crucible_item")).build();
+        else if (resultSection.isString("mmoitems_id") && resultSection.isString("mmoitems_type"))
             result = MMOItems.plugin.getItem(resultSection.getString("mmoitems_type"), resultSection.getString("mmoitems_id"));
-        } else if (resultSection.isString("minecraft_type")) {
+        else if (resultSection.isString("ecoitem_id"))
+            result = new WrappedEcoItem(resultSection.getString("ecoitem_id")).build();
+        else if (resultSection.isString("minecraft_type")) {
             Material material = Material.getMaterial(resultSection.getString("minecraft_type", "AIR"));
             if (material == null || material.isAir()) return null;
             result = new ItemStack(material);
@@ -55,11 +59,15 @@ public abstract class RecipeLoader {
             return ItemUpdater.updateItem(OraxenItems.getItemById(ingredientSection.getString("oraxen_item")).build());
 
         if (ingredientSection.isString("crucible_item")) {
-            return MythicCrucible.core().getItemManager().getItemStack(ingredientSection.getString("crucible_item"));
+            return new WrappedCrucibleItem(ingredientSection.getString("crucible_item")).build();
         }
 
         if (ingredientSection.isString("mmoitems_id") && ingredientSection.isString("mmoitems_type")) {
             return MMOItems.plugin.getItem(ingredientSection.getString("mmoitems_type"), ingredientSection.getString("mmoitems_id"));
+        }
+
+        if (ingredientSection.isString("ecoitem_id")) {
+            return new WrappedEcoItem(ingredientSection.getString("ecoitem_id")).build();
         }
 
         if (ingredientSection.isString("minecraft_type")) {
@@ -77,11 +85,17 @@ public abstract class RecipeLoader {
             return new RecipeChoice.ExactChoice(ItemUpdater.updateItem(OraxenItems.getItemById(ingredientSection.getString("oraxen_item")).build()));
 
         if (ingredientSection.isString("crucible_item")) {
-            return new RecipeChoice.ExactChoice(MythicCrucible.core().getItemManager().getItemStack(section.getString("crucible_item")));
+            ItemStack ingredient = new WrappedCrucibleItem(section.getString("crucible_item")).build();
+            return new RecipeChoice.ExactChoice(ingredient != null ? ingredient : new ItemStack(Material.AIR));
         }
 
         if (ingredientSection.isString("mmoitems_id") && ingredientSection.isString("mmoitems_type")) {
             ItemStack ingredient = MMOItems.plugin.getItem(ingredientSection.getString("mmoitems_type"), ingredientSection.getString("mmoitems_id"));
+            return new RecipeChoice.ExactChoice(ingredient != null ? ingredient : new ItemStack(Material.AIR));
+        }
+
+        if (ingredientSection.isString("ecoitem_id")) {
+            ItemStack ingredient = new WrappedEcoItem(section.getString("ecoitem_id")).build();
             return new RecipeChoice.ExactChoice(ingredient != null ? ingredient : new ItemStack(Material.AIR));
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -146,6 +146,8 @@ public class BlockHelpers {
             target.setBlockData(newData);
             correctedData = oldCorrectBlockData(placedAgainst.getRelative(face), player, face, item);
             if (correctedData == null) target.setBlockData(oldData);
+            if (player.getGameMode() != GameMode.CREATIVE) item.setAmount(item.getAmount() - 1);
+            Utils.swingHand(player, hand);
         }
 
         if (target.getState() instanceof Sign sign) player.openSign(sign);

--- a/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -60,15 +60,23 @@ public class BlockHelpers {
     }
 
     public static Location toBlockLocation(Location location) {
-        return location.toBlockLocation();
+        Location blockLoc = location.clone();
+        blockLoc.setX(location.getBlockX());
+        blockLoc.setY(location.getBlockY());
+        blockLoc.setZ(location.getBlockZ());
+        return blockLoc;
     }
 
     public static Location toCenterLocation(Location location) {
-        return location.toCenterLocation();
+        Location centerLoc = location.clone();
+        centerLoc.setX(location.getBlockX() + 0.5);
+        centerLoc.setY(location.getBlockY() + 0.5);
+        centerLoc.setZ(location.getBlockZ() + 0.5);
+        return centerLoc;
     }
 
     public static Location toCenterBlockLocation(Location location) {
-        return location.toCenterLocation().subtract(0,0.5,0);
+        return toCenterLocation(location).subtract(0,0.5,0);
     }
 
     public static boolean isStandingInside(final Player player, final Block block) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/EventUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/EventUtils.java
@@ -1,0 +1,19 @@
+package io.th0rgal.oraxen.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+public class EventUtils {
+
+    /**
+     * Calls the event and tests if cancelled.
+     *
+     * @return false if event was cancelled, if cancellable. otherwise true.
+     */
+    public static boolean callEvent(Event event) {
+        Bukkit.getPluginManager().callEvent(event);
+        if (event instanceof Cancellable cancellable) return !cancellable.isCancelled();
+        else return true;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/OraxenYaml.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/OraxenYaml.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.utils;
 
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -48,10 +49,10 @@ public class OraxenYaml extends YamlConfiguration {
     public void load(@NotNull File file) {
         try {
             super.load(file);
-        } catch (Exception ex) {
+        } catch (Exception e) {
             // Handle the exception here (e.g., log the error)
-            System.err.println("Error loading YAML configuration file: " + file.getName());
-            ex.printStackTrace();
+            Logs.logError("Error loading YAML configuration file: " + file.getName());
+            if (Settings.DEBUG.toBool()) Logs.logWarning(e.getMessage());
             // You can choose to do nothing and keep the existing data in the file
             // or provide default values and continue.
         }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PackUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PackUtils.java
@@ -1,0 +1,18 @@
+package io.th0rgal.oraxen.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+
+public class PackUtils {
+
+    public static String getFinalPackPath(File file) {
+        String filePath = StringUtils.substringAfter(file.getAbsolutePath().replace("\\", "/"), "Oraxen/pack");
+        return filePath.startsWith("assets") ? filePath : "assets/minecraft/" + filePath;
+    }
+
+    public static String getShortenedPackPath(File file) {
+        String filePath = StringUtils.substringAfter(file.getAbsolutePath().replace("\\", "/"), "Oraxen/pack");
+        return filePath;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -22,10 +22,10 @@ public class VersionUtil {
         UNKNOWN;
 
         public static boolean matchesServer(String version) {
-            return getNMSVersion(Bukkit.getMinecraftVersion()).equals(getNMSVersion(version));
+            return getNMSVersion(getMinecraftVersion()).equals(getNMSVersion(version));
         }
         public static boolean matchesServer(NMSVersion version) {
-            return version != UNKNOWN && getNMSVersion(Bukkit.getMinecraftVersion()).equals(version);
+            return version != UNKNOWN && getNMSVersion(getMinecraftVersion()).equals(version);
         }
     }
 
@@ -51,11 +51,11 @@ public class VersionUtil {
     }
 
     public static boolean matchesServer(String server) {
-        return server.equals(Bukkit.getMinecraftVersion());
+        return server.equals(getMinecraftVersion());
     }
 
     public static boolean isSupportedVersionOrNewer(String versionString) {
-        int serverValue = getVersionValue(Bukkit.getMinecraftVersion());
+        int serverValue = getVersionValue(getMinecraftVersion());
         return getVersionValue(versionString) <= serverValue;
     }
 
@@ -137,5 +137,10 @@ public class VersionUtil {
     public static boolean isValidCompiler() {
         List<String> split = Arrays.stream(manifest.split(":|\n")).map(String::trim).toList();
         return Set.of("sivert", "thomas").contains(split.get(split.indexOf("Built-By") + 1).toLowerCase());
+    }
+
+    public static String getMinecraftVersion() {
+        if (isPaperServer()) return Bukkit.getMinecraftVersion();
+        else return Bukkit.getVersion().split("MC: ")[1].split("\\)")[0];
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/actions/ClickAction.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/actions/ClickAction.java
@@ -54,14 +54,10 @@ public class ClickAction {
 
     @SuppressWarnings("unchecked")
     public static List<ClickAction> parseList(final ConfigurationSection section) {
-        if (section.getParent().getParent().getName().contains("table")) Logs.logError("parseList");
-        // The section doesn't contain clickActions, we can just return an empty list
-        if (!section.isList("clickActions")) return Collections.emptyList();
-
-        final List<LinkedHashMap<String, Object>> list = (List<LinkedHashMap<String, Object>>) section.getList("clickActions");
+        final List<LinkedHashMap<String, Object>> list = (List<LinkedHashMap<String, Object>>) section.getList("clickActions", Collections.emptyList());
 
         // Return an empty list if the clickActions list is null / empty
-        if (list == null || list.isEmpty()) return Collections.emptyList();
+        if (list.isEmpty()) return Collections.emptyList();
 
         final List<ClickAction> clickActions = new ArrayList<>(list.size());
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/actions/impl/other/SoundAction.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/actions/impl/other/SoundAction.java
@@ -16,7 +16,7 @@ public class SoundAction extends Action<Player> {
     public static final String IDENTIFIER = "sound";
 
     private final Sound.Source source = getMeta().getProperty("source", Sound.Source.MASTER, input -> Sound.Source.NAMES.value(input.toLowerCase()));
-    private final float volume = getMeta().getProperty("float", 1f, Floats::tryParse);
+    private final float volume = getMeta().getProperty("volume", 1f, Floats::tryParse);
     private final float pitch = getMeta().getProperty("pitch", 1f, Floats::tryParse);
 
     public SoundAction(@NotNull ActionMeta<Player> meta) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/armorequipevent/ArmorListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/armorequipevent/ArmorListener.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.utils.armorequipevent;
 
+import io.th0rgal.oraxen.utils.EventUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
@@ -61,7 +62,7 @@ public class ArmorListener implements Listener {
             if (newArmorType != null) {
                 boolean equipping = event.getRawSlot() != newArmorType.getSlot();
                 if (newArmorType.equals(ArmorType.HELMET) && (equipping == isEmpty(event.getWhoClicked().getInventory().getHelmet())) || newArmorType.equals(ArmorType.CHESTPLATE) && (equipping == isEmpty(event.getWhoClicked().getInventory().getChestplate())) || newArmorType.equals(ArmorType.LEGGINGS) && (equipping ? isEmpty(event.getWhoClicked().getInventory().getLeggings()) : !isEmpty(event.getWhoClicked().getInventory().getLeggings())) || newArmorType.equals(ArmorType.BOOTS) && (equipping ? isEmpty(event.getWhoClicked().getInventory().getBoots()) : !isEmpty(event.getWhoClicked().getInventory().getBoots()))) {
-                    if (!new ArmorEquipEvent((Player) event.getWhoClicked(), ArmorEquipEvent.EquipMethod.SHIFT_CLICK, newArmorType, equipping ? null : event.getCurrentItem(), equipping ? event.getCurrentItem() : null).callEvent())
+                    if (!EventUtils.callEvent(new ArmorEquipEvent((Player) event.getWhoClicked(), ArmorEquipEvent.EquipMethod.SHIFT_CLICK, newArmorType, equipping ? null : event.getCurrentItem(), equipping ? event.getCurrentItem() : null)))
                         event.setCancelled(true);
                 }
             }
@@ -100,7 +101,7 @@ public class ArmorListener implements Listener {
                 ArmorEquipEvent.EquipMethod method = ArmorEquipEvent.EquipMethod.PICK_DROP;
                 if (event.getAction().equals(InventoryAction.HOTBAR_SWAP) || numberkey)
                     method = ArmorEquipEvent.EquipMethod.HOTBAR_SWAP;
-                if (!new ArmorEquipEvent((Player) event.getWhoClicked(), method, newArmorType, oldArmorPiece, newArmorPiece).callEvent())
+                if (!EventUtils.callEvent(new ArmorEquipEvent((Player) event.getWhoClicked(), method, newArmorType, oldArmorPiece, newArmorPiece)))
                     event.setCancelled(true);
             }
         }
@@ -129,7 +130,7 @@ public class ArmorListener implements Listener {
         if (newArmorType == ArmorType.LEGGINGS && !isEmpty(equipment.getLeggings())) return;
         if (newArmorType == ArmorType.BOOTS && !isEmpty(equipment.getBoots())) return;
 
-        if (!new ArmorEquipEvent(event.getPlayer(), ArmorEquipEvent.EquipMethod.HOTBAR, ArmorType.matchType(event.getItem()), null, event.getItem()).callEvent())
+        if (!EventUtils.callEvent(new ArmorEquipEvent(event.getPlayer(), ArmorEquipEvent.EquipMethod.HOTBAR, ArmorType.matchType(event.getItem()), null, event.getItem())))
             event.setCancelled(true);
     }
 
@@ -191,7 +192,7 @@ public class ArmorListener implements Listener {
         ArmorType type = ArmorType.matchType(event.getOldCursor());
         if (event.getRawSlots().isEmpty()) return;// Idk if this will ever happen
         if (type != null && type.getSlot() == event.getRawSlots().stream().findFirst().orElse(0)) {
-            if (!new ArmorEquipEvent((Player) event.getWhoClicked(), ArmorEquipEvent.EquipMethod.DRAG, type, null, event.getOldCursor()).callEvent()) {
+            if (!EventUtils.callEvent(new ArmorEquipEvent((Player) event.getWhoClicked(), ArmorEquipEvent.EquipMethod.DRAG, type, null, event.getOldCursor()))) {
                 event.setResult(Result.DENY);
                 event.setCancelled(true);
             }
@@ -203,7 +204,7 @@ public class ArmorListener implements Listener {
         ArmorType type = ArmorType.matchType(event.getBrokenItem());
         Player player = event.getPlayer();
         if (type == null) return;
-        if (new ArmorEquipEvent(player, ArmorEquipEvent.EquipMethod.BROKE, type, event.getBrokenItem(), null).callEvent()) return;
+        if (EventUtils.callEvent(new ArmorEquipEvent(player, ArmorEquipEvent.EquipMethod.BROKE, type, event.getBrokenItem(), null))) return;
 
         ItemStack i = event.getBrokenItem().clone();
         i.setAmount(1);
@@ -225,7 +226,7 @@ public class ArmorListener implements Listener {
         if (event.getKeepInventory()) return;
         for (ItemStack i : p.getInventory().getArmorContents()) {
             if (isEmpty(i)) continue;
-            new ArmorEquipEvent(p, ArmorEquipEvent.EquipMethod.DEATH, ArmorType.matchType(i), i, null).callEvent();
+            EventUtils.callEvent(new ArmorEquipEvent(p, ArmorEquipEvent.EquipMethod.DEATH, ArmorType.matchType(i), i, null));
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/armorequipevent/DispenserArmorListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/armorequipevent/DispenserArmorListener.java
@@ -1,6 +1,6 @@
 package io.th0rgal.oraxen.utils.armorequipevent;
 
-import org.bukkit.Bukkit;
+import io.th0rgal.oraxen.utils.EventUtils;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,7 +14,6 @@ class DispenserArmorListener implements Listener {
         if (type == null || !(event.getTargetEntity() instanceof Player p)) return;
 
         ArmorEquipEvent armorEquipEvent = new ArmorEquipEvent(p, ArmorEquipEvent.EquipMethod.DISPENSER, type, null, event.getItem());
-        Bukkit.getServer().getPluginManager().callEvent(armorEquipEvent);
-        if (armorEquipEvent.isCancelled()) event.setCancelled(true);
+        if (!EventUtils.callEvent(armorEquipEvent)) event.setCancelled(true);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -20,6 +20,7 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.blocksounds.BlockSounds;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
@@ -148,9 +149,9 @@ public class BreakerSystem {
 
                         if (value++ < 10) return;
 
-                        if (new BlockBreakEvent(block, player).callEvent() && ProtectionLib.canBreak(player, block.getLocation())) {
+                        if (EventUtils.callEvent(new BlockBreakEvent(block, player)) && ProtectionLib.canBreak(player, block.getLocation())) {
                             modifier.breakBlock(player, block, item);
-                            new PlayerItemDamageEvent(player, item, 1).callEvent();
+                            EventUtils.callEvent(new PlayerItemDamageEvent(player, item, 1));
                         } else breakerPlaySound.remove(block);
 
                         Bukkit.getScheduler().runTask(OraxenPlugin.get(), () ->

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -21,6 +21,8 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.EventUtils;
+import io.th0rgal.oraxen.utils.Utils;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.blocksounds.BlockSounds;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
@@ -36,6 +38,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -156,6 +159,13 @@ public class BreakerSystem {
 
                         Bukkit.getScheduler().runTask(OraxenPlugin.get(), () ->
                                 player.removePotionEffect(PotionEffectType.SLOW_DIGGING));
+
+                        if (VersionUtil.isPaperServer()) item.damage(1, player);
+                        else Utils.editItemMeta(item, meta -> {
+                            if (meta instanceof Damageable damageable)
+                                damageable.setDamage(damageable.getDamage() + 1);
+                        });
+
                         breakerPerLocation.remove(location);
                         for (final Entity entity : world.getNearbyEntities(location, 16, 16, 16)) {
                             if (entity instanceof Player viewer) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/commands/CommandsParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/commands/CommandsParser.java
@@ -1,10 +1,13 @@
 package io.th0rgal.oraxen.utils.commands;
 
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommandsParser {
 
@@ -13,14 +16,14 @@ public class CommandsParser {
     private List<String> oppedPlayerCommands;
     private boolean empty = false;
 
-    public CommandsParser(ConfigurationSection section) {
+    public CommandsParser(ConfigurationSection section, TagResolver tagResolver) {
         if (section == null) {
             empty = true;
             return;
         }
 
         if (section.isList("console"))
-            this.consoleCommands = section.getStringList("console");
+            this.consoleCommands = section.getStringList("console").stream().map(s -> AdventureUtils.parseMiniMessage(s, tagResolver)).collect(Collectors.toList());
 
         if (section.isList("player"))
             this.playerCommands = section.getStringList("player");

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 public class ItemsView {
 
-    private final YamlConfiguration settings = new ResourcesManager(OraxenPlugin.get()).getSettings();
+    private final YamlConfiguration settings = OraxenPlugin.get().getResourceManager().getSettings();
     ChestGui mainGui;
 
     public ChestGui create() {

--- a/core/src/main/resources/items/armors.yml
+++ b/core/src/main/resources/items/armors.yml
@@ -56,12 +56,9 @@ emerald_leggings:
     durability:
       value: 595
   AttributeModifiers:
-    - { attribute: GENERIC_MAX_HEALTH, amount: 3, operation: 0,
-        slot: LEGS }
-    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0,
-        slot: LEGS }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
-        slot: LEGS }
+    - { attribute: GENERIC_MAX_HEALTH, amount: 3, operation: 0, slot: LEGS }
+    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0, slot: LEGS }
+    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: LEGS }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -78,12 +75,9 @@ emerald_boots:
     durability:
       value: 516
   AttributeModifiers:
-    - { attribute: GENERIC_MAX_HEALTH, amount: 2, operation: 0,
-        slot: FEET }
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0,
-        slot: FEET }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
-        slot: FEET }
+    - { attribute: GENERIC_MAX_HEALTH, amount: 2, operation: 0, slot: FEET }
+    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: FEET }
+    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: FEET }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -100,8 +94,7 @@ obsidian_helmet:
     durability:
       value: 4370
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 2, operation: 0,
-        slot: HEAD }
+    - { attribute: GENERIC_ARMOR, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -119,8 +112,7 @@ obsidian_chestplate:
     durability:
       value: 6350
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0,
-        slot: CHEST }
+    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0, slot: CHEST }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -137,8 +129,7 @@ obsidian_leggings:
     durability:
       value: 5950
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 5, operation: 0,
-        slot: LEGS }
+    - { attribute: GENERIC_ARMOR, amount: 5, operation: 0, slot: LEGS }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -155,8 +146,7 @@ obsidian_boots:
     durability:
       value: 5160
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 2, operation: 0,
-        slot: FEET }
+    - { attribute: GENERIC_ARMOR, amount: 2, operation: 0, slot: FEET }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -171,10 +161,8 @@ ruby_helmet:
     durability:
       value: 547 # 50% more than diamond helmet
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0,
-        slot: HEAD }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
-        slot: HEAD }
+    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -189,10 +177,8 @@ ruby_chestplate:
     durability:
       value: 792
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 8, operation: 0,
-        slot: CHEST }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
-        slot: CHEST }
+    - { attribute: GENERIC_ARMOR, amount: 8, operation: 0, slot: CHEST }
+    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: CHEST }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -207,10 +193,8 @@ ruby_leggings:
     durability:
       value: 742
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0,
-        slot: LEGS }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
-        slot: LEGS }
+    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0, slot: LEGS }
+    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: LEGS }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -225,10 +209,8 @@ ruby_boots:
     durability:
       value: 643
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0,
-        slot: FEET }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0,
-        slot: FEET }
+    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: FEET }
+    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: FEET }
   Pack:
     generate_model: true
     parent_model: "item/generated"

--- a/core/src/main/resources/items/hats.yml
+++ b/core/src/main/resources/items/hats.yml
@@ -19,7 +19,7 @@ anubis_head:
   Mechanics:
     hat:
       enabled: true
-    armorpotioneffects:
+    armor_effects:
       night_vision:
         amplifier: 0
         ambient: true # Makes potion effect produce more, translucent, particles.

--- a/core/src/main/resources/items/items.yml
+++ b/core/src/main/resources/items/items.yml
@@ -28,7 +28,7 @@ example_sword:
     # - operations: 0 for ADD_NUMBER, 1 for ADD_SCALAR, 2 for MULTIPLY_SCALAR_1;
     # - generate one here: https://www.uuidgenerator.net/
     # - slot: HAND, OFF_HAND, FEET, LEGS, CHEST or HEAD
-    - { name: "oraxen_speed", attribute: GENERIC_MOVEMENT_SPEED, amount: 0.1, operation: 0, slot: HAND }
+    - { attribute: GENERIC_MOVEMENT_SPEED, amount: 0.1, operation: 0, slot: HAND }
 
   Enchantments:
     protection: 4

--- a/core/src/main/resources/items/mystical.yml
+++ b/core/src/main/resources/items/mystical.yml
@@ -67,11 +67,9 @@ battle_axe:
   displayname: '<gradient:#F06966:#FAD6A6>Battle Axe'
   material: DIAMOND_AXE
   AttributeModifiers:
-    - name: oraxen
-      attribute: GENERIC_ATTACK_DAMAGE
+    - attribute: GENERIC_ATTACK_DAMAGE
       amount: 7
       operation: 0
-      uuid: d1fe3908-8aa8-49bb-8c1f-907b765a43ab
       slot: HAND
   Pack:
     generate_model: false

--- a/core/src/main/resources/items/weapons.yml
+++ b/core/src/main/resources/items/weapons.yml
@@ -132,11 +132,9 @@ combat_bow:
   displayname: '<gradient:#F69D84:#FAD98D>Combat Bow'
   material: BOW
   AttributeModifiers:
-    - name: oraxen
-      attribute: GENERIC_ATTACK_DAMAGE
+    - attribute: GENERIC_ATTACK_DAMAGE
       amount: 7
       operation: 0
-      uuid: d1fe3908-8aa8-49bb-8c1f-907b765a43ab
       slot: HAND
   Pack:
     generate_model: false

--- a/core/src/main/resources/mechanics.yml
+++ b/core/src/main/resources/mechanics.yml
@@ -61,6 +61,9 @@ noteblock:
     - NETHERITE
     - # ticks between each check for dryout
   farmblock_check_delay: 1000
+  # Removes the mineable/axe tag from noteblocks for player
+  # This is to prevent axes from breaking custom-blocks in normal speed
+  remove_mineable_tag: false
   enabled: true
 
 stringblock:

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -50,6 +50,7 @@ Pack:
     excluded_file_extensions: []
     verify_pack_files: true # Checks all textures and models to make sure they abide by valid Resourcepack formatting
     fix_force_unicode_glyphs: true # Fixes glyphs not being shown when Force Unicode is enabled
+    texture_slicer: true # Slices default-texture overrides into new 1.20.2 format
     atlas:
       exclude_malformed_from_atlas: true # If a texture is malformed, it will not be included in the atlas
       generate: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 pluginVersion=1.164.0
-idofrontVersion=0.18.27
+idofrontVersion=0.20.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pluginVersion=1.163.0
+pluginVersion=1.164.0
 idofrontVersion=0.18.27

--- a/v1_18_R1/src/main/java/io/th0rgal/oraxen/nms/v1_18_R1/NMSHandler.java
+++ b/v1_18_R1/src/main/java/io/th0rgal/oraxen/nms/v1_18_R1/NMSHandler.java
@@ -105,6 +105,11 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     }
 
     @Override
+    public void customBlockDefaultTools(Player player) {
+        // Too different cant be asked
+    }
+
+    @Override
     public void setupNmsGlyphs() {
         if (!Settings.NMS_GLYPHS.toBool()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();

--- a/v1_18_R2/src/main/java/io/th0rgal/oraxen/nms/v1_18_R2/NMSHandler.java
+++ b/v1_18_R2/src/main/java/io/th0rgal/oraxen/nms/v1_18_R2/NMSHandler.java
@@ -10,9 +10,13 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Registry;
+import net.minecraft.data.BuiltinRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -20,13 +24,18 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.*;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerConnectionListener;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
@@ -46,7 +55,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
@@ -102,6 +113,43 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (direction == null) return null;
         BlockPos blockPos = new BlockPos(block.getX(), block.getY(), block.getZ()).relative(direction);
         return new BlockHitResult(vec3, direction.getOpposite(), blockPos, false);
+    }
+
+    @Override
+    public void customBlockDefaultTools(Player player) {
+        if (player instanceof CraftPlayer craftPlayer) {
+            TagNetworkSerialization.NetworkPayload payload = createPayload();
+            if (payload == null) return;
+            ClientboundUpdateTagsPacket packet = new ClientboundUpdateTagsPacket(Map.of(Registry.BLOCK.key(), payload));
+            craftPlayer.getHandle().connection.send(packet);
+        }
+    }
+
+    private TagNetworkSerialization.NetworkPayload createPayload() {
+        Constructor<?> constructor = Arrays.stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst().orElse(null);
+        if (constructor == null) return null;
+        constructor.setAccessible(true);
+        try {
+            return (TagNetworkSerialization.NetworkPayload) constructor.newInstance(tagRegistryMap);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private final Map<ResourceLocation, IntList> tagRegistryMap = createTagRegistryMap();
+
+    private static Map<ResourceLocation, IntList> createTagRegistryMap() {
+        return Registry.BLOCK.getTags().map(pair -> {
+            IntArrayList list = new IntArrayList(pair.getSecond().size());
+            if (pair.getFirst().location() == BlockTags.MINEABLE_WITH_AXE.location()) {
+                pair.getSecond().stream()
+                        .filter(block -> !block.value().getDescriptionId().endsWith("note_block"))
+                        .forEach(block -> list.add(Registry.BLOCK.getId(block.value())));
+            }
+
+            return Map.of(pair.getFirst().location(), list);
+        }).collect(HashMap::new, Map::putAll, Map::putAll);
     }
 
     @Override

--- a/v1_19_R1/src/main/java/io/th0rgal/oraxen/nms/v1_19_R1/NMSHandler.java
+++ b/v1_19_R1/src/main/java/io/th0rgal/oraxen/nms/v1_19_R1/NMSHandler.java
@@ -10,9 +10,12 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -20,13 +23,18 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.*;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerConnectionListener;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
@@ -46,7 +54,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
@@ -104,6 +114,43 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (direction == null) return null;
         BlockPos blockPos = new BlockPos(block.getX(), block.getY(), block.getZ()).relative(direction);
         return new BlockHitResult(vec3, direction.getOpposite(), blockPos, false);
+    }
+
+    @Override
+    public void customBlockDefaultTools(Player player) {
+        if (player instanceof CraftPlayer craftPlayer) {
+            TagNetworkSerialization.NetworkPayload payload = createPayload();
+            if (payload == null) return;
+            ClientboundUpdateTagsPacket packet = new ClientboundUpdateTagsPacket(Map.of(Registry.BLOCK.key(), payload));
+            craftPlayer.getHandle().connection.send(packet);
+        }
+    }
+
+    private TagNetworkSerialization.NetworkPayload createPayload() {
+        Constructor<?> constructor = Arrays.stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst().orElse(null);
+        if (constructor == null) return null;
+        constructor.setAccessible(true);
+        try {
+            return (TagNetworkSerialization.NetworkPayload) constructor.newInstance(tagRegistryMap);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private final Map<ResourceLocation, IntList> tagRegistryMap = createTagRegistryMap();
+
+    private static Map<ResourceLocation, IntList> createTagRegistryMap() {
+        return Registry.BLOCK.getTags().map(pair -> {
+            IntArrayList list = new IntArrayList(pair.getSecond().size());
+            if (pair.getFirst().location() == BlockTags.MINEABLE_WITH_AXE.location()) {
+                pair.getSecond().stream()
+                        .filter(block -> !block.value().getDescriptionId().endsWith("note_block"))
+                        .forEach(block -> list.add(Registry.BLOCK.getId(block.value())));
+            }
+
+            return Map.of(pair.getFirst().location(), list);
+        }).collect(HashMap::new, Map::putAll, Map::putAll);
     }
 
     @Override

--- a/v1_19_R2/src/main/java/io.th0rgal.oraxen.nms.v1_19_R2/NMSHandler.java
+++ b/v1_19_R2/src/main/java/io.th0rgal.oraxen.nms.v1_19_R2/NMSHandler.java
@@ -10,9 +10,13 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -20,13 +24,18 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.*;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerConnectionListener;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
@@ -46,7 +55,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
@@ -104,6 +115,43 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (direction == null) return null;
         BlockPos blockPos = new BlockPos(block.getX(), block.getY(), block.getZ()).relative(direction);
         return new BlockHitResult(vec3, direction.getOpposite(), blockPos, false);
+    }
+
+    @Override
+    public void customBlockDefaultTools(Player player) {
+        if (player instanceof CraftPlayer craftPlayer) {
+            TagNetworkSerialization.NetworkPayload payload = createPayload();
+            if (payload == null) return;
+            ClientboundUpdateTagsPacket packet = new ClientboundUpdateTagsPacket(Map.of(Registries.BLOCK, payload));
+            craftPlayer.getHandle().connection.send(packet);
+        }
+    }
+
+    private TagNetworkSerialization.NetworkPayload createPayload() {
+        Constructor<?> constructor = Arrays.stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst().orElse(null);
+        if (constructor == null) return null;
+        constructor.setAccessible(true);
+        try {
+            return (TagNetworkSerialization.NetworkPayload) constructor.newInstance(tagRegistryMap);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private final Map<ResourceLocation, IntList> tagRegistryMap = createTagRegistryMap();
+
+    private static Map<ResourceLocation, IntList> createTagRegistryMap() {
+        return BuiltInRegistries.BLOCK.getTags().map(pair -> {
+            IntArrayList list = new IntArrayList(pair.getSecond().size());
+            if (pair.getFirst().location() == BlockTags.MINEABLE_WITH_AXE.location()) {
+                pair.getSecond().stream()
+                        .filter(block -> !block.value().getDescriptionId().endsWith("note_block"))
+                        .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
+            }
+
+            return Map.of(pair.getFirst().location(), list);
+        }).collect(HashMap::new, Map::putAll, Map::putAll);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/io.th0rgal.oraxen.nms.v1_19_R3/NMSHandler.java
+++ b/v1_19_R3/src/main/java/io.th0rgal.oraxen.nms.v1_19_R3/NMSHandler.java
@@ -10,9 +10,13 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -21,13 +25,18 @@ import net.minecraft.network.*;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
+import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerConnectionListener;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
@@ -47,7 +56,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
@@ -105,6 +116,43 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (direction == null) return null;
         BlockPos blockPos = new BlockPos(block.getX(), block.getY(), block.getZ()).relative(direction);
         return new BlockHitResult(vec3, direction.getOpposite(), blockPos, false);
+    }
+
+    @Override
+    public void customBlockDefaultTools(Player player) {
+        if (player instanceof CraftPlayer craftPlayer) {
+            TagNetworkSerialization.NetworkPayload payload = createPayload();
+            if (payload == null) return;
+            ClientboundUpdateTagsPacket packet = new ClientboundUpdateTagsPacket(Map.of(Registries.BLOCK, payload));
+            craftPlayer.getHandle().connection.send(packet);
+        }
+    }
+
+    private TagNetworkSerialization.NetworkPayload createPayload() {
+        Constructor<?> constructor = Arrays.stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst().orElse(null);
+        if (constructor == null) return null;
+        constructor.setAccessible(true);
+        try {
+            return (TagNetworkSerialization.NetworkPayload) constructor.newInstance(tagRegistryMap);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private final Map<ResourceLocation, IntList> tagRegistryMap = createTagRegistryMap();
+
+    private static Map<ResourceLocation, IntList> createTagRegistryMap() {
+        return BuiltInRegistries.BLOCK.getTags().map(pair -> {
+            IntArrayList list = new IntArrayList(pair.getSecond().size());
+            if (pair.getFirst().location() == BlockTags.MINEABLE_WITH_AXE.location()) {
+                pair.getSecond().stream()
+                        .filter(block -> !block.value().getDescriptionId().endsWith("note_block"))
+                        .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
+            }
+
+            return Map.of(pair.getFirst().location(), list);
+        }).collect(HashMap::new, Map::putAll, Map::putAll);
     }
 
     @Override

--- a/v1_20_R1/src/main/java/io/th0rgal/oraxen/nms/v1_20_R1/NMSHandler.java
+++ b/v1_20_R1/src/main/java/io/th0rgal/oraxen/nms/v1_20_R1/NMSHandler.java
@@ -13,21 +13,30 @@ import io.th0rgal.oraxen.font.GlyphTag;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.*;
 import net.minecraft.network.*;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
+import net.minecraft.network.protocol.game.ClientboundUpdateTagsPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerConnectionListener;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagNetworkSerialization;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
@@ -47,7 +56,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Function;
@@ -115,6 +126,43 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (direction == null) return null;
         BlockPos blockPos = new BlockPos(block.getX(), block.getY(), block.getZ()).relative(direction);
         return new BlockHitResult(vec3, direction.getOpposite(), blockPos, false);
+    }
+
+    @Override
+    public void customBlockDefaultTools(Player player) {
+        if (player instanceof CraftPlayer craftPlayer) {
+            TagNetworkSerialization.NetworkPayload payload = createPayload();
+            if (payload == null) return;
+            ClientboundUpdateTagsPacket packet = new ClientboundUpdateTagsPacket(Map.of(Registries.BLOCK, payload));
+            craftPlayer.getHandle().connection.send(packet);
+        }
+    }
+
+    private TagNetworkSerialization.NetworkPayload createPayload() {
+        Constructor<?> constructor = Arrays.stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst().orElse(null);
+        if (constructor == null) return null;
+        constructor.setAccessible(true);
+        try {
+            return (TagNetworkSerialization.NetworkPayload) constructor.newInstance(tagRegistryMap);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private final Map<ResourceLocation, IntList> tagRegistryMap = createTagRegistryMap();
+
+    private static Map<ResourceLocation, IntList> createTagRegistryMap() {
+        return BuiltInRegistries.BLOCK.getTags().map(pair -> {
+            IntArrayList list = new IntArrayList(pair.getSecond().size());
+            if (pair.getFirst().location() == BlockTags.MINEABLE_WITH_AXE.location()) {
+                pair.getSecond().stream()
+                        .filter(block -> !block.value().getDescriptionId().endsWith("note_block"))
+                        .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
+            }
+
+            return Map.of(pair.getFirst().location(), list);
+        }).collect(HashMap::new, Map::putAll, Map::putAll);
     }
 
     @Override


### PR DESCRIPTION
**[New]**
- Add EcoItem support for recipes & food-mechanic replacementItem
- Add PackSlicer to split GUI-textures into 1.20.2 format

 **[Fixes]**
- Issues loading & sending pack to players on Spigot Servers
- `/oraxen reload all` command not reloading configs & re-registering listeners
- `crucible_item` not being loaded correctly
- Limited-placing mechanic not working properly
- ItemUpdater not retaining Armor Trims
- Stringblock not reducing itemcount when placed
- Food-mechanic not registering effects & replacementItem
- \<player>-tag not working in console-command mechanic
- Items not loosing durability when mining custom blocks
- Shapeless recipes not fully working
- Items with Durability-Mechanic inproperly repairing