### PR TITLE
Fixes damage error in 1.19.2

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
@@ -47,17 +47,14 @@ public class ItemUtils {
         damage = isTool(itemStack) ? damage : 0;
 
         if (damage == 0) return itemStack;
-        try {
-            return player.damageItemStack(itemStack, damage);
-        } catch (Exception e) {
-            int finalDamage = damage;
+        int finalDamage = damage;
             return editItemMeta(itemStack, meta -> {
                 if (meta instanceof Damageable damageable && EventUtils.callEvent(new PlayerItemDamageEvent(player, itemStack, finalDamage))) {
                     damageable.setDamage(damageable.getDamage() + 1);
                 }
             });
         }
-    }
+
 
     public static boolean isTool(ItemStack itemStack) {
         return isTool(itemStack.getType());


### PR DESCRIPTION
I'm unable to find the error log now, but I was having a error as it was unable to find this method while running a 1.19.4 test server `Paper version git-Paper-166 (MC: 1.19.2) (Implementing API version 1.19.2-R0.1-SNAPSHOT) (Git: f528f53)`. 

Here's a fix for the error of which I did have though in case it happens for anyone else. 