### PR TITLE
Fixed custom armors breaking too easily

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanic.java
@@ -32,7 +32,7 @@ public class DurabilityMechanic extends Mechanic {
         return itemDurability;
     }
 
-    public void changeDurability(ItemStack item, int amount) {
+    public boolean changeDurability(ItemStack item, int amount) {
         DurabilityMechanic durabilityMechanic = this;
         AtomicBoolean check = new AtomicBoolean(false);
 
@@ -67,6 +67,6 @@ public class DurabilityMechanic extends Mechanic {
                 }
             }
         });
-        check.get();
+        return check.get();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/durability/DurabilityMechanicManager.java
@@ -19,13 +19,18 @@ public class DurabilityMechanicManager implements Listener {
     public void onItemDamaged(PlayerItemDamageEvent event) {
         DurabilityMechanic mechanic = (DurabilityMechanic) factory.getMechanic(OraxenItems.getIdByItem(event.getItem()));
         if (mechanic == null) return;
-        mechanic.changeDurability(event.getItem(), -event.getDamage());
+        if (mechanic.changeDurability(event.getItem(), -event.getDamage())) {
+            event.setDamage(0);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onItemMend(PlayerItemMendEvent event) {
         DurabilityMechanic mechanic = (DurabilityMechanic) factory.getMechanic(OraxenItems.getIdByItem(event.getItem()));
         if (mechanic == null) return;
-        mechanic.changeDurability(event.getItem(), event.getRepairAmount());
+
+        if (mechanic.changeDurability(event.getItem(), event.getRepairAmount())) {
+            event.setRepairAmount(0);
+        }
     }
 }


### PR DESCRIPTION
After manually changing the durability of items with the durability mechanic, the event should be cancelled/set to 0.