### PR TITLE
1.168.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ compileOnly 'io.th0rgal:oraxen:VERSION'
   <artifactId>oraxen</artifactId>
   <version>VERSION</version>
   <scope>provided</scope>
+</dependency>
 ```
 Snapshot builds are also available at [https://repo.oraxen.com/snapshots](https://repo.oraxen.com/snapshots). \
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Oraxen's API is primarily found in these four classes:
 - OraxenPack - methods related to the resource-pack
 
 ### Repository
-**Gradle Kts**:
+**Gradle Kotlin**:
 ```kts
 maven("https://repo.oraxen.com/releases")
 ```
@@ -84,21 +84,74 @@ maven {
 </repository>
 ```
 ### Dependency [![version](https://img.shields.io/maven-metadata/v?metadataUrl=https://repo.oraxen.com/releases/io/th0rgal/oraxen/maven-metadata.xml)](https://repo.oraxen.com/#/releases/io/th0rgal/oraxen) [![version](https://img.shields.io/maven-metadata/v?metadataUrl=https://repo.oraxen.com/snapshots/io/th0rgal/oraxen/maven-metadata.xml)](https://repo.oraxen.com/#/snapshots/io/th0rgal/oraxen)
-The latest version can be found at above.\ 
+The latest version can be found at above.\
+**Gradle Kotlin**:
 ```kts
 compileOnly("io.th0rgal:oraxen:VERSION")
 ```
+**Groovy**:
 ```groovy
 compileOnly 'io.th0rgal:oraxen:VERSION'
 ```
+**Maven**
+<details open>
+<summary>Maven with exclusions</summary>
+
 ```html
 <dependency>
-  <groupId>io.th0rgal</groupId>
-  <artifactId>oraxen</artifactId>
-  <version>VERSION</version>
-  <scope>provided</scope>
+    <groupId>io.th0rgal</groupId>
+    <artifactId>oraxen</artifactId>
+    <version>1.167.0</version>
+    <exclusions>
+        <exclusion>
+            <groupId>me.gabytm.util</groupId>
+            <artifactId>actions-spigot</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.ticxo</groupId>
+            <artifactId>PlayerAnimator</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.github.stefvanschie.inventoryframework</groupId>
+            <artifactId>IF</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>io.th0rgal</groupId>
+            <artifactId>protectionlib</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>dev.triumphteam</groupId>
+            <artifactId>triumph-gui</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.jeff-media</groupId>
+            <artifactId>custom-block-data</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.jeff-media</groupId>
+            <artifactId>persistent-data-serializer</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.jeff_media</groupId>
+            <artifactId>MorePersistentDataTypes</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>gs.mclo</groupId>
+            <artifactId>java</artifactId>
+        </exclusion>
+    </exclusions>
+    <scope>provided</scope>
 </dependency>
 ```
+</details>
 Snapshot builds are also available at [https://repo.oraxen.com/snapshots](https://repo.oraxen.com/snapshots). \
 
 ## License

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,7 +193,7 @@ bukkit {
     name = "Oraxen"
     apiVersion = "1.18"
     authors = listOf("th0rgal", "boy0000")
-    softDepend = listOf("LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "MythicMobs", "BossShopPro", "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared", "NBTAPI", "ModelEngine", "CrashClaim", "ViaBackwards")
+    softDepend = listOf("LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "MythicMobs", "BossShopPro", "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared", "NBTAPI", "ModelEngine", "CrashClaim", "ViaBackwards", "HuskClaims")
     depend = listOf("ProtocolLib")
     loadBefore = listOf("Realistic_World")
     permissions.create("oraxen.command") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ val pluginVersion: String by project
 val commandApiVersion = "9.3.0"
 val adventureVersion = "4.15.0"
 val platformVersion = "4.3.2"
+val googleGsonVersion = "2.10.1"
 group = "io.th0rgal"
 version = pluginVersion
 
@@ -100,6 +101,7 @@ allprojects {
         compileOnly("io.lumine:MythicCrucible:1.6.0-SNAPSHOT")
         compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.0")
         compileOnly("commons-io:commons-io:2.11.0")
+        compileOnly("com.google.code.gson:gson:$googleGsonVersion")
         compileOnly("com.ticxo.modelengine:ModelEngine:R4.0.1")
         compileOnly("com.ticxo.modelengine:api:R3.1.8")
         compileOnly(files("../libs/compile/BSP.jar"))
@@ -144,7 +146,7 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.20")
+        minecraftVersion("1.18.2")
     }
 
     shadowJar {
@@ -207,6 +209,7 @@ bukkit {
         "net.kyori:adventure-text-serializer-plain:$adventureVersion",
         "net.kyori:adventure-text-serializer-ansi:$adventureVersion",
         "net.kyori:adventure-platform-bukkit:$platformVersion",
+        "com.google.code.gson:gson:$googleGsonVersion"
     )
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ allprojects {
         compileOnly("org.springframework:spring-expression:6.0.6")
         compileOnly("io.lumine:Mythic-Dist:5.3.5")
         compileOnly("io.lumine:MythicCrucible:1.6.0-SNAPSHOT")
-        compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.0")
+        compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.9")
         compileOnly("commons-io:commons-io:2.11.0")
         compileOnly("com.google.code.gson:gson:$googleGsonVersion")
         compileOnly("com.ticxo.modelengine:ModelEngine:R4.0.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,7 +209,8 @@ bukkit {
         "net.kyori:adventure-text-serializer-plain:$adventureVersion",
         "net.kyori:adventure-text-serializer-ansi:$adventureVersion",
         "net.kyori:adventure-platform-bukkit:$platformVersion",
-        "com.google.code.gson:gson:$googleGsonVersion"
+        "com.google.code.gson:gson:$googleGsonVersion",
+        "gs.mclo:java:2.2.1",
     )
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,8 @@ allprojects {
 
     dependencies {
         val actionsVersion = "1.0.0-SNAPSHOT"
+        compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+        compileOnly("gs.mclo:java:2.2.1")
 
         compileOnly("net.kyori:adventure-text-minimessage:$adventureVersion")
         compileOnly("net.kyori:adventure-text-serializer-plain:$adventureVersion")
@@ -114,6 +116,18 @@ allprojects {
         compileOnly("com.willfp:eco:6.65.5")
         compileOnly("com.willfp:libreforge:4.36.0")
         compileOnly("nl.rutgerkok:blocklocker:1.10.4-SNAPSHOT")
+
+        implementation("org.bstats:bstats-bukkit:3.0.0")
+        implementation("io.th0rgal:protectionlib:1.4.0")
+        implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
+        implementation("com.jeff-media:custom-block-data:2.2.2")
+        implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
+        implementation("com.jeff-media:persistent-data-serializer:1.0")
+        implementation("org.jetbrains:annotations:24.1.0") { isTransitive = false }
+        implementation("dev.triumphteam:triumph-gui:3.1.7") { exclude("net.kyori") }
+        implementation("com.ticxo:PlayerAnimator:R1.2.8") { isChanging = true }
+
+        implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }
     }
 }
 
@@ -155,10 +169,8 @@ tasks {
         //archiveClassifier = null
         relocate("org.bstats", "io.th0rgal.oraxen.shaded.bstats")
         relocate("dev.triumphteam.gui", "io.th0rgal.oraxen.shaded.triumphteam.gui")
-        relocate("com.jeff_media.customblockdata", "io.th0rgal.oraxen.shaded.customblockdata")
-        relocate("com.jeff_media.morepersistentdatatypes", "io.th0rgal.oraxen.shaded.morepersistentdatatypes")
-        relocate("com.jeff_media.persistentdataserializer", "io.th0rgal.oraxen.shaded.persistentdataserializer")
-        relocate("com.github.stefvanschie.inventoryframework", "io.th0rgal.oraxen.shaded.if")
+        relocate("com.jeff_media", "io.th0rgal.oraxen.shaded.jeff_media")
+        relocate("com.github.stefvanschie.inventoryframework", "io.th0rgal.oraxen.shaded.inventoryframework")
         relocate("me.gabytm.util.actions", "io.th0rgal.oraxen.shaded.actions")
         relocate("org.intellij.lang.annotations", "io.th0rgal.oraxen.shaded.intellij.annotations")
         relocate("org.jetbrains.annotations", "io.th0rgal.oraxen.shaded.jetbrains.annotations")
@@ -179,6 +191,7 @@ tasks {
             )
         }
         archiveFileName.set("oraxen-${pluginVersion}.jar")
+        archiveClassifier.set("")
     }
 
     compileJava.get().dependsOn(clean)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,10 +31,6 @@ dependencies {
     paperweight.paperDevBundle("1.20.4-R0.1-SNAPSHOT")
 }
 
-configurations.all {
-    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
-}
-
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,26 +8,12 @@ plugins {
 
 val pluginVersion = project.property("pluginVersion") as String
 tasks {
+    publish.get().dependsOn(shadowJar)
     shadowJar.get().archiveFileName.set("oraxen-${pluginVersion}.jar")
     build.get().dependsOn(shadowJar)
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
-    compileOnly("gs.mclo:java:2.2.1")
-
-    val actionsVersion = "1.0.0-SNAPSHOT"
-    implementation("org.bstats:bstats-bukkit:3.0.0")
-    implementation("io.th0rgal:protectionlib:1.4.0")
-    implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
-    implementation("com.jeff-media:custom-block-data:2.2.2")
-    implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
-    implementation("com.jeff-media:persistent-data-serializer:1.0")
-    implementation("org.jetbrains:annotations:24.1.0") { isTransitive = false }
-    implementation("dev.triumphteam:triumph-gui:3.1.7") { exclude("net.kyori") }
-    implementation("com.ticxo:PlayerAnimator:R1.2.8") { isChanging = true }
-
-    implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }
     paperweight.paperDevBundle("1.20.4-R0.1-SNAPSHOT")
 }
 
@@ -43,7 +29,8 @@ publishing {
             artifactId = rootProject.name
             version = publishData.getVersion()
 
-            from(components["java"])
+            //from(components["java"])
+            artifact(tasks.shadowJar.get().apply { archiveClassifier.set("") })
         }
     }
 
@@ -65,9 +52,10 @@ publishing {
     }
 }
 
+
 class PublishData(private val project: Project) {
-    var type: Type = getReleaseType()
-    var hashLength: Int = 7
+    private var type: Type = getReleaseType()
+    private var hashLength: Int = 7
 
     private fun getReleaseType(): Type {
         val branch = getCheckedOutBranch()
@@ -90,7 +78,7 @@ class PublishData(private val project: Project) {
     fun getVersion(appendCommit: Boolean): String =
         type.append(getVersionString(), appendCommit, getCheckedOutGitCommitHash())
 
-    private fun getVersionString(): String =
+    fun getVersionString(): String =
         (rootProject.version as String).removeSuffix("-SNAPSHOT").removeSuffix("-DEV")
 
     fun getRepository(): String = type.repo

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     val actionsVersion = "1.0.0-SNAPSHOT"
     implementation("org.bstats:bstats-bukkit:3.0.0")
     implementation("dev.triumphteam:triumph-gui:3.1.5") { exclude("net.kyori") }
-    implementation("io.th0rgal:protectionlib:1.3.6")
+    implementation("io.th0rgal:protectionlib:1.4.0")
     implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
     implementation("com.jeff-media:custom-block-data:2.2.2")
     implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,18 +14,18 @@ tasks {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+    compileOnly("gs.mclo:java:2.2.1")
 
     val actionsVersion = "1.0.0-SNAPSHOT"
     implementation("org.bstats:bstats-bukkit:3.0.0")
-    implementation("dev.triumphteam:triumph-gui:3.1.5") { exclude("net.kyori") }
     implementation("io.th0rgal:protectionlib:1.4.0")
     implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
     implementation("com.jeff-media:custom-block-data:2.2.2")
     implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
     implementation("com.jeff-media:persistent-data-serializer:1.0")
-    implementation("gs.mclo:java:2.2.1")
+    implementation("org.jetbrains:annotations:24.1.0") { isTransitive = false }
+    implementation("dev.triumphteam:triumph-gui:3.1.7") { exclude("net.kyori") }
     implementation("com.ticxo:PlayerAnimator:R1.2.8") { isChanging = true }
-    implementation("org.jetbrains:annotations:24.0.1") { isTransitive = false }
 
     implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }
     paperweight.paperDevBundle("1.20.4-R0.1-SNAPSHOT")

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -18,6 +18,7 @@ import io.th0rgal.oraxen.hud.HudManager;
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureFactory;
+import io.th0rgal.oraxen.nms.GlyphHandlers;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.pack.generation.ResourcePack;
 import io.th0rgal.oraxen.pack.upload.UploadManager;
@@ -149,8 +150,7 @@ public class OraxenPlugin extends JavaPlugin {
         unregisterListeners();
         FurnitureFactory.unregisterEvolution();
         for (Player player : Bukkit.getOnlinePlayers())
-            if (NMSHandlers.getHandler() != null && Settings.NMS_GLYPHS.toBool())
-                NMSHandlers.getHandler().uninject(player);
+            if (GlyphHandlers.isNms()) NMSHandlers.getHandler().uninject(player);
 
         CompatibilitiesManager.disableCompatibilities();
         Message.PLUGIN_UNLOADED.log();

--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
@@ -297,7 +297,7 @@ public class OraxenFurniture {
             }
 
             if (!OraxenFurniture.remove(entity, null)) return;
-            Entity newEntity = mechanic.place(entity.getLocation(), newItem, FurnitureMechanic.getFurnitureYaw(entity), oldFacing);
+            Entity newEntity = mechanic.place(entity.getLocation(), FurnitureMechanic.getFurnitureYaw(entity), oldFacing);
             if (newEntity == null) return;
 
             // Copy old PDC to new PDC, skip keys that should not persist

--- a/core/src/main/java/io/th0rgal/oraxen/commands/RecipesCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/RecipesCommand.java
@@ -42,7 +42,7 @@ public class RecipesCommand {
                             Message.RECIPE_NO_RECIPE.send(sender);
                             return;
                         }
-                        OraxenPlugin.get().getInvManager().getRecipesShowcase(player,0, recipes).show(player);
+                        OraxenPlugin.get().getInvManager().getRecipesShowcase(0, recipes).show(player);
                     } else
                         Message.NOT_PLAYER.send(sender);
                 });

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/CompatibilitiesManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/CompatibilitiesManager.java
@@ -8,8 +8,8 @@ import io.th0rgal.oraxen.compatibilities.provided.placeholderapi.PlaceholderAPIC
 import io.th0rgal.oraxen.compatibilities.provided.worldedit.WrappedWorldEdit;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
-import org.bukkit.Bukkit;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -113,6 +113,6 @@ public class CompatibilitiesManager {
     }
 
     public static boolean hasPlugin(String name) {
-        return Bukkit.getPluginManager().isPluginEnabled(name);
+        return PluginUtils.isEnabled(name);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/ecoitems/WrappedEcoItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/ecoitems/WrappedEcoItem.java
@@ -2,7 +2,7 @@ package io.th0rgal.oraxen.compatibilities.provided.ecoitems;
 
 import com.willfp.ecoitems.items.EcoItem;
 import com.willfp.ecoitems.items.EcoItems;
-import org.bukkit.Bukkit;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 
@@ -18,7 +18,7 @@ public class WrappedEcoItem {
     }
 
     public ItemStack build() {
-        if (id == null || !Bukkit.getPluginManager().isPluginEnabled("EcoItems")) return null;
+        if (id == null || !PluginUtils.isEnabled("EcoItems")) return null;
         EcoItem ecoItem = EcoItems.INSTANCE.getByID(id);
         return ecoItem != null ? ecoItem.getItemStack() : null;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/lightapi/WrappedLightAPI.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/lightapi/WrappedLightAPI.java
@@ -6,6 +6,7 @@ import io.th0rgal.oraxen.api.events.noteblock.OraxenNoteBlockBreakEvent;
 import io.th0rgal.oraxen.api.events.stringblock.OraxenStringBlockBreakEvent;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -21,8 +22,8 @@ public class WrappedLightAPI {
     public static boolean lighterApiEnabled;
 
     static {
-        lightApiEnabled = Bukkit.getPluginManager().isPluginEnabled("LightAPI");
-        lighterApiEnabled = Bukkit.getPluginManager().isPluginEnabled("LighterAPI");
+        lightApiEnabled = PluginUtils.isEnabled("LightAPI");
+        lighterApiEnabled = PluginUtils.isEnabled("LighterAPI");
     }
 
     private WrappedLightAPI() {

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mmoitems/WrappedMMOItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mmoitems/WrappedMMOItem.java
@@ -1,14 +1,11 @@
 package io.th0rgal.oraxen.compatibilities.provided.mmoitems;
 
-import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.Indyuce.mmoitems.MMOItems;
 import net.Indyuce.mmoitems.api.ItemTier;
 import net.Indyuce.mmoitems.api.Type;
-import net.Indyuce.mmoitems.api.item.build.MMOItemBuilder;
-import net.Indyuce.mmoitems.api.item.mmoitem.MMOItem;
 import net.Indyuce.mmoitems.api.item.template.MMOItemTemplate;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 
@@ -20,7 +17,7 @@ public class WrappedMMOItem {
     private final ItemTier tier;
 
     public WrappedMMOItem(ConfigurationSection section) {
-        if (!Bukkit.getPluginManager().isPluginEnabled("MMOItems")) {
+        if (!PluginUtils.isEnabled("MMOItems")) {
             Logs.logError("MMOItems is not installed");
             type = null;
             id = null;
@@ -68,7 +65,7 @@ public class WrappedMMOItem {
     }
 
     public ItemStack build() {
-        if (Bukkit.getPluginManager().isPluginEnabled("MMOItems")) {
+        if (PluginUtils.isEnabled("MMOItems")) {
             MMOItemTemplate template = getTemplate();
             if (template == null) {
                 Logs.logError("Failed to load MMOItem " + id);

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mythiccrucible/WrappedCrucibleItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/mythiccrucible/WrappedCrucibleItem.java
@@ -3,11 +3,9 @@ package io.th0rgal.oraxen.compatibilities.provided.mythiccrucible;
 import io.lumine.mythic.bukkit.BukkitAdapter;
 import io.lumine.mythic.bukkit.MythicBukkit;
 import io.lumine.mythic.core.items.MythicItem;
-import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +30,7 @@ public class WrappedCrucibleItem {
             return BukkitAdapter.adapt(maybeItem.orElseThrow().generateItemStack(1));
         } catch (Exception e) {
             Logs.logError("Failed to load MythicCrucible item " + id);
-            if (!Bukkit.getPluginManager().isPluginEnabled("MythicCrucible"))
+            if (!PluginUtils.isEnabled("MythicCrucible"))
                 Logs.logWarning("MythicCrucible is not installed");
             if (Settings.DEBUG.toBool()) Logs.logWarning(e.getMessage());
             return null;

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/worldedit/WorldEditHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/worldedit/WorldEditHandlers.java
@@ -1,8 +1,12 @@
 package io.th0rgal.oraxen.compatibilities.provided.worldedit;
 
+import com.sk89q.jnbt.CompoundTag;
+import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.entity.BaseEntity;
+import com.sk89q.worldedit.entity.Entity;
 import com.sk89q.worldedit.event.extent.EditSessionEvent;
 import com.sk89q.worldedit.extent.AbstractDelegateExtent;
 import com.sk89q.worldedit.math.BlockVector3;
@@ -10,18 +14,25 @@ import com.sk89q.worldedit.util.eventbus.Subscribe;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenBlocks;
+import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.mechanics.Mechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
 
 public class WorldEditHandlers {
-
 
 
     public WorldEditHandlers(boolean register) {
@@ -32,11 +43,51 @@ public class WorldEditHandlers {
         }
     }
 
+    private static final List<com.sk89q.worldedit.world.entity.EntityType> furnitureTypes = new ArrayList<>();
+
+    static {
+        furnitureTypes.add(BukkitAdapter.adapt(EntityType.ITEM_FRAME));
+        furnitureTypes.add(BukkitAdapter.adapt(EntityType.ITEM_DISPLAY));
+        furnitureTypes.add(BukkitAdapter.adapt(EntityType.INTERACTION));
+    }
+
+
     @Subscribe
     public void onEditSession(EditSessionEvent event) {
         if (event.getWorld() == null) return;
 
         event.setExtent(new AbstractDelegateExtent(event.getExtent()) {
+
+            @Override
+            public Entity createEntity(com.sk89q.worldedit.util.Location location, BaseEntity baseEntity) {
+                if (!Settings.WORLDEDIT_FURNITURE.toBool()) return super.createEntity(location, baseEntity);
+                if (baseEntity == null || baseEntity.getType() == BukkitAdapter.adapt(EntityType.INTERACTION)) return null;
+                if (!baseEntity.hasNbtData() || !furnitureTypes.contains(baseEntity.getType()))
+                    return super.createEntity(location, baseEntity);
+
+                Location bukkitLocation = BukkitAdapter.adapt(BukkitAdapter.adapt(event.getWorld()), location);
+                FurnitureMechanic mechanic = getFurnitureMechanic(baseEntity);
+                if (mechanic == null) return super.createEntity(location, baseEntity);
+
+                // Remove interaction-tag from baseEntity-nbt
+                CompoundTag compoundTag = baseEntity.getNbtData();
+                if (compoundTag == null) return super.createEntity(location, baseEntity);
+                Map<String, Tag> compoundTagMap = new HashMap<>(compoundTag.getValue());
+                Map<String, Tag> bukkitValues = new HashMap<>((Map<String, Tag>) compoundTagMap.get("BukkitValues").getValue());
+                bukkitValues.remove("oraxen:interaction");
+                compoundTagMap.put("BukkitValues", new CompoundTag(bukkitValues));
+                baseEntity.setNbtData(new CompoundTag(compoundTagMap));
+
+                Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> {
+                    List<org.bukkit.entity.Entity> entities = bukkitLocation.getNearbyEntities(0.5, 0.5, 0.5).stream().toList();
+                    List<org.bukkit.entity.Entity> nearbyEntities = entities.stream().sorted(Comparator.comparingDouble(entity -> entity.getLocation().distance(bukkitLocation))).toList();
+                    nearbyEntities.stream().findFirst().ifPresent(e ->
+                            mechanic.setEntityData(e, e.getLocation().getYaw(), BlockFace.NORTH));
+                }, 1L);
+
+                return super.createEntity(location, baseEntity);
+            }
+
             @Override
             public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 pos, T block) throws WorldEditException {
                 BlockData blockData = BukkitAdapter.adapt(block);
@@ -45,23 +96,39 @@ public class WorldEditHandlers {
                 Mechanic mechanic = OraxenBlocks.getOraxenBlock(blockData);
                 if (blockData.getMaterial() == Material.NOTE_BLOCK) {
                     if (mechanic != null && Settings.WORLDEDIT_NOTEBLOCKS.toBool()) {
-                        Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> OraxenBlocks.place(mechanic.getItemID(), loc));
+                        Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> OraxenBlocks.place(mechanic.getItemID(), loc), 1L);
                     }
                 } else if (blockData.getMaterial() == Material.TRIPWIRE) {
                     if (mechanic != null && Settings.WORLDEDIT_STRINGBLOCKS.toBool()) {
-                        Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> OraxenBlocks.place(mechanic.getItemID(), loc));
+                        Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> OraxenBlocks.place(mechanic.getItemID(), loc), 1L);
                     }
                 } else {
                     if (world == null) return super.setBlock(pos, block);
                     Mechanic replacingMechanic = OraxenBlocks.getOraxenBlock(loc);
                     if (replacingMechanic == null) return super.setBlock(pos, block);
-                    if (replacingMechanic instanceof StringBlockMechanic && !Settings.WORLDEDIT_STRINGBLOCKS.toBool()) return super.setBlock(pos, block);
-                    if (replacingMechanic instanceof NoteBlockMechanic && !Settings.WORLDEDIT_NOTEBLOCKS.toBool()) return super.setBlock(pos, block);
+                    if (replacingMechanic instanceof StringBlockMechanic && !Settings.WORLDEDIT_STRINGBLOCKS.toBool())
+                        return super.setBlock(pos, block);
+                    if (replacingMechanic instanceof NoteBlockMechanic && !Settings.WORLDEDIT_NOTEBLOCKS.toBool())
+                        return super.setBlock(pos, block);
 
-                    Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> OraxenBlocks.remove(loc, null));
+                    Bukkit.getScheduler().scheduleSyncDelayedTask(OraxenPlugin.get(), () -> OraxenBlocks.remove(loc, null), 1L);
                 }
 
-                return getExtent().setBlock(pos, block);
+                return super.setBlock(pos, block);
+            }
+
+            @Nullable
+            private FurnitureMechanic getFurnitureMechanic(@NotNull BaseEntity entity) {
+                if (!entity.hasNbtData() || !furnitureTypes.contains(entity.getType())) return null;
+                CompoundTag tag = entity.getNbtData();
+                Map<String, Tag> bukkitValues = null;
+                try {
+                    bukkitValues = (Map<String, Tag>) tag.getValue().get("BukkitValues").getValue();
+                } catch (Exception ignored) {
+                }
+                if (bukkitValues == null) return null;
+                String furnitureId = bukkitValues.get("oraxen:furniture").getValue().toString();
+                return OraxenFurniture.getFurnitureMechanic(furnitureId);
             }
         });
     }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/worldedit/WrappedWorldEdit.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/worldedit/WrappedWorldEdit.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.compatibilities.provided.worldedit;
 
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -18,7 +19,7 @@ public class WrappedWorldEdit {
     public static boolean loaded;
 
     public static void init() {
-        loaded = Bukkit.getPluginManager().isPluginEnabled("WorldEdit") || Bukkit.getPluginManager().isPluginEnabled("FastAsyncWorldEdit");
+        loaded = PluginUtils.isEnabled("WorldEdit") || PluginUtils.isEnabled("FastAsyncWorldEdit");
     }
 
     public static void registerParser() {

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -231,7 +231,8 @@ public class ConfigsManager {
 
     public Map<File, Map<String, ItemBuilder>> parseItemConfig() {
         Map<File, Map<String, ItemBuilder>> parseMap = new LinkedHashMap<>();
-        for (File file : getItemFiles()) parseMap.put(file, parseItemConfig(file));
+        ItemBuilder errorItem = new ItemParser(Settings.ERROR_ITEM.toConfigSection()).buildItem();
+        for (File file : getItemFiles()) parseMap.put(file, parseItemConfig(file, errorItem));
         return parseMap;
     }
 
@@ -300,10 +301,10 @@ public class ConfigsManager {
         return model;
     }
 
-    public Map<String, ItemBuilder> parseItemConfig(File itemFile) {
+    public Map<String, ItemBuilder> parseItemConfig(File itemFile, ItemBuilder errorItem) {
         YamlConfiguration config = OraxenYaml.loadConfiguration(itemFile);
         Map<String, ItemParser> parseMap = new LinkedHashMap<>();
-        ItemParser errorItem = new ItemParser(Settings.ERROR_ITEM.toConfigSection());
+
         for (String itemKey : config.getKeys(false)) {
             //Utils.ensureStringFormat(itemKey);
             ConfigurationSection itemSection = config.getConfigurationSection(itemKey);
@@ -319,8 +320,7 @@ public class ConfigsManager {
             try {
                 map.put(entry.getKey(), itemParser.buildItem());
             } catch (Exception e) {
-                map.put(entry.getKey(),
-                        errorItem.buildItem());
+                map.put(entry.getKey(), errorItem);
                 Logs.logError("ERROR BUILDING ITEM \"" + entry.getKey() + "\"");
                 if (Settings.DEBUG.toBool()) e.printStackTrace();
                 else Logs.logWarning(e.getMessage());

--- a/core/src/main/java/io/th0rgal/oraxen/config/RemovedSettings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/RemovedSettings.java
@@ -22,6 +22,8 @@ public enum RemovedSettings {
     UPDATE_FURNITURE_ON_RELOAD2("FurnitureUpdater.update_furniture_on_reload"),
     SEND_PACK_ADVANCED("Pack.dispatch.send_pack_advanced"),
     NMS_BLOCK_CORRECTION("Plugin.experimental.nms.block_correction"),
+    SPIGOT_CHAT_FORMATTING("Plugin.experimental.spigot_chat_formatting"),
+
     ;
 
     private final String path;

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -25,9 +25,11 @@ public enum Settings {
     FORMAT_ANVIL("Plugin.formatting.anvil"),
     FORMAT_SIGNS("Plugin.formatting.signs"),
     FORMAT_CHAT("Plugin.formatting.chat"),
-    SPIGOT_CHAT_FORMATTING("Plugin.experimental.spigot_chat_formatting"),
     FORMAT_BOOKS("Plugin.formatting.books"),
     NMS_GLYPHS("Plugin.experimental.nms.glyphs"),
+
+    // Chat
+    CHAT_HANDLER("Chat.chat_handler"),
 
     // Config Tools
     CONFIGS_VERSION("configs_version"),

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -15,8 +15,6 @@ public enum Settings {
     REPAIR_COMMAND_ORAXEN_DURABILITY("Plugin.commands.repair.oraxen_durability_only"),
     GENERATE_DEFAULT_ASSETS("Plugin.generation.default_assets"),
     GENERATE_DEFAULT_CONFIGS("Plugin.generation.default_configs"),
-    WORLDEDIT_NOTEBLOCKS("Plugin.worldedit.noteblock_mechanic"),
-    WORLDEDIT_STRINGBLOCKS("Plugin.worldedit.stringblock_mechanic"),
     FORMAT_INVENTORY_TITLES("Plugin.formatting.inventory_titles"),
     FORMAT_TITLES("Plugin.formatting.titles"),
     FORMAT_SUBTITLES("Plugin.formatting.subtitles"),
@@ -25,6 +23,11 @@ public enum Settings {
     FORMAT_SIGNS("Plugin.formatting.signs"),
     FORMAT_CHAT("Plugin.formatting.chat"),
     FORMAT_BOOKS("Plugin.formatting.books"),
+
+    // WorldEdit
+    WORLDEDIT_NOTEBLOCKS("WorldEdit.noteblock_mechanic"),
+    WORLDEDIT_STRINGBLOCKS("WorldEdit.stringblock_mechanic"),
+    WORLDEDIT_FURNITURE("WorldEdit.furniture_mechanic"),
 
     // Glyphs
     GLYPH_HANDLER("Glyphs.glyph_handler"),

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -13,7 +13,6 @@ public enum Settings {
     PLUGIN_LANGUAGE("Plugin.language"),
     KEEP_UP_TO_DATE("Plugin.keep_this_up_to_date"),
     REPAIR_COMMAND_ORAXEN_DURABILITY("Plugin.commands.repair.oraxen_durability_only"),
-    SHOW_PERMISSION_EMOJIS("Plugin.commands.emoji_list.only_show_emojis_with_permission"),
     GENERATE_DEFAULT_ASSETS("Plugin.generation.default_assets"),
     GENERATE_DEFAULT_CONFIGS("Plugin.generation.default_configs"),
     WORLDEDIT_NOTEBLOCKS("Plugin.worldedit.noteblock_mechanic"),
@@ -26,7 +25,12 @@ public enum Settings {
     FORMAT_SIGNS("Plugin.formatting.signs"),
     FORMAT_CHAT("Plugin.formatting.chat"),
     FORMAT_BOOKS("Plugin.formatting.books"),
-    NMS_GLYPHS("Plugin.experimental.nms.glyphs"),
+
+    // Glyphs
+    GLYPH_HANDLER("Glyphs.glyph_handler"),
+    SHOW_PERMISSION_EMOJIS("Glyphs.emoji_list_permission_only"),
+    UNICODE_COMPLETIONS("Glyphs.unicode_completions"),
+
 
     // Chat
     CHAT_HANDLER("Chat.chat_handler"),
@@ -62,7 +66,6 @@ public enum Settings {
     //Misc
     RESET_RECIPES("Misc.reset_recipes"),
     ADD_RECIPES_TO_BOOK("Misc.add_recipes_to_book"),
-    UNICODE_COMPLETIONS("Misc.unicode_completions"),
     ARMOR_EQUIP_EVENT_BYPASS("Misc.armor_equip_event_bypass"),
     SHIELD_DISPLAY("Misc.shield_display"),
     BOW_DISPLAY("Misc.bow_display"),

--- a/core/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
@@ -20,6 +20,8 @@ public enum UpdatedSettings {
     NMS_GLYPHS("Plugin.experimental.nms.glyphs", "Glyphs.nms_glyphs"),
     SHOW_PERMISSION_EMOJIS("Plugin.commands.emoji_list.only_show_emojis_with_permission", "Glyphs.emoji_list_permission_only"),
     UNICODE_COMPLETIONS("Misc.unicode_completions", "Glyphs.unicode_completions"),
+    WORLDEDIT_NOTEBLOCKS("Plugin.worldedit.noteblock_mechanic", "WorldEdit.noteblock_mechanic"),
+    WORLDEDIT_STRINGBLOCKS("Plugin.worldedit.stringblock_mechanic", "WorldEdit.stringblock_mechanic"),
     ;
 
     private final String path;

--- a/core/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
@@ -17,6 +17,9 @@ public enum UpdatedSettings {
     SEND_PACK_ADVANCED_MESSAGE("Pack.dispatch.send_pack_advanced.message", "Pack.dispatch.prompt"),
     VERIFY_PACK_FILES("Plugin.experimental.verify_pack_files", "Pack.generation.verify_pack_files"),
     EXCLUDE_MALFORMED_ATLAS("Plugin.experimental.exclude_malformed_from_atlas", "Pack.generation.atlas.exclude_malformed_from_atlas"),
+    NMS_GLYPHS("Plugin.experimental.nms.glyphs", "Glyphs.nms_glyphs"),
+    SHOW_PERMISSION_EMOJIS("Plugin.commands.emoji_list.only_show_emojis_with_permission", "Glyphs.emoji_list_permission_only"),
+    UNICODE_COMPLETIONS("Misc.unicode_completions", "Glyphs.unicode_completions"),
     ;
 
     private final String path;

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -10,6 +10,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.ItemUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.inventory.Book;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
@@ -43,13 +44,38 @@ public class FontEvents implements Listener {
 
     private final FontManager manager;
 
+    enum ChatHandler {
+        LEGACY,
+        MODERN;
+
+        public static boolean isLegacy() {
+            return get() == LEGACY;
+        }
+
+        public static boolean isModern() {
+            return get() == MODERN;
+        }
+
+        public static ChatHandler get() {
+            try {
+                return valueOf(Settings.CHAT_HANDLER.toString());
+            } catch (IllegalArgumentException e) {
+                ChatHandler chatHandler = VersionUtil.isPaperServer() ? MODERN : LEGACY;
+                Logs.logError("Invalid chat-handler defined in settings.yml, defaulting to " + chatHandler, true);
+                Logs.logError("Valid options are: " + Arrays.toString(values()), true);
+                return chatHandler;
+            }
+        }
+    }
+
     public FontEvents(FontManager manager) {
         this.manager = manager;
-        if (VersionUtil.isPaperServer() && !Settings.SPIGOT_CHAT_FORMATTING.toBool()) {
+        if (VersionUtil.isPaperServer()) {
             if (VersionUtil.atOrAbove("1.19.1"))
                 Bukkit.getPluginManager().registerEvents(new PaperChatHandler(), OraxenPlugin.get());
             Bukkit.getPluginManager().registerEvents(new LegacyPaperChatHandler(), OraxenPlugin.get());
-        } else Bukkit.getPluginManager().registerEvents(new SpigotChatHandler(), OraxenPlugin.get());
+        }
+        Bukkit.getPluginManager().registerEvents(new SpigotChatHandler(), OraxenPlugin.get());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
@@ -201,7 +227,7 @@ public class FontEvents implements Listener {
     public class SpigotChatHandler implements Listener {
         @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
         public void onPlayerChat(AsyncPlayerChatEvent event) {
-            if (!Settings.FORMAT_CHAT.toBool() || manager.useNmsGlyphs()) return;
+            if (!Settings.FORMAT_CHAT.toBool() || !ChatHandler.isLegacy() || manager.useNmsGlyphs()) return;
 
             String format = format(event.getFormat(), null);
             String message = format(event.getMessage(), event.getPlayer());
@@ -249,7 +275,7 @@ public class FontEvents implements Listener {
 
         @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
         public void onPlayerChat(AsyncChatDecorateEvent event) {
-            if (!Settings.FORMAT_CHAT.toBool() || manager.useNmsGlyphs()) return;
+            if (!Settings.FORMAT_CHAT.toBool() || !ChatHandler.isModern() || manager.useNmsGlyphs()) return;
             event.result(format(event.result(), event.player()));
         }
 
@@ -259,7 +285,7 @@ public class FontEvents implements Listener {
 
         @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
         public void onPlayerChat(AsyncChatEvent event) {
-            if (!Settings.FORMAT_CHAT.toBool() || manager.useNmsGlyphs()) return;
+            if (!Settings.FORMAT_CHAT.toBool() || !ChatHandler.isModern() || manager.useNmsGlyphs()) return;
             // AsyncChatDecorateEvent has formatted the component if server is 1.19.1+
             Component message = VersionUtil.atOrAbove("1.19.1") ? event.message() : format(event.message(), event.getPlayer());
             message = message != null ? message : Component.empty();

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -8,6 +8,7 @@ import io.th0rgal.oraxen.config.ConfigsManager;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.font.packets.InventoryPacketListener;
 import io.th0rgal.oraxen.font.packets.TitlePacketListener;
+import io.th0rgal.oraxen.nms.GlyphHandlers;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.VersionUtil;
@@ -63,14 +64,14 @@ public class FontManager {
         if (fontConfiguration.isConfigurationSection("fonts"))
             loadFonts(fontConfiguration.getConfigurationSection("fonts"));
 
-        if (Settings.NMS_GLYPHS.toBool() && NMSHandlers.getHandler() != null) {
-            useNmsGlyphs = true;
+        useNmsGlyphs = GlyphHandlers.isNms() && NMSHandlers.getHandler() != null;
+        if (useNmsGlyphs) {
             NMSHandlers.getHandler().setupNmsGlyphs();
             Logs.logSuccess("Oraxens NMS Glyph system has been enabled!");
             Logs.logInfo("Disabling packet-based glyph systems", true);
             OraxenPlugin.get().getProtocolManager().removePacketListener(new InventoryPacketListener());
             OraxenPlugin.get().getProtocolManager().removePacketListener(new TitlePacketListener());
-        } else useNmsGlyphs = false;
+        }
     }
 
     public boolean useNmsGlyphs() {

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -109,7 +109,7 @@ public class ItemBuilder {
         if (itemMeta instanceof SkullMeta skullMeta)
             owningPlayer = skullMeta.getOwningPlayer();
 
-        if (itemMeta instanceof TropicalFishBucketMeta tropicalFishBucketMeta) {
+        if (itemMeta instanceof TropicalFishBucketMeta tropicalFishBucketMeta && tropicalFishBucketMeta.hasVariant()) {
             bodyColor = tropicalFishBucketMeta.getBodyColor();
             pattern = tropicalFishBucketMeta.getPattern();
             patternColor = tropicalFishBucketMeta.getPatternColor();
@@ -324,8 +324,9 @@ public class ItemBuilder {
         return oraxenMeta;
     }
 
-    public void setOraxenMeta(final OraxenMeta itemResources) {
+    public ItemBuilder setOraxenMeta(final OraxenMeta itemResources) {
         oraxenMeta = itemResources;
+        return this;
     }
 
     public ItemStack getReferenceClone() {
@@ -447,7 +448,7 @@ public class ItemBuilder {
             }
         }
 
-        if (itemMeta instanceof TropicalFishBucketMeta tropicalFishBucketMeta)
+        if (itemMeta instanceof TropicalFishBucketMeta tropicalFishBucketMeta && tropicalFishBucketMeta.hasVariant())
             return handleTropicalFishBucketMeta(tropicalFishBucketMeta);
 
         return itemMeta;

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -87,14 +87,14 @@ public class ItemParser {
         return templateItem != null;
     }
 
-    private String parseComponentDisplayName(String miniString) {
+    public static String parseComponentDisplayName(String miniString) {
         if (miniString.isEmpty()) return miniString;
         Component component = AdventureUtils.MINI_MESSAGE.deserialize(miniString);
         // If it has no formatting, set color to WHITE to prevent Italic
         return AdventureUtils.LEGACY_SERIALIZER.serialize(component.colorIfAbsent(NamedTextColor.WHITE));
     }
 
-    private String parseComponentLore(String miniString) {
+    public static String parseComponentLore(String miniString) {
         Component component = AdventureUtils.MINI_MESSAGE.deserialize(miniString);
         // If it has no formatting, set color to WHITE to prevent Italic
         return AdventureUtils.LEGACY_SERIALIZER.serialize(component);
@@ -116,7 +116,7 @@ public class ItemParser {
         item.setDisplayName(parseComponentDisplayName(section.getString("displayname", "")));
 
         //if (section.contains("type")) item.setType(Material.getMaterial(section.getString("type", "PAPER")));
-        if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(this::parseComponentLore).toList());
+        if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(ItemParser::parseComponentLore).toList());
         if (section.contains("durability")) item.setDurability((short) section.getInt("durability"));
         if (section.contains("unbreakable")) item.setUnbreakable(section.getBoolean("unbreakable", false));
         if (section.contains("unstackable")) item.setUnstackable(section.getBoolean("unstackable", false));

--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -143,16 +143,18 @@ public class OraxenMeta {
         return hasPackInfos;
     }
 
-    public void setCustomModelData(int customModelData) {
+    public OraxenMeta setCustomModelData(int customModelData) {
         this.customModelData = customModelData;
+        return this;
     }
 
     public int getCustomModelData() {
         return customModelData;
     }
 
-    public void setModelName(String modelName) {
+    public OraxenMeta setModelName(String modelName) {
         this.modelName = modelName;
+        return this;
     }
 
     public OraxenMeta setNoUpdate(boolean noUpdate) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bigmining/BigMiningMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bigmining/BigMiningMechanicFactory.java
@@ -5,12 +5,9 @@ import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.utils.OraxenYaml;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.YamlConfiguration;
-
-import java.io.File;
 
 public class BigMiningMechanicFactory extends MechanicFactory {
 
@@ -18,7 +15,7 @@ public class BigMiningMechanicFactory extends MechanicFactory {
 
     public BigMiningMechanicFactory(ConfigurationSection section) {
         super(section);
-        if (Bukkit.getPluginManager().isPluginEnabled("AdvancedEnchantments") && section.getBoolean("call_events", true)) {
+        if (PluginUtils.isEnabled("AdvancedEnchantments") && section.getBoolean("call_events", true)) {
             Logs.logError("AdvancedEnchantment is enabled, disabling BigMining-Mechanic");
             section.set("call_events", false);
             OraxenYaml.saveConfig(OraxenPlugin.get().getDataFolder().toPath().resolve("mechanics.yml").toFile(), section);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bigmining/BigMiningMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/farming/bigmining/BigMiningMechanicListener.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.mechanics.provided.farming.bigmining;
 
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.EventUtils;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -69,7 +70,9 @@ public class BigMiningMechanicListener implements Listener {
         // the same tool at the same time
         final BlockBreakEvent event = new BlockBreakEvent(block, player);
         if (!factory.callEvents() || !EventUtils.callEvent(event)) return;
-        if (event.isDropItems()) block.breakNaturally(itemStack, true);
+        if (event.isDropItems())
+            if (VersionUtil.isPaperServer()) block.breakNaturally(itemStack, true);
+            else block.breakNaturally();
         else block.setType(Material.AIR);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -248,7 +248,7 @@ public class FurnitureListener implements Listener {
         if (!ProtectionLib.canBreak(player, entity.getLocation())) return;
         OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, entity, player, entity.getLocation().getBlock());
         if (!EventUtils.callEvent(furnitureBreakEvent)) return;
-        OraxenFurniture.remove(entity, player, furnitureBreakEvent.getDrop());
+        if (OraxenFurniture.remove(entity, player, furnitureBreakEvent.getDrop())) event.setCancelled(false);
     }
 
     //TODO This should take hardness into account.
@@ -264,13 +264,11 @@ public class FurnitureListener implements Listener {
         Entity baseEntity = mechanic.getBaseEntity(block);
         if (baseEntity == null) return;
 
+        event.setCancelled(true);
         OraxenFurnitureBreakEvent furnitureBreakEvent = new OraxenFurnitureBreakEvent(mechanic, baseEntity, player, block);
-        if (!EventUtils.callEvent(furnitureBreakEvent)) {
-            event.setCancelled(true);
-            return;
-        }
-
-        OraxenFurniture.remove(block.getLocation(), player, furnitureBreakEvent.getDrop());
+        if (!EventUtils.callEvent(furnitureBreakEvent)) return;
+        // If successfully removed, un-cancel the event
+        if (OraxenFurniture.remove(block.getLocation(), player, furnitureBreakEvent.getDrop())) event.setCancelled(false);
         event.setDropItems(false);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -8,7 +8,6 @@ import io.th0rgal.oraxen.api.events.furniture.OraxenFurnitureBreakEvent;
 import io.th0rgal.oraxen.api.events.furniture.OraxenFurnitureInteractEvent;
 import io.th0rgal.oraxen.api.events.furniture.OraxenFurniturePlaceEvent;
 import io.th0rgal.oraxen.config.Message;
-import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.limitedplacing.LimitedPlacing;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.storage.StorageMechanic;
@@ -17,7 +16,6 @@ import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -174,7 +172,7 @@ public class FurnitureListener implements Listener {
             return;
         }
 
-        Entity baseEntity = mechanic.place(block.getLocation(), item, yaw, event.getBlockFace());
+        Entity baseEntity = mechanic.place(block.getLocation(), yaw, event.getBlockFace());
         Utils.swingHand(player, event.getHand());
 
         final OraxenFurniturePlaceEvent furniturePlaceEvent = new OraxenFurniturePlaceEvent(mechanic, block, baseEntity, player, item, hand);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -370,7 +370,7 @@ public class FurnitureMechanic extends Mechanic {
         item.setAmount(1);
 
         Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location), entityClass, (e) -> setEntityData(e, yaw, item, facing));
-        if (this.isModelEngine() && Bukkit.getPluginManager().isPluginEnabled("ModelEngine")) {
+        if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -386,7 +386,7 @@ public class FurnitureMechanic extends Mechanic {
         if (displayEntityProperties.getDisplayTransform() != ItemDisplay.ItemDisplayTransform.NONE && !isWall && !isRoof) return correctedLocation;
         float scale = displayEntityProperties.hasScale() ? displayEntityProperties.getScale().y() : 1;
         // Since roof-furniture need to be more or less flipped, we have to add 0.5 (0.49 or it is "inside" the block above) to the Y coordinate
-        if (isFixed && isWall) correctedLocation.add(-facing.getModX() * (0.5 * scale), 0, -facing.getModZ() * (0.5 * scale));
+        if (isFixed && isWall) correctedLocation.add(-facing.getModX() * (0.49 * scale), 0, -facing.getModZ() * (0.49 * scale));
         return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 * (hitbox.height - 1) : 0), 0);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -377,11 +377,11 @@ public class FurnitureMechanic extends Mechanic {
         return baseEntity;
     }
 
-    //TODO Account for limitedPlacing differences
     private Location correctedSpawnLocation(Location baseLocation) {
         Location correctedLocation = BlockHelpers.toCenterBlockLocation(baseLocation);
+        boolean isWall = hasLimitedPlacing() && limitedPlacing.isWall();
         if (furnitureType != FurnitureType.DISPLAY_ENTITY || !hasDisplayEntityProperties()) return correctedLocation;
-        if (displayEntityProperties.getDisplayTransform() != ItemDisplay.ItemDisplayTransform.NONE) return correctedLocation;
+        if (displayEntityProperties.getDisplayTransform() != ItemDisplay.ItemDisplayTransform.NONE && !isWall) return correctedLocation;
         float scale = displayEntityProperties.hasScale() ? displayEntityProperties.getScale().y() : 1;
         return correctedLocation.add(0, 0.5 * scale, 0);
     }
@@ -481,16 +481,13 @@ public class FurnitureMechanic extends Mechanic {
         // since FIXED is meant to mimic ItemFrames, we rotate it to match the ItemFrame's rotation
         // 1.20 Fixes this, will break for 1.19.4 but added disclaimer in console
         float pitch;
-        float alterYaw;
-        if (VersionUtil.atOrAbove("1.20.1")) {
+        yaw = VersionUtil.atOrAbove("1.20.1") ? yaw : yaw - 180;
+        if (VersionUtil.atOrAbove("1.20.1"))
             pitch = isFixed && hasLimitedPlacing() && (limitedPlacing.isFloor() || limitedPlacing.isRoof()) ? -90 : 0;
-            alterYaw = yaw;
-        } else {
+        else
             pitch = isFixed && hasLimitedPlacing() ? limitedPlacing.isFloor() ? 90 : limitedPlacing.isWall() ? 0 : limitedPlacing.isRoof() ? -90 : 0 : 0;
-            alterYaw = yaw - 180;
-        }
         itemDisplay.setTransformation(transform);
-        itemDisplay.setRotation(alterYaw, pitch);
+        itemDisplay.setRotation(yaw, pitch);
     }
 
     private void setFrameData(ItemFrame frame, ItemStack item, float yaw, BlockFace facing) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -381,7 +381,8 @@ public class FurnitureMechanic extends Mechanic {
         float scale = displayEntityProperties.hasScale() ? displayEntityProperties.getScale().y() : 1;
         // Since roof-furniture need to be more or less flipped, we have to add 0.5 (0.49 or it is "inside" the block above) to the Y coordinate
         if (isFixed && isWall) correctedLocation.add(-facing.getModX() * (0.49 * scale), 0, -facing.getModZ() * (0.49 * scale));
-        return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 * (hitbox.height - 1) : 0), 0);
+        float heightCorrection = (hasHitbox() ? hitbox.height : 1) - 1;
+        return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 * heightCorrection : 0), 0);
     }
 
     public void setEntityData(Entity entity, float yaw, BlockFace facing) {
@@ -411,7 +412,7 @@ public class FurnitureMechanic extends Mechanic {
             float width = hasHitbox() ? hitbox.width : displayEntityProperties.getDisplayWidth();
             float height = hasHitbox() ? hitbox.height : displayEntityProperties.getDisplayHeight();
             boolean isFixed = displayEntityProperties.getDisplayTransform() == ItemDisplay.ItemDisplayTransform.FIXED;
-            Location interactionLoc = location.clone().subtract(0, (hasLimitedPlacing() && limitedPlacing.isRoof() && isFixed) ? 1.5 * (hitbox.height - 1) : 0, 0);
+            Location interactionLoc = location.clone().subtract(0, (hasLimitedPlacing() && limitedPlacing.isRoof() && isFixed) ? 1.5 * (height - 1) : 0, 0);
             Interaction interaction = spawnInteractionEntity(itemDisplay, interactionLoc, width, height);
             Location barrierLoc = EntityUtils.isNone(itemDisplay) && displayEntityProperties.hasScale()
                             ? location.clone().subtract(0, 0.5 * displayEntityProperties.getScale().y(), 0) : location;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -339,23 +339,23 @@ public class FurnitureMechanic extends Mechanic {
     public void setPlacedItem() {
         if (placedItem == null) {
             placedItem = OraxenItems.getItemById(placedItemId != null ? placedItemId : getItemID()).build();
-            //Utils.editItemMeta(placedItem, meta -> meta.setDisplayName(""));
+            ItemUtils.editItemMeta(placedItem, meta -> meta.setDisplayName(""));
+            placedItem.setAmount(1);
         }
     }
 
     public Entity place(Location location) {
         setPlacedItem();
-        return place(location, placedItem, 0f, BlockFace.NORTH);
+        return place(location, 0f, BlockFace.NORTH);
     }
 
-    public Entity place(Location location, float yaw, BlockFace facing) {
-        setPlacedItem();
-        return place(location, placedItem, yaw, facing);
+    public Entity place(Location location, Float yaw, BlockFace facing) {
+        return place(location, yaw, facing, true);
     }
 
-    public Entity place(Location location, ItemStack originalItem, Float yaw, BlockFace facing) {
+    public Entity place(Location location, Float yaw, BlockFace facing, boolean checkSpace) {
         if (!location.isWorldLoaded()) return null;
-        if (this.notEnoughSpace(yaw, location)) return null;
+        if (checkSpace && this.notEnoughSpace(yaw, location)) return null;
         assert location.getWorld() != null;
         setPlacedItem();
         assert location.getWorld() != null;
@@ -363,13 +363,7 @@ public class FurnitureMechanic extends Mechanic {
         Class<? extends Entity> entityClass = getFurnitureEntityType().getEntityClass();
         if (entityClass == null) entityClass = ItemFrame.class;
 
-        ItemStack item;
-        if (evolvingFurniture == null) {
-            item = ItemUtils.editItemMeta(originalItem.clone(), meta -> meta.setDisplayName(""));
-        } else item = placedItem;
-        item.setAmount(1);
-
-        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, facing), entityClass, (e) -> setEntityData(e, yaw, item, facing));
+        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, facing), entityClass, (e) -> setEntityData(e, yaw, facing));
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }
@@ -390,11 +384,11 @@ public class FurnitureMechanic extends Mechanic {
         return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 * (hitbox.height - 1) : 0), 0);
     }
 
-    private void setEntityData(Entity entity, float yaw, ItemStack item, BlockFace facing) {
+    public void setEntityData(Entity entity, float yaw, BlockFace facing) {
         setBaseFurnitureData(entity);
         Location location = entity.getLocation();
         if (entity instanceof ItemFrame frame) {
-            setFrameData(frame, item, yaw, facing);
+            setFrameData(frame, yaw, facing);
 
             if (hasBarriers()) setBarrierHitbox(entity, location, yaw, true);
             else {
@@ -413,7 +407,7 @@ public class FurnitureMechanic extends Mechanic {
                 }
             }
         } else if (entity instanceof ItemDisplay itemDisplay) {
-            setItemDisplayData(itemDisplay, item, yaw, displayEntityProperties);
+            setItemDisplayData(itemDisplay, yaw, displayEntityProperties);
             float width = hasHitbox() ? hitbox.width : displayEntityProperties.getDisplayWidth();
             float height = hasHitbox() ? hitbox.height : displayEntityProperties.getDisplayHeight();
             boolean isFixed = displayEntityProperties.getDisplayTransform() == ItemDisplay.ItemDisplayTransform.FIXED;
@@ -434,6 +428,12 @@ public class FurnitureMechanic extends Mechanic {
 
     private Interaction spawnInteractionEntity(Entity entity, Location location, float width, float height) {
         if (!OraxenPlugin.supportsDisplayEntities || width <= 0f || height <= 0f) return null;
+        UUID existingInteractionUUID = entity.getPersistentDataContainer().get(INTERACTION_KEY, DataType.UUID);
+        if (existingInteractionUUID != null) {
+            Entity existingInteraction = Bukkit.getEntity(existingInteractionUUID);
+            if (existingInteraction instanceof Interaction interaction) return interaction;
+        }
+
         Interaction interaction = EntityUtils.spawnEntity(BlockHelpers.toCenterBlockLocation(location), Interaction.class, (i) -> {
             i.setInteractionWidth(width);
             i.setInteractionHeight(height);
@@ -460,7 +460,7 @@ public class FurnitureMechanic extends Mechanic {
         }
     }
 
-    private void setItemDisplayData(ItemDisplay itemDisplay, ItemStack item, Float yaw, DisplayEntityProperties properties) {
+    private void setItemDisplayData(ItemDisplay itemDisplay, Float yaw, DisplayEntityProperties properties) {
         itemDisplay.setItemDisplayTransform(properties.getDisplayTransform());
         if (properties.hasSpecifiedViewRange()) itemDisplay.setViewRange(properties.getViewRange());
         if (properties.hasInterpolationDuration())
@@ -475,7 +475,7 @@ public class FurnitureMechanic extends Mechanic {
 
         itemDisplay.setDisplayWidth(properties.getDisplayWidth());
         itemDisplay.setDisplayHeight(properties.getDisplayHeight());
-        itemDisplay.setItemStack(item);
+        itemDisplay.setItemStack(placedItem);
 
         // Set scale to .5 if FIXED aka ItemFrame to fix size. Also flip it 90 degrees on pitch
         boolean isFixed = properties.getDisplayTransform().equals(ItemDisplay.ItemDisplayTransform.FIXED);
@@ -501,11 +501,11 @@ public class FurnitureMechanic extends Mechanic {
         itemDisplay.setRotation(yaw, pitch);
     }
 
-    private void setFrameData(ItemFrame frame, ItemStack item, float yaw, BlockFace facing) {
+    private void setFrameData(ItemFrame frame, float yaw, BlockFace facing) {
         frame.setVisible(false);
         frame.setItemDropChance(0);
         frame.setFacingDirection(facing, true);
-        frame.setItem(item, false);
+        frame.setItem(placedItem, false);
         frame.setRotation(yawToRotation(yaw));
 
         if (hasLimitedPlacing()) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -369,7 +369,7 @@ public class FurnitureMechanic extends Mechanic {
         } else item = placedItem;
         item.setAmount(1);
 
-        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location), entityClass, (e) -> setEntityData(e, yaw, item, facing));
+        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, facing), entityClass, (e) -> setEntityData(e, yaw, item, facing));
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }
@@ -377,7 +377,7 @@ public class FurnitureMechanic extends Mechanic {
         return baseEntity;
     }
 
-    private Location correctedSpawnLocation(Location baseLocation) {
+    private Location correctedSpawnLocation(Location baseLocation, BlockFace facing) {
         Location correctedLocation = BlockHelpers.toCenterBlockLocation(baseLocation);
         boolean isWall = hasLimitedPlacing() && limitedPlacing.isWall();
         boolean isRoof = hasLimitedPlacing() && limitedPlacing.isRoof();
@@ -386,6 +386,7 @@ public class FurnitureMechanic extends Mechanic {
         if (displayEntityProperties.getDisplayTransform() != ItemDisplay.ItemDisplayTransform.NONE && !isWall && !isRoof) return correctedLocation;
         float scale = displayEntityProperties.hasScale() ? displayEntityProperties.getScale().y() : 1;
         // Since roof-furniture need to be more or less flipped, we have to add 0.5 (0.49 or it is "inside" the block above) to the Y coordinate
+        if (isFixed && isWall) correctedLocation.add(-facing.getModX() * (0.5 * scale), 0, -facing.getModZ() * (0.5 * scale));
         return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 : 0), 0);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -387,7 +387,7 @@ public class FurnitureMechanic extends Mechanic {
         float scale = displayEntityProperties.hasScale() ? displayEntityProperties.getScale().y() : 1;
         // Since roof-furniture need to be more or less flipped, we have to add 0.5 (0.49 or it is "inside" the block above) to the Y coordinate
         if (isFixed && isWall) correctedLocation.add(-facing.getModX() * (0.5 * scale), 0, -facing.getModZ() * (0.5 * scale));
-        return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 : 0), 0);
+        return correctedLocation.add(0, (0.5 * scale) + (isRoof ? isFixed ? 0.49 : -1 * (hitbox.height - 1) : 0), 0);
     }
 
     private void setEntityData(Entity entity, float yaw, ItemStack item, BlockFace facing) {
@@ -417,7 +417,7 @@ public class FurnitureMechanic extends Mechanic {
             float width = hasHitbox() ? hitbox.width : displayEntityProperties.getDisplayWidth();
             float height = hasHitbox() ? hitbox.height : displayEntityProperties.getDisplayHeight();
             boolean isFixed = displayEntityProperties.getDisplayTransform() == ItemDisplay.ItemDisplayTransform.FIXED;
-            Location interactionLoc = location.clone().subtract(0, (hasLimitedPlacing() && limitedPlacing.isRoof() && isFixed) ? 1.5 : 0, 0);
+            Location interactionLoc = location.clone().subtract(0, (hasLimitedPlacing() && limitedPlacing.isRoof() && isFixed) ? 1.5 * (hitbox.height - 1) : 0, 0);
             Interaction interaction = spawnInteractionEntity(itemDisplay, interactionLoc, width, height);
             Location barrierLoc = EntityUtils.isNone(itemDisplay) && displayEntityProperties.hasScale()
                             ? location.clone().subtract(0, 0.5 * displayEntityProperties.getScale().y(), 0) : location;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
@@ -9,7 +9,6 @@ import io.th0rgal.oraxen.utils.blocksounds.BlockSounds;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -102,27 +101,27 @@ public class FurnitureSoundListener implements Listener {
         if (!isLoaded(entity.getLocation())) return;
 
         GameEvent gameEvent = event.getEvent();
-        Block block = entity.getLocation().getBlock();
-        Block blockBelow = block.getRelative(BlockFace.DOWN);
+        Block blockStandingOn = BlockHelpers.getBlockStandingOn(entity);
         EntityDamageEvent cause = entity.getLastDamageCause();
-        if (blockBelow.getType() == Material.AIR) return;
-        SoundGroup soundGroup = blockBelow.getBlockData().getSoundGroup();
+
+        if (blockStandingOn == null || blockStandingOn.getType().isAir()) return;
+        SoundGroup soundGroup = blockStandingOn.getBlockData().getSoundGroup();
 
         if (soundGroup.getStepSound() != Sound.BLOCK_STONE_STEP) return;
         if (gameEvent == GameEvent.HIT_GROUND && cause != null && cause.getCause() != EntityDamageEvent.DamageCause.FALL) return;
-        if (!BlockHelpers.isReplaceable(block) || block.getType() == Material.TRIPWIRE) return;
-        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(blockBelow);
+        if (blockStandingOn.getType() == Material.TRIPWIRE) return;
+        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(blockStandingOn);
 
         String sound;
         float volume;
         float pitch;
         if (gameEvent == GameEvent.STEP) {
-            boolean check = blockBelow.getType() == Material.BARRIER && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasStepSound();
+            boolean check = blockStandingOn.getType() == Material.BARRIER && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasStepSound();
             sound = (check) ? mechanic.getBlockSounds().getStepSound() : VANILLA_STONE_STEP;
             volume = (check) ? mechanic.getBlockSounds().getStepVolume() : VANILLA_STEP_VOLUME;
             pitch = (check) ? mechanic.getBlockSounds().getStepPitch() : VANILLA_STEP_PITCH;
         } else if (gameEvent == GameEvent.HIT_GROUND) {
-            boolean check = (blockBelow.getType() == Material.BARRIER && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasFallSound());
+            boolean check = (blockStandingOn.getType() == Material.BARRIER && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasFallSound());
             sound = (check) ? mechanic.getBlockSounds().getFallSound() : VANILLA_STONE_FALL;
             volume = (check) ? mechanic.getBlockSounds().getFallVolume() : VANILLA_FALL_VOLUME;
             pitch = (check) ? mechanic.getBlockSounds().getFallPitch() : VANILLA_FALL_PITCH;
@@ -142,11 +141,6 @@ public class FurnitureSoundListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBreakingFurniture(final OraxenFurnitureBreakEvent event) {
-        if (event.getPlayer().isSneaking()) {
-            event.setCancelled(true);
-            Logs.debug("baseEntity: " + event.getBaseEntity().getUniqueId());
-            Logs.debug("interaction: " + event.getMechanic().getInteractionEntity(event.getBaseEntity()).getUniqueId());
-        }
         Location loc = event.getBlock() != null ? event.getBlock().getLocation() : event.getBaseEntity().getLocation();
         final FurnitureMechanic mechanic = event.getMechanic();
         if (!mechanic.hasBlockSounds()) return;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
@@ -142,6 +142,11 @@ public class FurnitureSoundListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBreakingFurniture(final OraxenFurnitureBreakEvent event) {
+        if (event.getPlayer().isSneaking()) {
+            event.setCancelled(true);
+            Logs.debug("baseEntity: " + event.getBaseEntity().getUniqueId());
+            Logs.debug("interaction: " + event.getMechanic().getInteractionEntity(event.getBaseEntity()).getUniqueId());
+        }
         Location loc = event.getBlock() != null ? event.getBlock().getLocation() : event.getBaseEntity().getLocation();
         final FurnitureMechanic mechanic = event.getMechanic();
         if (!mechanic.hasBlockSounds()) return;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
@@ -6,7 +6,6 @@ import io.th0rgal.oraxen.api.events.furniture.OraxenFurnitureBreakEvent;
 import io.th0rgal.oraxen.api.events.furniture.OraxenFurniturePlaceEvent;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.blocksounds.BlockSounds;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -55,7 +54,7 @@ public class FurnitureSoundListener implements Listener {
     }
 
     // Play sound due to furniture/barrier custom sound replacing stone
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGH)
     public void onBreakingStone(final BlockBreakEvent event) {
         Block block = event.getBlock();
         Location location = block.getLocation();
@@ -66,7 +65,7 @@ public class FurnitureSoundListener implements Listener {
         }
 
         if (block.getBlockData().getSoundGroup().getBreakSound() != Sound.BLOCK_STONE_BREAK) return;
-        if (!OraxenFurniture.isFurniture(block)) return;
+        if (OraxenFurniture.isFurniture(block)) return;
 
         if (!event.isCancelled() && ProtectionLib.canBreak(event.getPlayer(), location))
             BlockHelpers.playCustomBlockSound(location, VANILLA_STONE_BREAK, VANILLA_BREAK_VOLUME, VANILLA_BREAK_PITCH);
@@ -106,6 +105,7 @@ public class FurnitureSoundListener implements Listener {
         Block block = entity.getLocation().getBlock();
         Block blockBelow = block.getRelative(BlockFace.DOWN);
         EntityDamageEvent cause = entity.getLastDamageCause();
+        if (blockBelow.getType() == Material.AIR) return;
         SoundGroup soundGroup = blockBelow.getBlockData().getSoundGroup();
 
         if (soundGroup.getStepSound() != Sound.BLOCK_STONE_STEP) return;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -15,7 +15,6 @@ import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.breaker.BreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.HardnessModifier;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.apache.commons.lang3.Range;
 import org.bukkit.*;
@@ -32,7 +31,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.*;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.EntityPlaceEvent;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryCreativeEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -327,11 +325,12 @@ public class NoteBlockMechanicListener implements Listener {
     public void onCatchFire(final BlockIgniteEvent event) {
         Block block = event.getBlock();
         NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
-        if (block.getType() != Material.NOTE_BLOCK || mechanic == null) return;
+        if (mechanic == null) return;
         if (!mechanic.canIgnite()) event.setCancelled(true);
-
-        block.getWorld().playSound(block.getLocation(), Sound.ITEM_FLINTANDSTEEL_USE, 1, 1);
-        block.getRelative(BlockFace.UP).setType(Material.FIRE);
+        else {
+            block.getWorld().playSound(block.getLocation(), Sound.ITEM_FLINTANDSTEEL_USE, 1, 1);
+            block.getRelative(BlockFace.UP).setType(Material.FIRE);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -129,13 +129,12 @@ public class NoteBlockMechanicListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void callInteract(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
-        if (block == null) return;
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if (block == null || (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK)) return;
         if (event.getClickedBlock().getType() != Material.NOTE_BLOCK) return;
         NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
         if (mechanic == null) return;
         if (!EventUtils.callEvent(new OraxenNoteBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace())))
-            event.setCancelled(true);
+            event.setUseInteractedBlock(Event.Result.DENY);
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -210,18 +209,12 @@ public class NoteBlockMechanicListener implements Listener {
         EquipmentSlot hand = event.getHand();
         BlockFace blockFace = event.getBlockFace();
 
-        if (hand == null || event.getAction() != Action.RIGHT_CLICK_BLOCK || block == null || block.getType() != Material.NOTE_BLOCK)
-            return;
+        if (hand == null || event.getAction() != Action.RIGHT_CLICK_BLOCK || block == null || block.getType() != Material.NOTE_BLOCK) return;
         if (!player.isSneaking() && BlockHelpers.isInteractable(block)) return;
-
-        NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
-        if (mechanic == null) return;
-        if (mechanic.isDirectional() && !mechanic.getDirectional().isParentBlock())
-            mechanic = mechanic.getDirectional().getParentMechanic();
+        if (event.useInteractedBlock() == Event.Result.DENY || !OraxenBlocks.isOraxenNoteBlock(block)) return;
 
         event.setUseInteractedBlock(Event.Result.DENY);
         if (OraxenBlocks.isOraxenNoteBlock(item)) return;
-        if (!EventUtils.callEvent(new OraxenNoteBlockInteractEvent(mechanic, player, item, hand, block, blockFace))) event.setCancelled(true);
         if (item == null) return;
 
         Material type = item.getType();

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockSoundListener.java
@@ -6,11 +6,9 @@ import io.th0rgal.oraxen.api.events.noteblock.OraxenNoteBlockBreakEvent;
 import io.th0rgal.oraxen.api.events.noteblock.OraxenNoteBlockPlaceEvent;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.blocksounds.BlockSounds;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -104,14 +102,13 @@ public class NoteBlockSoundListener implements Listener {
         if (!isLoaded(entity.getLocation())) return;
 
         GameEvent gameEvent = event.getEvent();
-        Block block = entity.getLocation().getBlock();
-        Block blockBelow = block.getRelative(BlockFace.DOWN);
+        Block block = BlockHelpers.getBlockStandingOn(entity);
         EntityDamageEvent cause = entity.getLastDamageCause();
 
         if (gameEvent == GameEvent.HIT_GROUND && cause != null && cause.getCause() != EntityDamageEvent.DamageCause.FALL) return;
-        if (blockBelow.getBlockData().getSoundGroup().getStepSound() != Sound.BLOCK_WOOD_STEP) return;
+        if (block == null || block.getType().isAir() || block.getBlockData().getSoundGroup().getStepSound() != Sound.BLOCK_WOOD_STEP) return;
 
-        NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(blockBelow);
+        NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
         if (mechanic != null && mechanic.isDirectional() && !mechanic.getDirectional().isParentBlock())
             mechanic = mechanic.getDirectional().getParentMechanic();
 
@@ -119,12 +116,12 @@ public class NoteBlockSoundListener implements Listener {
         float volume;
         float pitch;
         if (gameEvent == GameEvent.STEP) {
-            boolean check = blockBelow.getType() == Material.NOTE_BLOCK && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasStepSound();
+            boolean check = block.getType() == Material.NOTE_BLOCK && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasStepSound();
             sound = (check) ? mechanic.getBlockSounds().getStepSound() : VANILLA_WOOD_STEP;
             volume = (check) ? mechanic.getBlockSounds().getStepVolume() : VANILLA_STEP_VOLUME;
             pitch = (check) ? mechanic.getBlockSounds().getStepPitch() : VANILLA_STEP_PITCH;
         } else if (gameEvent == GameEvent.HIT_GROUND) {
-            boolean check = (blockBelow.getType() == Material.NOTE_BLOCK && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasFallSound());
+            boolean check = (block.getType() == Material.NOTE_BLOCK && mechanic != null && mechanic.hasBlockSounds() && mechanic.getBlockSounds().hasFallSound());
             sound = (check) ? mechanic.getBlockSounds().getFallSound() : VANILLA_WOOD_FALL;
             volume = (check) ? mechanic.getBlockSounds().getFallVolume() : VANILLA_FALL_VOLUME;
             pitch = (check) ? mechanic.getBlockSounds().getFallPitch() : VANILLA_FALL_PITCH;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/logstrip/LogStripListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/logstrip/LogStripListener.java
@@ -2,10 +2,10 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.logstrip;
 
 import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.api.OraxenItems;
-import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.misc.misc.MiscMechanic;
+import io.th0rgal.oraxen.mechanics.provided.misc.misc.MiscMechanicFactory;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -64,6 +64,10 @@ public class LogStripListener implements Listener {
     }
 
     private boolean canStripLog(ItemStack itemStack) {
-        return itemStack.getType().toString().endsWith("_AXE") || (MechanicsManager.getMechanicFactory("misc").getMechanic(OraxenItems.getIdByItem(itemStack)) instanceof MiscMechanic miscMechanic && miscMechanic.canStripLogs());
+        if (itemStack.getType().toString().endsWith("_AXE")) return true;
+        else if (MiscMechanicFactory.get() != null) {
+            MiscMechanic miscMechanic = MiscMechanicFactory.get().getMechanic(OraxenItems.getIdByItem(itemStack));
+            return miscMechanic != null && miscMechanic.canStripLogs();
+        } else return false;
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockSoundListener.java
@@ -5,7 +5,6 @@ import io.th0rgal.oraxen.api.events.stringblock.OraxenStringBlockBreakEvent;
 import io.th0rgal.oraxen.api.events.stringblock.OraxenStringBlockPlaceEvent;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.blocksounds.BlockSounds;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.GameEvent;
 import org.bukkit.Material;
 import org.bukkit.SoundCategory;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingListener.java
@@ -4,7 +4,11 @@ import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.compatibilities.provided.worldedit.WrappedWorldEdit;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
-import org.bukkit.*;
+import io.th0rgal.oraxen.utils.PluginUtils;
+import org.bukkit.Effect;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -40,7 +44,7 @@ public class SaplingListener implements Listener {
         if (sapling.requiresLight() && sapling.getMinLightLevel() > block.getLightLevel()) return;
         if (sapling.requiresWaterSource() && sapling.isInWater(block)) return;
         if (!sapling.canGrowFromBoneMeal()) return;
-        if (!Bukkit.getPluginManager().isPluginEnabled("WorldEdit")) return;
+        if (!PluginUtils.isEnabled("WorldEdit")) return;
         if (!sapling.replaceBlocks() && !WrappedWorldEdit.getBlocksInSchematic(loc, sapling.getSchematic()).isEmpty()) return;
 
         if (player.getGameMode() != GameMode.CREATIVE) item.setAmount(item.getAmount() - 1);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingTask.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingTask.java
@@ -6,6 +6,7 @@ import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.compatibilities.provided.worldedit.WrappedWorldEdit;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.PluginUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
@@ -27,7 +28,7 @@ public class SaplingTask extends BukkitRunnable {
 
     @Override
     public void run() {
-        if (!Bukkit.getPluginManager().isPluginEnabled("WorldEdit")) return;
+        if (!PluginUtils.isEnabled("WorldEdit")) return;
         for (World world : Bukkit.getWorlds()) {
             for (Chunk chunk : world.getLoadedChunks()) {
                 for (Block block : CustomBlockData.getBlocksWithCustomData(OraxenPlugin.get(), chunk)) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscListener.java
@@ -36,10 +36,7 @@ import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.FIRE_TICK;
 
 public class MiscListener implements Listener {
 
-    private final MiscMechanicFactory factory;
-
     public MiscListener(MiscMechanicFactory factory) {
-        this.factory = factory;
         if (VersionUtil.isPaperServer()) {
             OraxenPlugin.get().getServer().getPluginManager().registerEvents(new PaperOnlyListeners(factory), OraxenPlugin.get());
         }
@@ -55,7 +52,7 @@ public class MiscListener implements Listener {
         if (composter.getType() != Material.COMPOSTER) return;
         if (!(composter.getBlockData() instanceof Levelled levelled)) return;
 
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(event.getItem());
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(event.getItem());
         if (mechanic == null || !mechanic.isCompostable()) return;
 
         if (levelled.getLevel() < levelled.getMaximumLevel()) {
@@ -79,7 +76,7 @@ public class MiscListener implements Listener {
         if (item == null || block == null || block.getType() != Material.COMPOSTER) return;
         if (!(block.getBlockData() instanceof Levelled levelled)) return;
         if (!ProtectionLib.canInteract(player, block.getLocation())) return;
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(item);
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(item);
         if (mechanic == null || !mechanic.isCompostable()) return;
         if (event.useInteractedBlock() == Event.Result.DENY) return;
         event.setUseInteractedBlock(Event.Result.ALLOW);
@@ -100,11 +97,11 @@ public class MiscListener implements Listener {
         Block block = event.getClickedBlock();
         ItemStack item = event.getItem();
         Player player = event.getPlayer();
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(item);
 
         if (block == null || !Tag.LOGS.isTagged(block.getType())) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || item == null) return;
-        if (!(factory.getMechanic(OraxenItems.getIdByItem(item)) instanceof MiscMechanic mechanic)) return;
-        if (!mechanic.canStripLogs()) return;
+        if (mechanic == null || !mechanic.canStripLogs()) return;
 
         if (item.getItemMeta() instanceof Damageable axeDurabilityMeta) {
             int durability = axeDurabilityMeta.getDamage();
@@ -162,14 +159,14 @@ public class MiscListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDisableVanillaInteraction(PlayerInteractEvent event) {
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(event.getItem());
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(event.getItem());
         if (mechanic == null || !mechanic.isVanillaInteractionDisabled()) return;
         event.setUseItemInHand(Event.Result.DENY);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onDisableItemConsume(PlayerItemConsumeEvent event) {
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(event.getItem());
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(event.getItem());
         if (mechanic == null || !mechanic.isVanillaInteractionDisabled()) return;
         event.setCancelled(true);
     }
@@ -177,7 +174,7 @@ public class MiscListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onDisableBowShoot(EntityShootBowEvent event) {
         if (!(event.getEntity() instanceof Player player)) return;
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(event.getConsumable());
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(event.getConsumable());
         if (mechanic == null || !mechanic.isVanillaInteractionDisabled()) return;
         event.setConsumeItem(false);
         event.setCancelled(true);
@@ -196,7 +193,7 @@ public class MiscListener implements Listener {
         else return;
 
 
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(item);
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(item);
         if (mechanic == null || !mechanic.isVanillaInteractionDisabled()) return;
         event.setCancelled(true);
     }
@@ -205,7 +202,7 @@ public class MiscListener implements Listener {
     public void onDisableHorseArmorEquip(PlayerInteractEntityEvent event) {
         if (!(event.getRightClicked() instanceof Horse)) return;
         ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(item);
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(item);
         if (mechanic == null || !mechanic.isVanillaInteractionDisabled()) return;
         if (item.getType().name().endsWith("_HORSE_ARMOR")) {
             event.setCancelled(true);
@@ -219,7 +216,7 @@ public class MiscListener implements Listener {
         String itemID = OraxenItems.getIdByItem(itemStack);
         if (itemID == null) return null;
 
-        return (MiscMechanic) factory.getMechanic(itemID);
+        return MiscMechanicFactory.get().getMechanic(itemID);
     }
 
     private Material getStrippedLog(Material log) {
@@ -249,7 +246,7 @@ public class MiscListener implements Listener {
     }
 
     private boolean shouldPreventPiglinAggro(ItemStack itemStack) {
-        MiscMechanic mechanic = (MiscMechanic) factory.getMechanic(OraxenItems.getIdByItem(itemStack));
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(OraxenItems.getIdByItem(itemStack));
         return mechanic != null && mechanic.piglinIgnoreWhenEquipped();
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanic.java
@@ -13,6 +13,8 @@ public class MiscMechanic extends Mechanic {
     private final boolean piglinsIgnoreWhenEquipped;
     private final boolean compostable;
 
+    private final boolean allowInVanillaRecipes;
+
     public MiscMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
         super(mechanicFactory, section);
         cactusBreaks = section.getBoolean("breaks_from_cactus", true);
@@ -22,6 +24,7 @@ public class MiscMechanic extends Mechanic {
         canStripLogs = section.getBoolean("can_strip_logs", false);
         piglinsIgnoreWhenEquipped = section.getBoolean("piglins_ignore_when_equipped", false);
         compostable = section.getBoolean("compostable", false);
+        allowInVanillaRecipes = section.getBoolean("allow_in_vanilla_recipes", false);
     }
 
     public boolean breaksFromCactus() { return cactusBreaks; }
@@ -31,4 +34,6 @@ public class MiscMechanic extends Mechanic {
     public boolean canStripLogs() { return canStripLogs; }
     public boolean piglinIgnoreWhenEquipped() { return piglinsIgnoreWhenEquipped; }
     public boolean isCompostable() { return compostable; }
+
+    public boolean isAllowedInVanillaRecipes() { return allowInVanillaRecipes; }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanicFactory.java
@@ -5,11 +5,15 @@ import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
 
 public class MiscMechanicFactory extends MechanicFactory {
+
+    private static MiscMechanicFactory instance;
     public MiscMechanicFactory(ConfigurationSection section) {
         super(section);
         MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new MiscListener(this));
+        instance = this;
     }
 
     @Override
@@ -17,5 +21,19 @@ public class MiscMechanicFactory extends MechanicFactory {
         Mechanic mechanic = new MiscMechanic(this, section);
         addToImplemented(mechanic);
         return mechanic;
+    }
+
+    public static MiscMechanicFactory get() {
+        return instance;
+    }
+
+    @Override
+    public MiscMechanic getMechanic(String itemID) {
+        return (MiscMechanic) super.getMechanic(itemID);
+    }
+
+    @Override
+    public MiscMechanic getMechanic(ItemStack itemStack) {
+        return (MiscMechanic) super.getMechanic(itemStack);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/nms/GlyphHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/GlyphHandlers.java
@@ -4,26 +4,42 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.font.Glyph;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.translation.GlobalTranslator;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GlyphHandlers {
+
+    private enum GlyphHandler {
+        NMS, VANILLA;
+
+        public static GlyphHandler get() {
+            try {
+                return GlyphHandler.valueOf(Settings.GLYPH_HANDLER.toString());
+            } catch (IllegalArgumentException e) {
+                Logs.logError("Invalid glyph handler: " + Settings.GLYPH_HANDLER + ", defaulting to VANILLA", true);
+                Logs.logError("Valid options are: NMS, VANILLA", true);
+                return GlyphHandler.VANILLA;
+            }
+        }
+    }
+
+    public static boolean isNms() {
+        return GlyphHandler.get() == GlyphHandler.NMS;
+    }
 
     public static Component transform(Component component, @Nullable Player player, boolean isUtf) {
         if (player != null) return escapeGlyphs(component, player);

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSListeners.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSListeners.java
@@ -1,8 +1,5 @@
 package io.th0rgal.oraxen.nms;
 
-import io.th0rgal.oraxen.config.Settings;
-import io.th0rgal.oraxen.mechanics.MechanicsManager;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,7 +13,7 @@ public class NMSListeners implements Listener {
         Player player = event.getPlayer();
         if (NMSHandlers.getHandler() == null) return;
 
-        if (Settings.NMS_GLYPHS.toBool()) NMSHandlers.getHandler().inject(player);
+        if (GlyphHandlers.isNms()) NMSHandlers.getHandler().inject(player);
         if (NoteBlockMechanicFactory.isEnabled() && NoteBlockMechanicFactory.getInstance().removeMineableTag())
             NMSHandlers.getHandler().customBlockDefaultTools(player);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -191,7 +191,7 @@ public class DuplicationHandler {
 
             JsonArray providers = fontelement.getAsJsonObject().getAsJsonArray("providers");
             List<String> newProviderChars = getNewProviderCharSet(newProviders);
-            for (JsonElement providerElement : providers) {
+            if (providers != null) for (JsonElement providerElement : providers) {
                 if (!providerElement.isJsonObject()) continue;
                 if (newProviders.contains(providerElement)) continue;
                 if (!providerElement.getAsJsonObject().has("chars")) continue;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -13,6 +13,7 @@ import io.th0rgal.oraxen.utils.logs.Logs;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -328,22 +329,22 @@ public class DuplicationHandler {
         }
 
         JsonObject json = JsonParser.parseString(fileContent).getAsJsonObject();
-        JsonArray overrides = json.getAsJsonArray("overrides");
-        //Map<Integer, Map<Integer, String>> pullingModels = new HashMap<>();
+        List<JsonObject> overrides = new ArrayList<>(json.getAsJsonArray("overrides").asList().stream().filter(JsonElement::isJsonObject).map(JsonElement::getAsJsonObject).toList());
         Map<Integer, List<String>> pullingModels = new HashMap<>();
         Map<Integer, String> chargedModels = new HashMap<>();
         Map<Integer, String> blockingModels = new HashMap<>();
         Map<Integer, String> castModels = new HashMap<>();
         Map<Integer, List<String>> damagedModels = new HashMap<>();
         List<JsonElement> overridesToRemove = new ArrayList<>();
-        if (overrides != null) {
+
+        if (!overrides.isEmpty()) {
             handleBowPulling(overrides, overridesToRemove, pullingModels);
             handleCrossbowPulling(overrides, overridesToRemove, chargedModels);
             handleShieldBlocking(overrides, overridesToRemove, blockingModels);
             handleFishingRodCast(overrides, overridesToRemove, castModels);
             handleDamaged(overrides, overridesToRemove, damagedModels);
 
-            for (JsonElement element : overridesToRemove) overrides.remove(element);
+            overrides.removeIf(overridesToRemove::contains);
 
             for (JsonElement element : overrides) {
                 JsonObject predicate = element.getAsJsonObject().get("predicate").getAsJsonObject();
@@ -378,15 +379,15 @@ public class DuplicationHandler {
         return true;
     }
 
-    private static void handleBowPulling(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, List<String>> pullingModels) {
+    private static void handleBowPulling(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, List<String>> pullingModels) {
         handleExtraListPredicates(overrides, overridesToRemove, pullingModels, "pulling");
     }
-    private static void handleDamaged(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, List<String>> damagedModels) {
+    private static void handleDamaged(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, List<String>> damagedModels) {
         handleExtraListPredicates(overrides, overridesToRemove, damagedModels, "damaged");
     }
 
-    private static void handleExtraListPredicates(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, List<String>> predicateModels, String predicate) {
-        for (JsonObject object : overrides.asList().stream().filter(JsonElement::isJsonObject).map(JsonElement::getAsJsonObject).toList()) {
+    private static void handleExtraListPredicates(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, List<String>> predicateModels, String predicate) {
+        for (JsonObject object : overrides) {
             if (object.get("predicate") == null || !object.get("predicate").isJsonObject()) continue;
             JsonObject predicateObject = object.get("predicate").getAsJsonObject();
             if (predicateObject == null || !predicateObject.has(predicate)) continue;
@@ -397,18 +398,18 @@ public class DuplicationHandler {
         }
     }
 
-    private static void handleCrossbowPulling(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, String> chargedModels) {
+    private static void handleCrossbowPulling(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, String> chargedModels) {
         handleExtraPredicates(overrides, overridesToRemove, chargedModels, "charged");
     }
-    private static void handleShieldBlocking(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, String> blockingModels) {
+    private static void handleShieldBlocking(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, String> blockingModels) {
         handleExtraPredicates(overrides, overridesToRemove, blockingModels, "blocking");
     }
-    private static void handleFishingRodCast(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, String> castModels) {
+    private static void handleFishingRodCast(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, String> castModels) {
         handleExtraPredicates(overrides, overridesToRemove, castModels, "cast");
     }
 
-    private static void handleExtraPredicates(JsonArray overrides, List<JsonElement> overridesToRemove, Map<Integer, String> predicateModels, String predicate) {
-        for (JsonObject object : overrides.asList().stream().filter(JsonElement::isJsonObject).map(JsonElement::getAsJsonObject).toList()) {
+    private static void handleExtraPredicates(@NotNull List<JsonObject> overrides, List<JsonElement> overridesToRemove, Map<Integer, String> predicateModels, String predicate) {
+        for (JsonObject object : overrides) {
             if (object.get("predicate") == null || !object.get("predicate").isJsonObject()) continue;
             JsonObject predicateObject = object.get("predicate").getAsJsonObject();
             if (predicateObject == null || !predicateObject.has(predicate)) continue;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.pack.generation;
 
-import com.destroystokyo.paper.MaterialSetTag;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -9,12 +8,15 @@ import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.OraxenMeta;
 import io.th0rgal.oraxen.utils.ItemUtils;
 import io.th0rgal.oraxen.utils.Utils;
+import io.th0rgal.oraxen.utils.VersionUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.meta.SpawnEggMeta;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,21 +37,21 @@ public class PredicatesGenerator {
 
         // textures
         final ItemMeta exampleMeta = new ItemStack(material).getItemMeta();
-        final JsonObject textures = new JsonObject();
+        JsonObject textures = new JsonObject();
 
         if (material == Material.TIPPED_ARROW) {
             textures.addProperty("layer0", "item/tipped_arrow_head");
             textures.addProperty("layer1", "item/tipped_arrow_base");
         } else if (exampleMeta instanceof PotionMeta) {
-            textures.addProperty("layer0", vanillaTextureName + "_overlay");
+            textures.addProperty("layer0", "item/potion_overlay");
             textures.addProperty("layer1", vanillaTextureName);
         } else if (exampleMeta instanceof LeatherArmorMeta && material != Material.LEATHER_HORSE_ARMOR) {
             textures.addProperty("layer0", vanillaTextureName);
             textures.addProperty("layer1", vanillaTextureName + "_overlay");
-        }
+        } else if (exampleMeta instanceof SpawnEggMeta) textures = new JsonObject();
         else textures.addProperty("layer0", vanillaTextureName);
 
-        json.add("textures", textures);
+        if (!textures.entrySet().isEmpty()) json.add("textures", textures);
 
         // overrides
         final JsonArray overrides = new JsonArray();
@@ -87,6 +89,32 @@ public class PredicatesGenerator {
                 overrides.add(getOverride(JsonParser.parseString(chargedPredicate.toString()).getAsJsonObject(), "item/crossbow_firework"));
 
                 json.add("display", JsonParser.parseString(Settings.CROSSBOW_DISPLAY.toString()).getAsJsonObject());
+            }
+            case LIGHT -> {
+                JsonObject lightPredicate = new JsonObject();
+                for (int i = 0; i < 16; i++) {
+                    lightPredicate.addProperty("level", (float) i / 16);
+                    overrides.add(getOverride(JsonParser.parseString(lightPredicate.toString()).getAsJsonObject(), "item/light_" + (i >= 10 ? i : "0" + i)));
+                }
+            }
+            case CHEST, ENDER_CHEST, TRAPPED_CHEST -> json.add("display", JsonParser.parseString(CHEST_DISPLAY).getAsJsonObject());
+            case LARGE_AMETHYST_BUD -> json.add("display", JsonParser.parseString(LARGE_AMETHYST_BUD_DISPLAY).getAsJsonObject());
+            case SMALL_DRIPLEAF -> json.add("display", JsonParser.parseString(SMALL_DRIPLEAF_DISPLAY).getAsJsonObject());
+            case BIG_DRIPLEAF -> json.add("display", JsonParser.parseString(BIG_DRIPLEAF_DISPLAY).getAsJsonObject());
+            case HANGING_ROOTS -> json.add("display", JsonParser.parseString(HANGING_ROOTS_DISPLAY).getAsJsonObject());
+            case DRAGON_HEAD -> json.add("display", JsonParser.parseString(DRAGON_HEAD_DISPLAY).getAsJsonObject());
+            case CONDUIT -> json.add("display", JsonParser.parseString(CONDUIT_DISPLAY).getAsJsonObject());
+        }
+
+        if (VersionUtil.atOrAbove("1.20") && material == Material.DECORATED_POT) {
+            textures.addProperty("particle", "entity/decorated_pot/decorated_pot_side");
+            json.add("display", JsonParser.parseString(DECORATED_POT_DISPLAY).getAsJsonObject());
+        }
+        if (material == Material.COMPASS || material == Material.CLOCK || (VersionUtil.atOrAbove("1.19") && material == Material.RECOVERY_COMPASS)) {
+            String override = material == Material.CLOCK ? CLOCK_OVERRIDES : COMPASS_OVERRIDES;
+            JsonArray jsonArray = JsonParser.parseString(override.replace("X", material.name().toLowerCase())).getAsJsonArray();
+            for (int i = 0; i < jsonArray.size(); i++) {
+                overrides.add(jsonArray.get(i).getAsJsonObject());
             }
         }
 
@@ -240,37 +268,134 @@ public class PredicatesGenerator {
     }
 
     public String getVanillaTextureName(final Material material, final boolean model) {
-        if (!model)
+        String materialName = material.toString().toLowerCase(Locale.ENGLISH);
+        if (!model) {
+            if (material == Material.COMPASS) return "item/compass_16";
+            if (material == Material.DEBUG_STICK) return "item/stick";
+            if (material == Material.ENCHANTED_GOLDEN_APPLE) return "item/golden_apple";
+            if (material == Material.SUNFLOWER) return "block/sunflower_front";
+            if (Tag.TALL_FLOWERS.isTagged(material) && !material.name().equals("PITCHER_PLANT"))
+                return "block/" + materialName + "_top";
+            if (material == Material.LARGE_FERN || material == Material.TALL_GRASS)
+                return "block/" + materialName + "_top";
+            if (material.name().contains("GLASS_PANE"))
+                return "block/" + materialName.replace("_pane", "");
+            if (material == Material.TWISTING_VINES || material == Material.WEEPING_VINES)
+                return "block/" + materialName + "_plant";
             if (material == Material.IRON_BARS || (material.isBlock() && !has2DBlockIcon(material)))
-                return "block/" + material.toString().toLowerCase(Locale.ENGLISH);
-            else if (material == Material.CROSSBOW) return "item/crossbow_standby";
-        return "item/" + material.toString().toLowerCase(Locale.ENGLISH);
+                return "block/" + materialName;
+            if (material == Material.CROSSBOW) return "item/crossbow_standby";
+        }
+        return "item/" + materialName;
     }
 
     private String getParent(final Material material) {
-        if (ItemUtils.isSkull(material))
-            return "item/template_skull";
-        if (Arrays.stream(tools).anyMatch(tool -> material.toString().contains(tool)))
-            return "item/handheld";
+        String materialName = material.name().toLowerCase();
+        if (material == Material.SNOW)
+            return "block/snow_height2";
         if (material == Material.FISHING_ROD)
             return "item/handheld_rod";
-        if (material == Material.SHIELD)
+        if (material == Material.SCAFFOLDING)
+            return "block/scaffolding_stable";
+        if (material == Material.RESPAWN_ANCHOR)
+            return "block/respawn_anchor_0";
+        if (VersionUtil.atOrAbove("1.20") && (material == Material.SUSPICIOUS_GRAVEL || material == Material.SUSPICIOUS_SAND))
+            return "block/" + materialName + "_0";
+        if (material == Material.CONDUIT || material == Material.SHIELD || material == Material.CHEST || material == Material.TRAPPED_CHEST || material == Material.ENDER_CHEST)
             return "builtin/entity";
+        if (VersionUtil.atOrAbove("1.20") && material == Material.DECORATED_POT)
+            return "builtin/entity";
+        if (material == Material.SMALL_DRIPLEAF)
+            return "block/small_dripleaf_top";
+        if (material == Material.SPORE_BLOSSOM || material == Material.BIG_DRIPLEAF || material == Material.AZALEA || material == Material.FLOWERING_AZALEA)
+            return "block/" + materialName;
+        if (material == Material.CHORUS_FLOWER || material == Material.CHORUS_PLANT || material == Material.END_ROD)
+            return "block/" + materialName;
+        if (material == Material.SMALL_AMETHYST_BUD || material == Material.MEDIUM_AMETHYST_BUD || material == Material.LARGE_AMETHYST_BUD)
+            return "item/amethyst_bud";
+        if (material == Material.AMETHYST_CLUSTER)
+            return "item/generated";
+        if (VersionUtil.atOrAbove("1.19") && material == Material.SCULK_VEIN)
+            return "item/generated";
+        if (VersionUtil.atOrAbove("1.20") && material == Material.CALIBRATED_SCULK_SENSOR)
+            return "block/calibrated_sculk_sensor_inactive";
+        if (materialName.contains("infested"))
+            return "block/" + StringUtils.substringAfter(materialName, "infested_");
+
+        if (ItemUtils.isSkull(material))
+            return "item/template_skull";
+        if (Tag.SHULKER_BOXES.isTagged(material))
+            return "item/template_shulker_box";
+        if (Tag.CORAL_PLANTS.isTagged(material) || materialName.contains("coral_fan"))
+            return "item/generated";
+        if (material.name().contains("GLASS_PANE"))
+            return "item/generated";
+        if (materialName.startsWith("waxed") && materialName.contains("copper"))
+            return "block/" + StringUtils.substringAfter(materialName, "waxed_");
+        if (Tag.BEDS.isTagged(material))
+            return "item/template_bed";
+        if (Tag.TRAPDOORS.isTagged(material))
+            return "block/" + materialName + "_bottom";
+        if (materialName.endsWith("_spawn_egg"))
+            return "item/template_spawn_egg";
+        if (Tag.BANNERS.isTagged(material))
+            return "item/template_banner";
+        if (Tag.CARPETS.isTagged(material) || material == Material.MOSS_CARPET)
+            return "block/" + materialName;
+
+        if (Arrays.stream(tools).anyMatch(tool -> material.toString().contains(tool)))
+            return "item/handheld";
+        if (ItemUtils.hasInventoryParent(material))
+            return "block/" + materialName + "_inventory";
         if (has2DBlockIcon(material))
             return "item/generated";
-        if (material.isBlock() && material.isSolid())
-            return "block/" + material.name().toLowerCase();
+        if ((material.isBlock() && material.isSolid()))
+            return "block/" + materialName;
         return "item/generated";
     }
 
     private static boolean has2DBlockIcon(Material material) {
-        if (material == Material.BARRIER || material == Material.STRUCTURE_VOID) return true;
-        else if (material == Material.IRON_BARS || material == Material.CHAIN) return true;
-        else if (Tag.DOORS.isTagged(material)) return true;
-        else if (Tag.CANDLES.isTagged(material)) return true;
+        if (material == Material.BARRIER || material == Material.STRUCTURE_VOID || material == Material.LIGHT) return true;
+        if (material == Material.IRON_BARS || material == Material.CHAIN) return true;
+        if (material == Material.SEA_PICKLE || material == Material.POINTED_DRIPSTONE || material == Material.BELL) return true;
+        if (material == Material.COMPARATOR || material == Material.REPEATER) return true;
+        if (material == Material.FLOWER_POT || material == Material.BREWING_STAND) return true;
+        if (material == Material.CAULDRON || material == Material.HOPPER) return true;
+        if (material == Material.SUGAR_CANE || material == Material.BAMBOO) return true;
+        if (material == Material.NETHER_WART || material == Material.WHEAT || material == Material.CAKE) return true;
+        if (material == Material.LANTERN || material == Material.SOUL_LANTERN) return true;
+        if (material == Material.CAMPFIRE || material == Material.SOUL_CAMPFIRE) return true;
+        if (VersionUtil.atOrAbove("1.20") && (material == Material.PITCHER_PLANT || material == Material.PINK_PETALS)) return true;
+        if (Tag.DOORS.isTagged(material)) return true;
+        if (Tag.CANDLES.isTagged(material)) return true;
+        if (Tag.SIGNS.isTagged(material)) return true;
+        if (VersionUtil.atOrAbove("1.20") && (material == Material.SNIFFER_EGG || Tag.ITEMS_HANGING_SIGNS.isTagged(material))) return true;
 
-        else return false;
+        return false;
     }
+
+    private static final String HANGING_ROOTS_DISPLAY = """
+            {"thirdperson_righthand": {"rotation": [0,0,0],"translation": [0,0,1],"scale": [0.55,0.55,0.55]}, "firstperson_righthand": {"rotation": [0,-90,25],"translation": [1.13,0,1.13],"scale": [0.68,0.68,0.68]}}""".trim();
+    private static final String CHEST_DISPLAY = """
+            {"gui": {"rotation": [30,45,0],"translation": [0,0,0],"scale": [0.625,0.625,0.625]}, "ground": {"rotation": [0,0,0],"translation": [0,3,0],"scale": [0.25,0.25,0.25]}, "head": {"rotation": [0,180,0],"translation": [0,0,0],"scale": [1,1,1]}, "fixed": {"rotation": [0,180,0],"translation": [0,0,0],"scale": [0.5,0.5,0.5]}, "thirdperson_righthand": {"rotation": [75,315,0],"translation": [0,2.5,0],"scale": [0.375,0.375,0.375]}, "firstperson_righthand": {"rotation": [0,315,0],"translation": [0,0,0],"scale": [0.4,0.4,0.4]}}""".trim();
+    private static final String LARGE_AMETHYST_BUD_DISPLAY = """
+            {"fixed": {"translation": [0,4,0]}}""".trim();
+
+    private static final String SMALL_DRIPLEAF_DISPLAY = """
+            {"thirdperson_righthand": {"rotation": [0,0,0],"translation": [0,4,1],"scale": [0.55,0.55,0.55]}, "firstperson_righthand": {"rotation": [0,45,0],"translation": [0,3.2,0],"scale": [0.4,0.4,0.4]}}""".trim();
+    private static final String BIG_DRIPLEAF_DISPLAY = """
+            {"gui": {"rotation": [30,225,0],"translation": [0,-2,0],"scale": [0.625,0.625,0.625]}, "fixed": {"rotation": [0,0,0],"translation": [0,0,-1],"scale": [0.5,0.5,0.5]}, "thirdperson_righthand": {"rotation": [0,0,0],"translation": [0,1,0],"scale": [0.55,0.55,0.55]}, "firstperson_righthand": {"rotation": [0,0,0],"translation": [1.13,0,1.13],"scale": [0.68,0.68,0.68]}}""".trim();
+    private static final String DRAGON_HEAD_DISPLAY = """
+            {"gui": {"translation": [-2,2,0],"rotation": [30,45,0],"scale": [0.6,0.6,0.6]}, "thirdperson_righthand": {"rotation": [0,180,0],"translation": [0,-1,2],"scale": [0.5,0.5,0.5]}}""".trim();
+    private static final String CONDUIT_DISPLAY = """
+            {"gui":{"rotation":[30,45,0],"translation":[0,0,0],"scale":[1,1,1]},"ground":{"rotation":[0,0,0],"translation":[0,3,0],"scale":[0.5,0.5,0.5]},"head":{"rotation":[0,180,0],"translation":[0,0,0],"scale":[1,1,1]},"fixed":{"rotation":[0,180,0],"translation":[0,0,0],"scale":[1,1,1]},"thirdperson_righthand":{"rotation":[75,315,0],"translation":[0,2.5,0],"scale":[0.5,0.5,0.5]},"firstperson_righthand":{"rotation":[0,315,0],"translation":[0,0,0],"scale":[0.8,0.8,0.8]}}""".trim();
+    private static final String DECORATED_POT_DISPLAY = """
+            {"thirdperson_righthand":{"rotation":[0,90,0],"translation":[0,2,0.5],"scale":[0.375,0.375,0.375]},"firstperson_righthand":{"rotation":[0,90,0],"translation":[0,0,0],"scale":[0.375,0.375,0.375]},"gui":{"rotation":[30,45,0],"translation":[0,0,0],"scale":[0.6,0.6,0.6]},"ground":{"rotation":[0,0,0],"translation":[0,1,0],"scale":[0.25,0.25,0.25]},"head":{"rotation":[0,180,0],"translation":[0,16,0],"scale":[1.5,1.5,1.5]},"fixed":{"rotation":[0,180,0],"translation":[0,0,0],"scale":[0.5,0.5,0.5]}}""".trim();
+    private static final String CLOCK_OVERRIDES = """
+            [{"predicate": {"time": 0}, "model": "item/X"},{"predicate": {"time": 0.0078125}, "model": "item/X_01"},{"predicate": {"time": 0.0234375}, "model": "item/X_02"},{"predicate": {"time": 0.0390625}, "model": "item/X_03"},{"predicate": {"time": 0.0546875}, "model": "item/X_04"},{"predicate": {"time": 0.0703125}, "model": "item/X_05"},{"predicate": {"time": 0.0859375}, "model": "item/X_06"},{"predicate": {"time": 0.1015625}, "model": "item/X_07"},{"predicate": {"time": 0.1171875}, "model": "item/X_08"},{"predicate": {"time": 0.1328125}, "model": "item/X_09"},{"predicate": {"time": 0.1484375}, "model": "item/X_10"},{"predicate": {"time": 0.1640625}, "model": "item/X_11"},{"predicate": {"time": 0.1796875}, "model": "item/X_12"},{"predicate": {"time": 0.1953125}, "model": "item/X_13"},{"predicate": {"time": 0.2109375}, "model": "item/X_14"},{"predicate": {"time": 0.2265625}, "model": "item/X_15"},{"predicate": {"time": 0.2421875}, "model": "item/X_16"},{"predicate": {"time": 0.2578125}, "model": "item/X_17"},{"predicate": {"time": 0.2734375}, "model": "item/X_18"},{"predicate": {"time": 0.2890625}, "model": "item/X_19"},{"predicate": {"time": 0.3046875}, "model": "item/X_20"},{"predicate": {"time": 0.3203125}, "model": "item/X_21"},{"predicate": {"time": 0.3359375}, "model": "item/X_22"},{"predicate": {"time": 0.3515625}, "model": "item/X_23"},{"predicate": {"time": 0.3671875}, "model": "item/X_24"},{"predicate": {"time": 0.3828125}, "model": "item/X_25"},{"predicate": {"time": 0.3984375}, "model": "item/X_26"},{"predicate": {"time": 0.4140625}, "model": "item/X_27"},{"predicate": {"time": 0.4296875}, "model": "item/X_28"},{"predicate": {"time": 0.4453125}, "model": "item/X_29"},{"predicate": {"time": 0.4609375}, "model": "item/X_30"},{"predicate": {"time": 0.4765625}, "model": "item/X_31"},{"predicate": {"time": 0.4921875}, "model": "item/X_32"},{"predicate": {"time": 0.5078125}, "model": "item/X_33"},{"predicate": {"time": 0.5234375}, "model": "item/X_34"},{"predicate": {"time": 0.5390625}, "model": "item/X_35"},{"predicate": {"time": 0.5546875}, "model": "item/X_36"},{"predicate": {"time": 0.5703125}, "model": "item/X_37"},{"predicate": {"time": 0.5859375}, "model": "item/X_38"},{"predicate": {"time": 0.6015625}, "model": "item/X_39"},{"predicate": {"time": 0.6171875}, "model": "item/X_40"},{"predicate": {"time": 0.6328125}, "model": "item/X_41"},{"predicate": {"time": 0.6484375}, "model": "item/X_42"},{"predicate": {"time": 0.6640625}, "model": "item/X_43"},{"predicate": {"time": 0.6796875}, "model": "item/X_44"},{"predicate": {"time": 0.6953125}, "model": "item/X_45"},{"predicate": {"time": 0.7109375}, "model": "item/X_46"},{"predicate": {"time": 0.7265625}, "model": "item/X_47"},{"predicate": {"time": 0.7421875}, "model": "item/X_48"},{"predicate": {"time": 0.7578125}, "model": "item/X_49"},{"predicate": {"time": 0.7734375}, "model": "item/X_50"},{"predicate": {"time": 0.7890625}, "model": "item/X_51"},{"predicate": {"time": 0.8046875}, "model": "item/X_52"},{"predicate": {"time": 0.8203125}, "model": "item/X_53"},{"predicate": {"time": 0.8359375}, "model": "item/X_54"},{"predicate": {"time": 0.8515625}, "model": "item/X_55"},{"predicate": {"time": 0.8671875}, "model": "item/X_56"},{"predicate": {"time": 0.8828125}, "model": "item/X_57"},{"predicate": {"time": 0.8984375}, "model": "item/X_58"},{"predicate": {"time": 0.9140625}, "model": "item/X_59"},{"predicate": {"time": 0.9296875}, "model": "item/X_60"},{"predicate": {"time": 0.9453125}, "model": "item/X_61"},{"predicate": {"time": 0.9609375}, "model": "item/X_62"},{"predicate": {"time": 0.9765625}, "model": "item/X_63"},{"predicate": {"time": 0.9921875}, "model": "item/X"}]
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            """.trim();
+    private static final String COMPASS_OVERRIDES = """
+            [{"predicate": {"angle": 0}, "model": "item/X"},{"predicate": {"angle": 0.015625}, "model": "item/X_17"},{"predicate": {"angle": 0.046875}, "model": "item/X_18"},{"predicate": {"angle": 0.078125}, "model": "item/X_19"},{"predicate": {"angle": 0.109375}, "model": "item/X_20"},{"predicate": {"angle": 0.140625}, "model": "item/X_21"},{"predicate": {"angle": 0.171875}, "model": "item/X_22"},{"predicate": {"angle": 0.203125}, "model": "item/X_23"},{"predicate": {"angle": 0.234375}, "model": "item/X_24"},{"predicate": {"angle": 0.265625}, "model": "item/X_25"},{"predicate": {"angle": 0.296875}, "model": "item/X_26"},{"predicate": {"angle": 0.328125}, "model": "item/X_27"},{"predicate": {"angle": 0.359375}, "model": "item/X_28"},{"predicate": {"angle": 0.390625}, "model": "item/X_29"},{"predicate": {"angle": 0.421875}, "model": "item/X_30"},{"predicate": {"angle": 0.453125}, "model": "item/X_31"},{"predicate": {"angle": 0.484375}, "model": "item/X_00"},{"predicate": {"angle": 0.515625}, "model": "item/X_01"},{"predicate": {"angle": 0.546875}, "model": "item/X_02"},{"predicate": {"angle": 0.578125}, "model": "item/X_03"},{"predicate": {"angle": 0.609375}, "model": "item/X_04"},{"predicate": {"angle": 0.640625}, "model": "item/X_05"},{"predicate": {"angle": 0.671875}, "model": "item/X_06"},{"predicate": {"angle": 0.703125}, "model": "item/X_07"},{"predicate": {"angle": 0.734375}, "model": "item/X_08"},{"predicate": {"angle": 0.765625}, "model": "item/X_09"},{"predicate": {"angle": 0.796875}, "model": "item/X_10"},{"predicate": {"angle": 0.828125}, "model": "item/X_11"},{"predicate": {"angle": 0.859375}, "model": "item/X_12"},{"predicate": {"angle": 0.890625}, "model": "item/X_13"},{"predicate": {"angle": 0.921875}, "model": "item/X_14"},{"predicate": {"angle": 0.953125}, "model": "item/X_15"},{"predicate": {"angle": 0.984375}, "model": "item/X"}]""".trim();
 
     public JsonObject toJSON() {
         return json;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -20,19 +20,11 @@ import io.th0rgal.oraxen.sound.SoundManager;
 import io.th0rgal.oraxen.utils.*;
 import io.th0rgal.oraxen.utils.customarmor.CustomArmorsTextures;
 import io.th0rgal.oraxen.utils.logs.Logs;
-import net.kyori.adventure.text.Component;
-import net.minecraft.world.scores.ScoreHolder;
-import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
-import org.bukkit.scoreboard.DisplaySlot;
-import org.bukkit.scoreboard.RenderType;
-import org.bukkit.scoreboard.Score;
-import org.bukkit.scoreboard.Scoreboard;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -336,8 +328,8 @@ public class ResourcePack {
         final Map<Material, List<ItemBuilder>> texturedItems = new HashMap<>();
         for (final Map.Entry<String, ItemBuilder> entry : OraxenItems.getEntries()) {
             final ItemBuilder item = entry.getValue();
-            if (item.getOraxenMeta().hasPackInfos()) {
-                OraxenMeta oraxenMeta = item.getOraxenMeta();
+            OraxenMeta oraxenMeta = item.getOraxenMeta();
+            if (item.hasOraxenMeta() && oraxenMeta.hasPackInfos()) {
                 if (oraxenMeta.shouldGenerateModel()) {
                     writeStringToVirtual(oraxenMeta.getModelPath(),
                             item.getOraxenMeta().getModelName() + ".json",

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -150,9 +150,14 @@ public class ResourcePack {
             EventUtils.callEvent(event);
             ZipUtils.writeZipFile(pack, event.getOutput());
 
-            UploadManager uploadManager = new UploadManager(OraxenPlugin.get());
-            OraxenPlugin.get().setUploadManager(uploadManager);
-            uploadManager.uploadAsyncAndSendToPlayers(OraxenPlugin.get().getResourcePack());
+            UploadManager uploadManager = OraxenPlugin.get().getUploadManager();
+            if (uploadManager != null) { // If the uploadManager isnt null, this was triggered by a pack-reload
+                uploadManager.uploadAsyncAndSendToPlayers(OraxenPlugin.get().getResourcePack(), true, true);
+            } else { // Otherwise this is was triggered on server-startup
+                uploadManager = new UploadManager(OraxenPlugin.get());
+                OraxenPlugin.get().setUploadManager(uploadManager);
+                uploadManager.uploadAsyncAndSendToPlayers(OraxenPlugin.get().getResourcePack(), false, false);
+            }
         });
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -63,7 +63,7 @@ public class ResourcePack {
 
         if (!Settings.GENERATE.toBool()) return;
 
-        if (Settings.HIDE_SCOREBOARD_NUMBERS.toBool() && Bukkit.getPluginManager().isPluginEnabled("HappyHUD")) {
+        if (Settings.HIDE_SCOREBOARD_NUMBERS.toBool() && PluginUtils.isEnabled("HappyHUD")) {
             Logs.logError("HappyHUD detected with hide_scoreboard_numbers enabled!");
             Logs.logWarning("Recommend following this guide for compatibility: https://docs.oraxen.com/compatibility/happyhud");
         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
@@ -47,10 +47,6 @@ public class UploadManager {
         return packSender;
     }
 
-    public void uploadAsyncAndSendToPlayers(final ResourcePack resourcePack) {
-        uploadAsyncAndSendToPlayers(resourcePack, false, false);
-    }
-
     public void uploadAsyncAndSendToPlayers(final ResourcePack resourcePack, final boolean updatePackSender, final boolean isReload) {
         if (!enabled)
             return;

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/builders/RecipeBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/builders/RecipeBuilder.java
@@ -2,13 +2,13 @@ package io.th0rgal.oraxen.recipes.builders;
 
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
-import io.th0rgal.oraxen.config.ResourcesManager;
 import io.th0rgal.oraxen.utils.OraxenYaml;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,17 +53,17 @@ public abstract class RecipeBuilder {
         return this.inventory;
     }
 
-    protected void setSerializedItem(ConfigurationSection section, ItemStack itemStack) {
+    protected void setSerializedItem(ConfigurationSection section, @NotNull ItemStack itemStack) {
 
         // if our itemstack is made using oraxen and is not modified
-        if (OraxenItems.exists(itemStack)) {
-            String itemID = OraxenItems.getIdByItem(itemStack);
-            section.set("oraxen_item", itemID);
-        }
-        // if our itemstack is an unmodified vanilla item
-        else if (itemStack != null && itemStack.equals(new ItemStack(itemStack.getType())))
-            section.set("minecraft_type", itemStack.getType().toString());
+        if (OraxenItems.exists(itemStack))
+            section.set("oraxen_item", OraxenItems.getIdByItem(itemStack));
+        // if our itemstack is an unmodified vanilla item outside of amount
+        else if (itemStack.isSimilar(new ItemStack(itemStack.getType())))
+            section.set("minecraft_type", itemStack.getType().name());
         else section.set("minecraft_item", itemStack);
+
+        if (itemStack.getAmount() > 1) section.set("amount", itemStack.getAmount());
     }
 
     public YamlConfiguration getConfig() {

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
@@ -4,6 +4,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
@@ -35,6 +36,9 @@ public class RecipesEventsManager implements Listener {
 
     public void registerEvents() {
         Bukkit.getPluginManager().registerEvents(instance, OraxenPlugin.get());
+        if (VersionUtil.atOrAbove("1.20")) {
+            Bukkit.getPluginManager().registerEvents(new SmithingRecipeEvents(), OraxenPlugin.get());
+        }
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/SmithingRecipeEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/SmithingRecipeEvents.java
@@ -1,0 +1,42 @@
+package io.th0rgal.oraxen.recipes.listeners;
+
+import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.mechanics.provided.misc.misc.MiscMechanic;
+import io.th0rgal.oraxen.mechanics.provided.misc.misc.MiscMechanicFactory;
+import io.th0rgal.oraxen.utils.ItemUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareSmithingEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.SmithingInventory;
+import org.bukkit.inventory.SmithingTransformRecipe;
+
+import java.util.Arrays;
+
+public class SmithingRecipeEvents implements Listener {
+
+    @EventHandler
+    public void onSmithingRecipe(PrepareSmithingEvent event) {
+        SmithingInventory inventory = event.getInventory();
+        ItemStack template = inventory.getInputTemplate();
+        ItemStack material = inventory.getInputMineral();
+        ItemStack input = inventory.getInputEquipment();
+
+        if (ItemUtils.isEmpty(template) || ItemUtils.isEmpty(material) || ItemUtils.isEmpty(input)) return;
+        if (Arrays.stream(inventory.getContents()).anyMatch(ItemUtils::isEmpty)) return;
+        if (Arrays.stream(inventory.getContents()).noneMatch(OraxenItems::exists)) return;
+
+        String oraxenItemId = OraxenItems.getIdByItem(input);
+        MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(input);
+        if (mechanic != null && mechanic.isAllowedInVanillaRecipes()) return;
+
+        Bukkit.recipeIterator().forEachRemaining(recipe -> {
+            if (!(recipe instanceof SmithingTransformRecipe smithing)) return;
+            if (!smithing.getTemplate().test(template) || !smithing.getAddition().test(material)) return;
+            if (oraxenItemId.equals(OraxenItems.getIdByItem(smithing.getBase().getItemStack()))) return;
+
+            event.setResult(null);
+        });
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/AdventureUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/AdventureUtils.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -52,8 +53,8 @@ public class AdventureUtils {
         return MINI_MESSAGE.serialize(MINI_MESSAGE.deserialize(message)).replaceAll("\\\\(?!u)(?!n)(?!\")", "");
     }
 
-    public static String parseMiniMessage(String message, TagResolver tagResolver) {
-        return MINI_MESSAGE.serialize(MINI_MESSAGE.deserialize(message, tagResolver)).replaceAll("\\\\(?!u)(?!n)(?!\")", "");
+    public static String parseMiniMessage(String message, @Nullable TagResolver tagResolver) {
+        return MINI_MESSAGE.serialize((tagResolver != null ? MINI_MESSAGE.deserialize(message, tagResolver) : MINI_MESSAGE.deserialize(message))).replaceAll("\\\\(?!u)(?!n)(?!\")", "");
     }
 
     public static String parseMiniMessage(String message, Player player) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -20,7 +20,6 @@ import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.EquipmentSlot;
@@ -111,14 +110,13 @@ public class BlockHelpers {
 
     public static boolean isStandingInside(final Player player, final Block block) {
         if (player == null || block == null) return false;
-        final Location blockLoc = BlockHelpers.toCenterLocation(block.getLocation());
-        // determine if there is an entity in the target location
-        return blockLoc.getWorld().getNearbyEntities(blockLoc, 0.5, 0.5, 0.5, entity -> {
-            if (entity instanceof LivingEntity livingEntity) {
-                return !livingEntity.isInvisible();
-            }
-            return false;
-        }).size() > 0;
+        // Since the block might be AIR, Block#getBoundingBox returns an empty one
+        // Get the block-center and expand it 0.5 to cover the block
+        BoundingBox blockBox = BoundingBox.of(BlockHelpers.toCenterLocation(block.getLocation()), 0.5, 0.5, 0.5);
+
+        return !block.getWorld().getNearbyEntities(blockBox).stream()
+                .filter(e -> !(e instanceof Player p) || p.getGameMode() != GameMode.SPECTATOR)
+                .toList().isEmpty();
     }
 
     /** Returns the PersistentDataContainer from CustomBlockData

--- a/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -20,6 +20,7 @@ import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.EquipmentSlot;
@@ -110,11 +111,14 @@ public class BlockHelpers {
 
     public static boolean isStandingInside(final Player player, final Block block) {
         if (player == null || block == null) return false;
-        final Location playerLoc = player.getLocation().getBlock().getLocation();
         final Location blockLoc = BlockHelpers.toCenterLocation(block.getLocation());
-        return Range.between(0.5, 1.5).contains(blockLoc.getY() - playerLoc.getY()) &&
-                Range.between(-0.80, 0.80).contains(blockLoc.getX() - playerLoc.getX())
-                && Range.between(-0.80, 0.80).contains(blockLoc.getZ() - playerLoc.getZ());
+        // determine if there is an entity in the target location
+        return blockLoc.getWorld().getNearbyEntities(blockLoc, 0.5, 0.5, 0.5, entity -> {
+            if (entity instanceof LivingEntity livingEntity) {
+                return !livingEntity.isInvisible();
+            }
+            return false;
+        }).size() > 0;
     }
 
     /** Returns the PersistentDataContainer from CustomBlockData

--- a/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -19,7 +19,9 @@ import org.bukkit.block.data.type.Chest;
 import org.bukkit.block.data.type.Lectern;
 import org.bukkit.block.data.type.*;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.EquipmentSlot;
@@ -115,7 +117,7 @@ public class BlockHelpers {
         BoundingBox blockBox = BoundingBox.of(BlockHelpers.toCenterLocation(block.getLocation()), 0.5, 0.5, 0.5);
 
         return !block.getWorld().getNearbyEntities(blockBox).stream()
-                .filter(e -> !(e instanceof Player p) || p.getGameMode() != GameMode.SPECTATOR)
+                .filter(e -> e instanceof LivingEntity && (!(e instanceof Player p) || p.getGameMode() != GameMode.SPECTATOR))
                 .toList().isEmpty();
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
@@ -13,6 +13,10 @@ import java.util.function.Consumer;
 
 public class ItemUtils {
 
+    public static boolean isEmpty(ItemStack itemStack) {
+        return itemStack == null || itemStack.getType() == Material.AIR || itemStack.getAmount() == 0;
+    }
+
     /**
      * @param itemStack The ItemStack to edit the ItemMeta of
      * @param function  The function-block to edit the ItemMeta in

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
@@ -82,4 +82,8 @@ public class ItemUtils {
             default -> false;
         };
     }
+
+    public static boolean hasInventoryParent(Material material) {
+        return Tag.WALLS.isTagged(material) || Tag.FENCES.isTagged(material) || Tag.BUTTONS.isTagged(material) || material == Material.PISTON || material == Material.STICKY_PISTON || (VersionUtil.atOrAbove("1.20") && material == Material.CHISELED_BOOKSHELF) || material == Material.BROWN_MUSHROOM_BLOCK || material == Material.RED_MUSHROOM_BLOCK || material == Material.MUSHROOM_STEM;
+    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/MinecraftVersion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/MinecraftVersion.java
@@ -1,0 +1,418 @@
+package io.th0rgal.oraxen.utils;
+
+import com.comphenix.protocol.ProtocolLibrary;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class MinecraftVersion implements Comparable<MinecraftVersion>, Serializable {
+
+    /**
+     * Version 1.20 - the trails and tails update
+     */
+    public static final MinecraftVersion TRAILS_AND_TAILS = new MinecraftVersion("1.20");
+
+    /**
+     * Version 1.19.4 - the rest of the feature preview
+     */
+    public static final MinecraftVersion FEATURE_PREVIEW_2 = new MinecraftVersion("1.19.4");
+
+    /**
+     * Version 1.19.3 - introducing feature preview
+     */
+    public static final MinecraftVersion FEATURE_PREVIEW_UPDATE = new MinecraftVersion("1.19.3");
+    /**
+     * Version 1.19 - the wild update
+     */
+    public static final MinecraftVersion WILD_UPDATE = new MinecraftVersion("1.19");
+    /**
+     * Version 1.18 - caves and cliffs part 2
+     */
+    public static final MinecraftVersion CAVES_CLIFFS_2 = new MinecraftVersion("1.18");
+    /**
+     * Version 1.17 - caves and cliffs part 1
+     */
+    public static final MinecraftVersion CAVES_CLIFFS_1 = new MinecraftVersion("1.17");
+    /**
+     * Version 1.16.4
+     */
+    public static final MinecraftVersion NETHER_UPDATE_4 = new MinecraftVersion("1.16.4");
+    /**
+     * Version 1.16.2 - breaking change to the nether update
+     */
+    public static final MinecraftVersion NETHER_UPDATE_2 = new MinecraftVersion("1.16.2");
+    /**
+     * Version 1.16.0 - the nether update
+     */
+    public static final MinecraftVersion NETHER_UPDATE = new MinecraftVersion("1.16");
+    /**
+     * Version 1.15 - the bee update
+     */
+    public static final MinecraftVersion BEE_UPDATE = new MinecraftVersion("1.15");
+    /**
+     * Version 1.14 - village and pillage update.
+     */
+    public static final MinecraftVersion VILLAGE_UPDATE = new MinecraftVersion("1.14");
+    /**
+     * Version 1.13 - update aquatic.
+     */
+    public static final MinecraftVersion AQUATIC_UPDATE = new MinecraftVersion("1.13");
+    /**
+     * Version 1.12 - the world of color update.
+     */
+    public static final MinecraftVersion COLOR_UPDATE = new MinecraftVersion("1.12");
+    /**
+     * Version 1.11 - the exploration update.
+     */
+    public static final MinecraftVersion EXPLORATION_UPDATE = new MinecraftVersion("1.11");
+    /**
+     * Version 1.10 - the frostburn update.
+     */
+    public static final MinecraftVersion FROSTBURN_UPDATE = new MinecraftVersion("1.10");
+    /**
+     * Version 1.9 - the combat update.
+     */
+    public static final MinecraftVersion COMBAT_UPDATE = new MinecraftVersion("1.9");
+    /**
+     * Version 1.8 - the "bountiful" update.
+     */
+    public static final MinecraftVersion BOUNTIFUL_UPDATE = new MinecraftVersion("1.8");
+    /**
+     * Version 1.7.8 - the update that changed the skin format (and distribution - R.I.P. player disguise)
+     */
+    public static final MinecraftVersion SKIN_UPDATE = new MinecraftVersion("1.7.8");
+    /**
+     * Version 1.7.2 - the update that changed the world.
+     */
+    public static final MinecraftVersion WORLD_UPDATE = new MinecraftVersion("1.7.2");
+    /**
+     * Version 1.6.1 - the horse update.
+     */
+    public static final MinecraftVersion HORSE_UPDATE = new MinecraftVersion("1.6.1");
+    /**
+     * Version 1.5.0 - the redstone update.
+     */
+    public static final MinecraftVersion REDSTONE_UPDATE = new MinecraftVersion("1.5.0");
+    /**
+     * Version 1.4.2 - the scary update (Wither Boss).
+     */
+    public static final MinecraftVersion SCARY_UPDATE = new MinecraftVersion("1.4.2");
+
+    /**
+     * The latest release version of minecraft.
+     */
+    public static final MinecraftVersion LATEST = TRAILS_AND_TAILS;
+
+    // used when serializing
+    private static final long serialVersionUID = -8695133558996459770L;
+
+    /**
+     * Regular expression used to parse version strings.
+     */
+    private static final Pattern VERSION_PATTERN = Pattern.compile(".*\\(.*MC.\\s*([a-zA-z0-9\\-.]+).*");
+
+    /**
+     * The current version of minecraft, lazy initialized by MinecraftVersion.currentVersion()
+     */
+    private static MinecraftVersion currentVersion;
+
+    private final int major;
+    private final int minor;
+    private final int build;
+    // The development stage
+    private final String development;
+
+    // Snapshot?
+    private final SnapshotVersion snapshot;
+    private volatile Boolean atCurrentOrAbove;
+
+    /**
+     * Determine the current Minecraft version.
+     *
+     * @param server - the Bukkit server that will be used to examine the MC version.
+     */
+    public MinecraftVersion(Server server) {
+        this(extractVersion(server.getVersion()));
+    }
+
+    /**
+     * Construct a version object from the format major.minor.build, or the snapshot format.
+     *
+     * @param versionOnly - the version in text form.
+     */
+    public MinecraftVersion(String versionOnly) {
+        this(versionOnly, true);
+    }
+
+    /**
+     * Construct a version format from the standard release version or the snapshot verison.
+     *
+     * @param versionOnly   - the version.
+     * @param parseSnapshot - TRUE to parse the snapshot, FALSE otherwise.
+     */
+    private MinecraftVersion(String versionOnly, boolean parseSnapshot) {
+        String[] section = versionOnly.split("-");
+        SnapshotVersion snapshot = null;
+        int[] numbers = new int[3];
+
+        try {
+            numbers = this.parseVersion(section[0]);
+        } catch (NumberFormatException cause) {
+            // Skip snapshot parsing
+            if (!parseSnapshot) {
+                throw cause;
+            }
+
+            try {
+                // Determine if the snapshot is newer than the current release version
+                snapshot = new SnapshotVersion(section[0]);
+                SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+
+                MinecraftVersion latest = new MinecraftVersion(ProtocolLibrary.MAXIMUM_MINECRAFT_VERSION, false);
+                boolean newer = snapshot.getSnapshotDate().compareTo(
+                        format.parse(ProtocolLibrary.MINECRAFT_LAST_RELEASE_DATE)) > 0;
+
+                numbers[0] = latest.getMajor();
+                numbers[1] = latest.getMinor() + (newer ? 1 : -1);
+            } catch (Exception e) {
+                throw new IllegalStateException("Cannot parse " + section[0], e);
+            }
+        }
+
+        this.major = numbers[0];
+        this.minor = numbers[1];
+        this.build = numbers[2];
+        this.development = section.length > 1 ? section[1] : (snapshot != null ? "snapshot" : null);
+        this.snapshot = snapshot;
+    }
+
+    /**
+     * Construct a version object directly.
+     *
+     * @param major - major version number.
+     * @param minor - minor version number.
+     * @param build - build version number.
+     */
+    public MinecraftVersion(int major, int minor, int build) {
+        this(major, minor, build, null);
+    }
+
+    /**
+     * Construct a version object directly.
+     *
+     * @param major       - major version number.
+     * @param minor       - minor version number.
+     * @param build       - build version number.
+     * @param development - development stage.
+     */
+    public MinecraftVersion(int major, int minor, int build, String development) {
+        this.major = major;
+        this.minor = minor;
+        this.build = build;
+        this.development = development;
+        this.snapshot = null;
+    }
+
+    /**
+     * Extract the Minecraft version from CraftBukkit itself.
+     *
+     * @param text - the server version in text form.
+     * @return The underlying MC version.
+     * @throws IllegalStateException If we could not parse the version string.
+     */
+    public static String extractVersion(String text) {
+        Matcher version = VERSION_PATTERN.matcher(text);
+
+        if (version.matches() && version.group(1) != null) {
+            return version.group(1);
+        } else {
+            throw new IllegalStateException("Cannot parse version String '" + text + "'");
+        }
+    }
+
+    /**
+     * Parse the given server version into a Minecraft version.
+     *
+     * @param serverVersion - the server version.
+     * @return The resulting Minecraft version.
+     */
+    public static MinecraftVersion fromServerVersion(String serverVersion) {
+        return new MinecraftVersion(extractVersion(serverVersion));
+    }
+
+    public static MinecraftVersion getCurrentVersion() {
+        if (currentVersion == null) {
+            currentVersion = fromServerVersion(Bukkit.getVersion());
+        }
+
+        return currentVersion;
+    }
+
+    public static void setCurrentVersion(MinecraftVersion version) {
+        currentVersion = version;
+    }
+
+    private static boolean atOrAbove(MinecraftVersion version) {
+        return getCurrentVersion().isAtLeast(version);
+    }
+
+    private int[] parseVersion(String version) {
+        String[] elements = version.split("\\.");
+        int[] numbers = new int[3];
+
+        // Make sure it's even a valid version
+        if (elements.length < 1) {
+            throw new IllegalStateException("Corrupt MC version: " + version);
+        }
+
+        // The String 1 or 1.2 is interpreted as 1.0.0 and 1.2.0 respectively.
+        for (int i = 0; i < Math.min(numbers.length, elements.length); i++) {
+            numbers[i] = Integer.parseInt(elements[i].trim());
+        }
+        return numbers;
+    }
+
+    /**
+     * Major version number
+     *
+     * @return Current major version number.
+     */
+    public int getMajor() {
+        return this.major;
+    }
+
+    /**
+     * Minor version number
+     *
+     * @return Current minor version number.
+     */
+    public int getMinor() {
+        return this.minor;
+    }
+
+    /**
+     * Build version number
+     *
+     * @return Current build version number.
+     */
+    public int getBuild() {
+        return this.build;
+    }
+
+    /**
+     * Retrieve the development stage.
+     *
+     * @return Development stage, or NULL if this is a release.
+     */
+    public String getDevelopmentStage() {
+        return this.development;
+    }
+
+    /**
+     * Retrieve the snapshot version, or NULL if this is a release.
+     *
+     * @return The snapshot version.
+     */
+    public SnapshotVersion getSnapshot() {
+        return this.snapshot;
+    }
+
+    /**
+     * Determine if this version is a snapshot.
+     *
+     * @return The snapshot version.
+     */
+    public boolean isSnapshot() {
+        return this.snapshot != null;
+    }
+
+    /**
+     * Checks if this version is at or above the current version the server is running.
+     *
+     * @return true if this version is equal or newer than the server version, false otherwise.
+     */
+    public boolean atOrAbove() {
+        if (this.atCurrentOrAbove == null) {
+            this.atCurrentOrAbove = atOrAbove(this);
+        }
+
+        return this.atCurrentOrAbove;
+    }
+
+    /**
+     * Retrieve the version String (major.minor.build) only.
+     *
+     * @return A normal version string.
+     */
+    public String getVersion() {
+        if (this.getDevelopmentStage() == null) {
+            return String.format("%s.%s.%s", this.getMajor(), this.getMinor(), this.getBuild());
+        } else {
+            return String.format("%s.%s.%s-%s%s", this.getMajor(), this.getMinor(), this.getBuild(),
+                    this.getDevelopmentStage(), this.isSnapshot() ? this.snapshot : "");
+        }
+    }
+
+    @Override
+    public int compareTo(MinecraftVersion o) {
+        if (o == null) {
+            return 1;
+        }
+
+        return ComparisonChain.start()
+                .compare(this.getMajor(), o.getMajor())
+                .compare(this.getMinor(), o.getMinor())
+                .compare(this.getBuild(), o.getBuild())
+                .compare(this.getDevelopmentStage(), o.getDevelopmentStage(), Ordering.natural().nullsLast())
+                .compare(this.getSnapshot(), o.getSnapshot(), Ordering.natural().nullsFirst())
+                .result();
+    }
+
+    public boolean isAtLeast(MinecraftVersion other) {
+        if (other == null) {
+            return false;
+        }
+
+        return this.compareTo(other) >= 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof MinecraftVersion) {
+            MinecraftVersion other = (MinecraftVersion) obj;
+
+            return this.getMajor() == other.getMajor() &&
+                    this.getMinor() == other.getMinor() &&
+                    this.getBuild() == other.getBuild() &&
+                    Objects.equals(this.getDevelopmentStage(), other.getDevelopmentStage());
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getMajor(), this.getMinor(), this.getBuild());
+    }
+
+    @Override
+    public String toString() {
+        // Convert to a String that we can parse back again
+        return String.format("(MC: %s)", this.getVersion());
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PluginUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PluginUtils.java
@@ -1,0 +1,10 @@
+package io.th0rgal.oraxen.utils;
+
+import org.bukkit.Bukkit;
+
+public class PluginUtils {
+
+    public static boolean isEnabled(String pluginName) {
+        return Bukkit.getPluginManager().isPluginEnabled(pluginName);
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/SnapshotVersion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/SnapshotVersion.java
@@ -1,0 +1,126 @@
+package io.th0rgal.oraxen.utils;
+
+import com.google.common.collect.ComparisonChain;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SnapshotVersion implements Comparable<SnapshotVersion>, Serializable {
+
+    private static final long serialVersionUID = 2778655372579322310L;
+    private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("(\\d{2}w\\d{2})([a-z])");
+
+    private final Date snapshotDate;
+    private final int snapshotWeekVersion;
+
+    private transient String rawString;
+
+    public SnapshotVersion(String version) {
+        Matcher matcher = SNAPSHOT_PATTERN.matcher(version.trim());
+
+        if (matcher.matches()) {
+            try {
+                this.snapshotDate = getDateFormat().parse(matcher.group(1));
+                this.snapshotWeekVersion = matcher.group(2).charAt(0) - 'a';
+                this.rawString = version;
+            } catch (ParseException e) {
+                throw new IllegalArgumentException("Date implied by snapshot version is invalid.", e);
+            }
+        } else {
+            throw new IllegalArgumentException("Cannot parse " + version + " as a snapshot version.");
+        }
+    }
+
+    /**
+     * Retrieve the snapshot date parser.
+     * <p>
+     * We have to create a new instance of SimpleDateFormat every time as it is not thread safe.
+     *
+     * @return The date formatter.
+     */
+    private static SimpleDateFormat getDateFormat() {
+        SimpleDateFormat format = new SimpleDateFormat("yy'w'ww", Locale.US);
+        format.setLenient(false);
+        return format;
+    }
+
+    /**
+     * Retrieve the snapshot version within a week, starting at zero.
+     *
+     * @return The weekly version
+     */
+    public int getSnapshotWeekVersion() {
+        return this.snapshotWeekVersion;
+    }
+
+    /**
+     * Retrieve the week this snapshot was released.
+     *
+     * @return The week.
+     */
+    public Date getSnapshotDate() {
+        return this.snapshotDate;
+    }
+
+    /**
+     * Retrieve the raw snapshot string (yy'w'ww[a-z]).
+     *
+     * @return The snapshot string.
+     */
+    public String getSnapshotString() {
+        if (this.rawString == null) {
+            // It's essential that we use the same locale
+            Calendar current = Calendar.getInstance(Locale.US);
+            current.setTime(this.snapshotDate);
+            this.rawString = String.format("%02dw%02d%s",
+                    current.get(Calendar.YEAR) % 100,
+                    current.get(Calendar.WEEK_OF_YEAR),
+                    (char) ('a' + this.snapshotWeekVersion));
+        }
+        return this.rawString;
+    }
+
+    @Override
+    public int compareTo(SnapshotVersion o) {
+        if (o == null) {
+            return 1;
+        }
+
+        return ComparisonChain.start()
+                .compare(this.snapshotDate, o.getSnapshotDate())
+                .compare(this.snapshotWeekVersion, o.getSnapshotWeekVersion())
+                .result();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof SnapshotVersion) {
+            SnapshotVersion other = (SnapshotVersion) obj;
+            return Objects.equals(this.snapshotDate, other.getSnapshotDate())
+                    && this.snapshotWeekVersion == other.getSnapshotWeekVersion();
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.snapshotDate, this.snapshotWeekVersion);
+    }
+
+    @Override
+    public String toString() {
+        return this.getSnapshotString();
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/UUIDUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/UUIDUtils.java
@@ -1,0 +1,30 @@
+package io.th0rgal.oraxen.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.UUID;
+
+public class UUIDUtils {
+
+    public static UUID uuidFromIntArray(int[] array) {
+        return new UUID((long)array[0] << 32 | (long)array[1] & 4294967295L, (long)array[2] << 32 | (long)array[3] & 4294967295L);
+    }
+
+    public static int[] uuidToIntArray(UUID uuid) {
+        long l = uuid.getMostSignificantBits();
+        long m = uuid.getLeastSignificantBits();
+        return leastMostToIntArray(l, m);
+    }
+
+    public static byte[] uuidToByteArray(@NotNull UUID uuid) {
+        byte[] bs = new byte[16];
+        ByteBuffer.wrap(bs).order(ByteOrder.BIG_ENDIAN).putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+        return bs;
+    }
+
+    private static int[] leastMostToIntArray(long uuidMost, long uuidLeast) {
+        return new int[]{(int)(uuidMost >> 32), (int)uuidMost, (int)(uuidLeast >> 32), (int)uuidLeast};
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.utils;
 
-import com.comphenix.protocol.utility.MinecraftVersion;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.apache.commons.lang3.Validate;
 import org.bukkit.Bukkit;

--- a/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorsTextures.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorsTextures.java
@@ -488,6 +488,7 @@ public class CustomArmorsTextures {
             String itemId = entry.getKey();
             ItemBuilder builder = entry.getValue();
             String armorType = StringUtils.substringBeforeLast(itemId, "_");
+            if (!builder.hasOraxenMeta()) continue;
             List<String> layerList = builder.getOraxenMeta().getLayers();
 
             boolean isArmor = builder.build().getType().toString().contains("LEATHER_");

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -21,9 +21,9 @@ public class Loot {
     private LinkedHashMap<String, Object> config;
 
     public Loot(LinkedHashMap<String, Object> config) {
-        this.probability = config.containsKey("probability") ? (int) (1D / (double) config.get("probability")) : 1;
-        this.minAmount = config.containsKey("min_amount") ? (int) config.get("min_amount") : 1;
-        this.maxAmount = config.containsKey("max_amount") ? Math.max((int) config.get("max_amount"), this.minAmount) : this.minAmount;
+        this.probability = Integer.getInteger(config.getOrDefault("probability", 1).toString(), 1);
+        this.minAmount = Integer.getInteger(config.getOrDefault("min_amount", 1).toString(), 1);
+        this.maxAmount = Math.max(Integer.getInteger(config.getOrDefault("max_amount", this.minAmount).toString(), this.minAmount), this.minAmount);
         this.config = config;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 public class InvManager {
 
     private Map<UUID, ChestGui> itemsViews = new HashMap<>();
-    private  Map<UUID, ChestGui> recipesViews = new HashMap<>();
 
     public InvManager() {
         regen();
@@ -20,7 +19,6 @@ public class InvManager {
 
     public void regen() {
         itemsViews.clear();
-        recipesViews.clear();
     }
 
     public ChestGui getItemsView(Player player) {
@@ -28,7 +26,7 @@ public class InvManager {
     }
 
 
-    public ChestGui getRecipesShowcase(Player player, final int page, final List<CustomRecipe> filteredRecipes) {
-        return recipesViews.computeIfAbsent(player.getUniqueId(), uuid -> new RecipesView().create(page, filteredRecipes));
+    public ChestGui getRecipesShowcase(final int page, final List<CustomRecipe> filteredRecipes) {
+        return new RecipesView().create(page, filteredRecipes);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
@@ -7,13 +7,12 @@ import com.github.stefvanschie.inventoryframework.pane.StaticPane;
 import com.github.stefvanschie.inventoryframework.pane.util.Slot;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
-import io.th0rgal.oraxen.config.ResourcesManager;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.items.ItemBuilder;
+import io.th0rgal.oraxen.items.ItemParser;
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.utils.Utils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemFlag;
@@ -134,30 +133,31 @@ public class ItemsView {
 
     private Pair<ItemStack, Integer> getItemStack(final File file) {
         ItemStack itemStack;
-        String material = settings.getString(String.format("oraxen_inventory.menu_layout.%s.icon", Utils.removeExtension(file.getName())), "PAPER");
-
+        String fileName = Utils.removeExtension(file.getName());
+        String material = settings.getString(String.format("oraxen_inventory.menu_layout.%s.icon", fileName), "PAPER");
+        String displayName = ItemParser.parseComponentDisplayName(settings.getString(String.format("oraxen_inventory.menu_layout.%s.displayname", fileName), "<green>" + file.getName()));
         try {
             itemStack = new ItemBuilder(OraxenItems.getItemById(material).build())
                     .addItemFlags(ItemFlag.HIDE_ATTRIBUTES)
-                    .setDisplayName(ChatColor.GREEN + file.getName())
+                    .setDisplayName(displayName)
                     .setLore(new ArrayList<>())
                     .build();
         } catch (final Exception e) {
             try {
                 itemStack = new ItemBuilder(Material.getMaterial(material.toUpperCase()))
                         .addItemFlags(ItemFlag.HIDE_ATTRIBUTES)
-                        .setDisplayName(ChatColor.GREEN + file.getName())
+                        .setDisplayName(displayName)
                         .build();
             } catch (final Exception ignored) {
                 itemStack = new ItemBuilder(Material.PAPER)
-                        .setDisplayName(ChatColor.GREEN + file.getName())
+                        .setDisplayName(displayName)
                         .build();
             }
         }
 
         if (itemStack == null)
             // avoid possible bug if isOraxenItems is available but can't be an itemstack
-            itemStack = new ItemBuilder(Material.PAPER).setDisplayName(ChatColor.GREEN + file.getName()).build();
+            itemStack = new ItemBuilder(Material.PAPER).setDisplayName(displayName).build();
 
         return Pair.of(itemStack, settings.getInt(String.format("oraxen_inventory.menu_layout.%s.slot", Utils.removeExtension(file.getName())), -1) - 1);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/logs/Logs.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/logs/Logs.java
@@ -1,12 +1,9 @@
 package io.th0rgal.oraxen.utils.logs;
 
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.tag.Tag;
-import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 
 public class Logs {
@@ -17,10 +14,8 @@ public class Logs {
         logInfo(message, false);
     }
 
-    private static final TagResolver PrefixResolver = TagResolver.resolver("prefix", Tag.selfClosingInserting(AdventureUtils.MINI_MESSAGE_EMPTY.deserialize(Message.PREFIX.toString())));
-
     public static void logInfo(String message, boolean newline) {
-        Component info = AdventureUtils.MINI_MESSAGE_EMPTY.deserialize("<prefix><#529ced>" + message + "</#529ced>", PrefixResolver);
+        Component info = AdventureUtils.MINI_MESSAGE.deserialize("<prefix><#529ced>" + message + "</#529ced>");
         OraxenPlugin.get().getAudience().console().sendMessage(newline ? info.append(Component.newline()) : info);
     }
 
@@ -29,7 +24,7 @@ public class Logs {
     }
 
     public static void logSuccess(String message, boolean newline) {
-        Component success = AdventureUtils.MINI_MESSAGE_EMPTY.deserialize("<prefix><#55ffa4>" + message + "</#55ffa4>", PrefixResolver);
+        Component success = AdventureUtils.MINI_MESSAGE.deserialize("<prefix><#55ffa4>" + message + "</#55ffa4>");
         OraxenPlugin.get().getAudience().console().sendMessage(newline ? success.append(Component.newline()) : success);
     }
 
@@ -38,7 +33,7 @@ public class Logs {
     }
 
     public static void logError(String message, boolean newline) {
-        Component error = AdventureUtils.MINI_MESSAGE_EMPTY.deserialize("<prefix><#e73f34>" + message + "</#e73f34>", PrefixResolver);
+        Component error = AdventureUtils.MINI_MESSAGE.deserialize("<prefix><#e73f34>" + message + "</#e73f34>");
         OraxenPlugin.get().getAudience().console().sendMessage(newline ? error.append(Component.newline()) : error);
     }
 
@@ -47,7 +42,7 @@ public class Logs {
     }
 
     public static void logWarning(String message, boolean newline) {
-        Component warning = AdventureUtils.MINI_MESSAGE_EMPTY.deserialize("<prefix><#f9f178>" + message + "</#f9f178>", PrefixResolver);
+        Component warning = AdventureUtils.MINI_MESSAGE.deserialize("<prefix><#f9f178>" + message + "</#f9f178>");
         OraxenPlugin.get().getAudience().console().sendMessage(newline ? warning.append(Component.newline()) : warning);
     }
 

--- a/core/src/main/resources/glyphs/interface.yml
+++ b/core/src/main/resources/glyphs/interface.yml
@@ -8,8 +8,8 @@ logo:
 
 menu_banner:
   texture: required/ui/menu_banner
-  ascent: -14
-  height: 256
+  ascent: -10
+  height: 236
 
 menu_recipe:
   texture: required/recipe_showcase

--- a/core/src/main/resources/items/items.yml
+++ b/core/src/main/resources/items/items.yml
@@ -90,7 +90,7 @@ miner_sandwitch:
     textures:
       - default/sandwitch.png # .png extension is not mandatory
   Mechanics:
-    consumablepotioneffects:
+    consumable_potion_effects:
       fast_digging:
         amplifier: 0
         ambient: true # Makes potion effect produce more, translucent, particles.

--- a/core/src/main/resources/items/plants.yml
+++ b/core/src/main/resources/items/plants.yml
@@ -14,7 +14,7 @@ weed_leaf:
     textures:
       - default/weed/leaf
   Mechanics:
-    consumablepotioneffects:
+    consumable_potion_effects:
       confusion:
         amplifier: 0
         ambient: true # Makes potion effect produce more, translucent, particles.

--- a/core/src/main/resources/mechanics.yml
+++ b/core/src/main/resources/mechanics.yml
@@ -10,7 +10,7 @@ armor_effects:
 consumable:
   enabled: true
 
-consumablepotioneffects:
+consumable_potion_effects:
   enabled: true
 
 custom:

--- a/core/src/main/resources/pack/lang/en_us.json
+++ b/core/src/main/resources/pack/lang/en_us.json
@@ -1,6 +1,6 @@
 {
   "connect.joining": "",
-  "menu.disconnect": "§7<shift:60>See you soon!<shift:-143><glyph:menu_banner>",
+  "menu.disconnect": "<shift:74><gray>See you soon!<shift:-142><glyph:menu_banner>",
   "menu.returnToGame": "Back to the Oraxen experience",
   "menu.game": "<glyph:logo>",
   "item.dyed": "",

--- a/core/src/main/resources/pack/lang/global.json
+++ b/core/src/main/resources/pack/lang/global.json
@@ -4,5 +4,5 @@
 
 
   "menu.game": "<glyph:logo>",
-  "menu.disconnect": "<gray><shift:60>See you soon!<shift:-143><glyph:menu_banner>"
+  "menu.disconnect": "<shift:74><gray>See you soon!<shift:-142><glyph:menu_banner>"
 }

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -17,9 +17,11 @@ Plugin:
     signs: true # Formats text on signs when placed or edited
     chat: true # Formats text and glyphs in chat. Disable if using a chat-plugin and you are experiencing issues
     books: true # Formats glyphs in books.
-  worldedit: # Please note these are both experimental still and should be used with caution
-    noteblock_mechanic: false
-    stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
+
+WorldEdit: # Please note these are both experimental still and should be used with caution
+  noteblock_mechanic: false
+  stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
+  furniture_mechanic: false # NOTE: This only handles clipboard stuff, it does not allow for anything outside cut/copy/paste
 
 ConfigsTools:
   # list of model data numbers the automatic system will skip

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -5,8 +5,6 @@ Plugin:
   commands:
     repair:
       oraxen_durability_only: false # will not repair vanilla items if set to true
-    emoji_list:
-      only_show_emojis_with_permission: true # will only show emojis player has permission to use if set to true
   generation:
     default_assets: true
     default_configs: true
@@ -22,9 +20,6 @@ Plugin:
   worldedit: # Please note these are both experimental still and should be used with caution
     noteblock_mechanic: false
     stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
-  experimental:
-    nms:
-      glyphs: false # Uses NMS to render glyphs instead of the default method
 
 ConfigsTools:
   # list of model data numbers the automatic system will skip
@@ -37,6 +32,11 @@ ConfigsTools:
     material: PODZOL
     excludeFromInventory: false # set to true if you don't want to display it inside inventory
     injectID: false
+
+Glyphs:
+  glyph_handler: VANILLA # Valid handlers are VANILLA and NMS
+  emoji_list_permission_only: true # will only show emojis player has permission to use if set to true
+  unicode_completions: true # Whether glyph tab-completions shows unicodes or glyph-pølaceholders
 
 Chat:
   # If glyphs do not show up in chat, try setting this to LEGACY
@@ -236,9 +236,6 @@ Misc:
   hide_scoreboard_numbers: false
   # This will hide the background of scoreboards
   hide_scoreboard_background: false
-
-  # Whether Oraxen should register emoji tab completions with unicode characters
-  unicode_completions: true
 
   # All blocks with an inventory or any blocks that when right clicked shouldn't equip armor.
   armor_equip_event_bypass:

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -344,44 +344,55 @@ oraxen_inventory:
     armors:
       slot: 1
       icon: emerald_chestplate
+      displayname: "<green>Armors"
       title: "<main_menu_title><#362753><glyph:menu_items_overlay:colorable>"
     blocks:
       slot: 2
       icon: orax_ore
+      displayname: "<green>Blocks"
       title: "<main_menu_title><#EDCDEB><glyph:menu_items_overlay:colorable>"
     furniture:
       slot: 3
       icon: chair
+      displayname: "<green>Furniture"
       title: "<main_menu_title><#F2F2F2><glyph:menu_items_overlay:colorable>"
     flowers:
       slot: 4
       icon: dailily
+      displayname: "<green>Flowers"
       title: "<main_menu_title><#bf332c><glyph:menu_items_overlay:colorable>"
     hats:
       slot: 5
       icon: crown
+      displayname: "<green>Hats"
       title: "<main_menu_title><#81B125><glyph:menu_items_overlay:colorable>"
     items:
       slot: 6
       icon: ruby
+      displayname: "<green>Ruby"
       title: "<main_menu_title><#DA2E45><glyph:menu_items_overlay:colorable>"
     mystical:
       slot: 7
       icon: legendary_hammer
+      displayname: "<green>Mystical"
       title: "<main_menu_title><#9AB2E4><glyph:menu_items_overlay:colorable>"
     plants:
       slot: 8
       icon: weed_leaf
+      displayname: "<green>Plants"
       title: "<main_menu_title><#44C886><glyph:menu_items_overlay:colorable>"
     skins:
       slot: 9
       icon: wood_sword
+      displayname: "<green>Skins"
       title: "<main_menu_title><#C48E40><glyph:menu_items_overlay:colorable>"
     tools:
       slot: 10
       icon: iron_serpe
+      displayname: "<green>Tools"
       title: "<main_menu_title><#FFFFFF><glyph:menu_items_overlay:colorable>"
     weapons:
       slot: 11
       icon: energy_crystal_sword
+      displayname: "<green>Weapons"
       title: "<main_menu_title><#2FB6FF><glyph:menu_items_overlay:colorable>"

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -23,7 +23,6 @@ Plugin:
     noteblock_mechanic: false
     stringblock_mechanic: false # Works, but is buggy with some stringblocks, specifically with Tall-property
   experimental:
-    spigot_chat_formatting: false # This will enable the use of Spigot's chat formatting, which is not recommended
     nms:
       glyphs: false # Uses NMS to render glyphs instead of the default method
 
@@ -38,6 +37,10 @@ ConfigsTools:
     material: PODZOL
     excludeFromInventory: false # set to true if you don't want to display it inside inventory
     injectID: false
+
+Chat:
+  # If glyphs do not show up in chat, try setting this to LEGACY
+  chat_handler: MODERN # Valid once are MODERN & LEGACY
 
 CustomArmor:
   disable_leather_repair: true # Makes custom armor not repairable with leather, only with copies of said custom armor

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pluginVersion=1.167.0
+pluginVersion=1.168.0
 idofrontVersion=0.20.14

--- a/v1_18_R1/src/main/java/io/th0rgal/oraxen/nms/v1_18_R1/NMSHandler.java
+++ b/v1_18_R1/src/main/java/io/th0rgal/oraxen/nms/v1_18_R1/NMSHandler.java
@@ -7,13 +7,10 @@ import io.netty.channel.*;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.GlyphHandlers;
-import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
@@ -36,9 +33,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemStack;
@@ -120,7 +114,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -209,7 +203,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         inject(channel);
@@ -226,7 +220,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_18_R2/src/main/java/io/th0rgal/oraxen/nms/v1_18_R2/NMSHandler.java
+++ b/v1_18_R2/src/main/java/io/th0rgal/oraxen/nms/v1_18_R2/NMSHandler.java
@@ -7,15 +7,12 @@ import io.netty.channel.*;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.GlyphHandlers;
-import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -43,9 +40,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_18_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
@@ -161,7 +155,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -249,7 +243,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         inject(channel);
@@ -266,7 +260,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_19_R1/src/main/java/io/th0rgal/oraxen/nms/v1_19_R1/NMSHandler.java
+++ b/v1_19_R1/src/main/java/io/th0rgal/oraxen/nms/v1_19_R1/NMSHandler.java
@@ -163,7 +163,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -254,7 +254,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         inject(channel);
@@ -271,7 +271,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_19_R2/src/main/java/io.th0rgal.oraxen.nms.v1_19_R2/NMSHandler.java
+++ b/v1_19_R2/src/main/java/io.th0rgal.oraxen.nms.v1_19_R2/NMSHandler.java
@@ -163,7 +163,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -253,7 +253,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         channel.eventLoop().submit(() -> inject(channel));
@@ -270,7 +270,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_19_R3/src/main/java/io.th0rgal.oraxen.nms.v1_19_R3/NMSHandler.java
+++ b/v1_19_R3/src/main/java/io.th0rgal.oraxen.nms.v1_19_R3/NMSHandler.java
@@ -166,7 +166,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -256,7 +256,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         channel.eventLoop().submit(() -> inject(channel));
@@ -273,7 +273,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_20_R1/src/main/java/io/th0rgal/oraxen/nms/v1_20_R1/NMSHandler.java
+++ b/v1_20_R1/src/main/java/io/th0rgal/oraxen/nms/v1_20_R1/NMSHandler.java
@@ -180,7 +180,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -270,7 +270,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         channel.eventLoop().submit(() -> inject(channel, player));
@@ -278,7 +278,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_20_R2/src/main/java/io/th0rgal/oraxen/nms/v1_20_R2/NMSHandler.java
+++ b/v1_20_R2/src/main/java/io/th0rgal/oraxen/nms/v1_20_R2/NMSHandler.java
@@ -171,7 +171,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         final List<Connection> connections = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -259,7 +259,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         channel.eventLoop().submit(() -> inject(channel, player));
@@ -267,7 +267,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);

--- a/v1_20_R3/src/main/java/io/th0rgal/oraxen/nms/v1_20_R3/NMSHandler.java
+++ b/v1_20_R3/src/main/java/io/th0rgal/oraxen/nms/v1_20_R3/NMSHandler.java
@@ -174,7 +174,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void setupNmsGlyphs() {
-        if (!Settings.NMS_GLYPHS.toBool()) return;
+        if (!GlyphHandlers.isNms()) return;
         List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
         List<ChannelFuture> channelFutures;
 
@@ -265,7 +265,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void inject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         channel.eventLoop().submit(() -> inject(channel, player));
@@ -273,7 +273,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public void uninject(Player player) {
-        if (player == null || !Settings.NMS_GLYPHS.toBool()) return;
+        if (player == null || !GlyphHandlers.isNms()) return;
         Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
 
         uninject(channel);


### PR DESCRIPTION
**[New]**
- Clipboard-WorldEdit support for furniture
  * This meant `//copy/cut/paste -e` works, it does not mean support for other commands

**[Changes]**
- Move glyph-related settings into common Glyph section
- Experimental spigot-chat-formatting setting moved to Chat.chat_handler
  * MODERN is aimed at Paper servers and chat-plugins using this
  * LEGACY is everything else
- Add setting to change displayName of icons in `/oraxen inventory` ([Happy-FMZ](https://github.com/Happy-FZM))

**[Fixes]**
- Pack sending multiple times after using reload commands
- Ensure BlockBreakEvent & EntityDamagedByEntityEvent are properly cancelled if furniture-break is cancelled
- Incorrect step-sound when walking on edge of a Custom Block ([Happy-FMZ](https://github.com/Happy-FZM))
- Break sound not playing when breaking Stone blocks
- Nullpointer in Custom-Mechanic command-parsing
- Remaining Base-Item models breaking when using as OraxenItem-material
- Lava igniting OraxenBlocks when can_ignite is false
- Language-prefix not respected in some log/debug messages
- consumablepotioneffects mechanic not renamed to consumable_potion_effects
- Recipe-showcase gui caching and showing wrong recipe
- OraxenNoteBlockInteractEvent called twice & not for left-clicking blocks
- Bad offset/rotation for Display-Entity type with LimitedPlacing#wall/roof/floor
- Probability not accepting integers
- Recipe-builder improperly registering result-amount