### PR TITLE
1.170.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,7 +199,7 @@ tasks {
 }
 
 bukkit {
-    load = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.PluginLoadOrder.POSTWORLD
+    load = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.PluginLoadOrder.STARTUP
     main = "io.th0rgal.oraxen.OraxenPlugin"
     version = pluginVersion
     name = "Oraxen"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ allprojects {
         compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.9")
         compileOnly("commons-io:commons-io:2.11.0")
         compileOnly("com.google.code.gson:gson:$googleGsonVersion")
-        compileOnly("com.ticxo.modelengine:ModelEngine:R4.0.1")
+        compileOnly("com.ticxo.modelengine:ModelEngine:R4.0.4")
         compileOnly("com.ticxo.modelengine:api:R3.1.8")
         compileOnly(files("../libs/compile/BSP.jar"))
         compileOnly("dev.jorel:commandapi-bukkit-shade:$commandApiVersion")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,8 +29,8 @@ publishing {
             artifactId = rootProject.name
             version = publishData.getVersion()
 
-            //from(components["java"])
-            artifact(tasks.shadowJar.get().apply { archiveClassifier.set("") })
+            from(components["java"])
+            //artifact(tasks.shadowJar.get().apply { archiveClassifier.set("") })
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/OraxenPackPreUploadEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/OraxenPackPreUploadEvent.java
@@ -1,0 +1,35 @@
+package io.th0rgal.oraxen.api.events;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class OraxenPackPreUploadEvent extends Event implements Cancellable {
+    private boolean cancelled;
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public OraxenPackPreUploadEvent() {
+        super(true);
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/noteblock/OraxenNoteBlockInteractEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/noteblock/OraxenNoteBlockInteractEvent.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.Action;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -20,9 +21,11 @@ public class OraxenNoteBlockInteractEvent extends Event implements Cancellable {
     private final ItemStack itemInHand;
     private final BlockFace blockFace;
     private final EquipmentSlot hand;
+    private final Action action;
     private boolean isCancelled;
     private static final HandlerList HANDLERS = new HandlerList();
 
+    @Deprecated
     public OraxenNoteBlockInteractEvent(@NotNull final NoteBlockMechanic mechanic, @NotNull final Player player, @Nullable final ItemStack itemInHand, @NotNull final EquipmentSlot hand, @NotNull final Block block, @NotNull final BlockFace blockFace) {
         this.mechanic = mechanic;
         this.block = block;
@@ -30,6 +33,18 @@ public class OraxenNoteBlockInteractEvent extends Event implements Cancellable {
         this.itemInHand = itemInHand;
         this.blockFace = blockFace;
         this.hand = hand;
+        this.action = Action.RIGHT_CLICK_BLOCK;
+        this.isCancelled = false;
+    }
+
+    public OraxenNoteBlockInteractEvent(@NotNull final NoteBlockMechanic mechanic, @NotNull final Player player, @Nullable final ItemStack itemInHand, @NotNull final EquipmentSlot hand, @NotNull final Block block, @NotNull final BlockFace blockFace, @NotNull final Action action) {
+        this.mechanic = mechanic;
+        this.block = block;
+        this.player = player;
+        this.itemInHand = itemInHand;
+        this.blockFace = blockFace;
+        this.hand = hand;
+        this.action = action;
         this.isCancelled = false;
     }
 
@@ -79,6 +94,14 @@ public class OraxenNoteBlockInteractEvent extends Event implements Cancellable {
     @NotNull
     public EquipmentSlot getHand() {
         return hand;
+    }
+
+    /**
+     * @return The type of interaction
+     */
+    @NotNull
+    public Action getAction() {
+        return action;
     }
 
     @Override

--- a/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -78,9 +78,8 @@ public class CommandsManager {
                 .withPermission("oraxen.command.inventory.view")
                 .executes((sender, args) -> {
                     if (sender instanceof Player player)
-                        OraxenPlugin.get().getInvManager().getItemsView(player).show(player);
-                    else
-                        Message.NOT_PLAYER.send(sender);
+                        OraxenPlugin.get().getInvManager().getItemsView(player).open(player);
+                    else Message.NOT_PLAYER.send(sender);
                 });
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
@@ -6,6 +6,7 @@ import gs.mclo.java.Log;
 import gs.mclo.java.MclogsAPI;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -24,13 +25,13 @@ public class LogDumpCommand {
         return new CommandAPICommand("dump_log")
                 .withPermission("oraxen.command.dumplog")
                 .executes((sender, args) -> {
-                    String packUrl = OraxenPlugin.get().getUploadManager().getHostingProvider().getPackURL();
+                    String packUrl = "http://atlas.oraxen.com:8080/.*";
                     String logfile;
 
                     try {
-                        Logs.logError(OraxenPlugin.get().getDataFolder().getAbsoluteFile().getParentFile().getParentFile().toPath().resolve("logs/latest.log").toString());
                         Path path = OraxenPlugin.get().getDataFolder().getAbsoluteFile().getParentFile().getParentFile().toPath().resolve("logs/latest.log");
-                        logfile = Files.readString(path).replace(packUrl, "[REDACTED]");
+                        logfile = Files.readString(path).replaceAll(packUrl, "[REDACTED]");
+                        if (VersionUtil.isLeaked()) logfile = logfile + "\n\nThis server is running a leaked version of Oraxen, please report it to the developers.";
                     } catch (Exception e) {
                         Logs.logError("Failed to read latest.log, is it missing?");
                         if (Settings.DEBUG.toBool()) e.printStackTrace();

--- a/core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
@@ -31,7 +31,7 @@ public class LogDumpCommand {
                     try {
                         Path path = OraxenPlugin.get().getDataFolder().getAbsoluteFile().getParentFile().getParentFile().toPath().resolve("logs/latest.log");
                         logfile = Files.readString(path).replaceAll(packUrl, "[REDACTED]");
-                        if (VersionUtil.isLeaked()) logfile = logfile + "\n\nThis server is running a leaked version of Oraxen, please report it to the developers.";
+                        if (VersionUtil.isLeaked()) logfile = logfile + "\n\nThis server is running a leaked version of Oraxen";
                     } catch (Exception e) {
                         Logs.logError("Failed to read latest.log, is it missing?");
                         if (Settings.DEBUG.toBool()) e.printStackTrace();

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -1,7 +1,9 @@
 package io.th0rgal.oraxen.config;
 
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
+import net.kyori.adventure.text.Component;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 
@@ -128,7 +130,10 @@ public enum Settings {
     // Inventory
     ORAXEN_INV_LAYOUT("oraxen_inventory.menu_layout"),
     ORAXEN_INV_ROWS("oraxen_inventory.menu_rows"),
-    ORAXEN_INV_TITLE("oraxen_inventory.main_menu_title");
+    ORAXEN_INV_TITLE("oraxen_inventory.main_menu_title"),
+    ORAXEN_INV_NEXT_ICON("oraxen_inventory.next_page_icon"),
+    ORAXEN_INV_PREVIOUS_ICON("oraxen_inventory.previous_page_icon"),
+    ORAXEN_INV_EXIT("oraxen_inventory.exit_icon");
 
     private final String path;
 
@@ -157,6 +162,10 @@ public enum Settings {
     @Override
     public String toString() {
         return (String) getValue();
+    }
+
+    public Component toComponent() {
+        return AdventureUtils.MINI_MESSAGE.deserialize(getValue().toString());
     }
 
     public Boolean toBool() {

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -131,6 +131,7 @@ public enum Settings {
     ORAXEN_INV_LAYOUT("oraxen_inventory.menu_layout"),
     ORAXEN_INV_ROWS("oraxen_inventory.menu_rows"),
     ORAXEN_INV_TITLE("oraxen_inventory.main_menu_title"),
+    ORAXEN_INV_TYPE("oraxen_inventory.main_menu_type"),
     ORAXEN_INV_NEXT_ICON("oraxen_inventory.next_page_icon"),
     ORAXEN_INV_PREVIOUS_ICON("oraxen_inventory.previous_page_icon"),
     ORAXEN_INV_EXIT("oraxen_inventory.exit_icon");

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.items;
 
-import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
 import io.th0rgal.oraxen.compatibilities.provided.mmoitems.WrappedMMOItem;
@@ -9,10 +8,9 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.PotionUtils;
 import io.th0rgal.oraxen.utils.Utils;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
@@ -154,13 +152,13 @@ public class ItemParser {
                     .getList("PotionEffects");
             if (potionEffects == null) return;
             for (Map<String, Object> serializedPotionEffect : potionEffects) {
-                PotionEffectType effect = PotionEffectType.getByName((String) serializedPotionEffect.get("type"));
+                PotionEffectType effect = PotionUtils.getEffectType((String) serializedPotionEffect.getOrDefault("type", ""));
                 if (effect == null) return;
-                int duration = (int) serializedPotionEffect.get("duration");
-                int amplifier = (int) serializedPotionEffect.get("amplifier");
-                boolean ambient = (boolean) serializedPotionEffect.get("ambient");
-                boolean particles = (boolean) serializedPotionEffect.get("particles");
-                boolean icon = (boolean) serializedPotionEffect.get("icon");
+                int duration = (int) serializedPotionEffect.getOrDefault("duration", 60);
+                int amplifier = (int) serializedPotionEffect.getOrDefault("amplifier", 0);
+                boolean ambient = (boolean) serializedPotionEffect.getOrDefault("ambient", true);
+                boolean particles = (boolean) serializedPotionEffect.getOrDefault("particles", true);
+                boolean icon = (boolean) serializedPotionEffect.getOrDefault("icon", true);
                 item.addPotionEffect(new PotionEffect(effect, duration, amplifier, ambient, particles, icon));
             }
         }

--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -117,7 +117,7 @@ public class OraxenMeta {
         this.generatedModelPath = section.getString("generated_model_path", "");
         this.parentModel = section.getString("parent_model", "item/generated");
 
-        if (generate_model && !modelName.matches("^[a-z0-9-_]+$")) {
+        if (generate_model && !modelName.matches("^[a-z0-9-_/]+$")) {
             Logs.logWarning("Item " + section.getParent().getName() + " is set to generate a model, but ItemID does not adhere to [a-z0-9-_]!");
             Logs.logWarning("This will generate a malformed model!");
         }

--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -56,7 +56,6 @@ public class OraxenMeta {
     public void setPackInfos(ConfigurationSection section) {
         this.hasPackInfos = true;
         this.modelName = readModelName(section, "model");
-        Logs.debug("model name: " + modelName);
         this.blockingModel = readModelName(section, "blocking_model");
         this.castModel = readModelName(section, "cast_model");
         this.chargedModel = readModelName(section, "charged_model");

--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -56,6 +56,7 @@ public class OraxenMeta {
     public void setPackInfos(ConfigurationSection section) {
         this.hasPackInfos = true;
         this.modelName = readModelName(section, "model");
+        Logs.debug("model name: " + modelName);
         this.blockingModel = readModelName(section, "blocking_model");
         this.castModel = readModelName(section, "cast_model");
         this.chargedModel = readModelName(section, "charged_model");

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -155,7 +155,7 @@ public class FurnitureListener implements Listener {
 
         BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(block, block.getState(), placedAgainst, item, player, true, hand);
 
-        final Rotation rotation = getRotation(player.getEyeLocation().getYaw(), mechanic.getBarriers().size() > 1);
+        final Rotation rotation = getRotation(player.getEyeLocation().getYaw(), mechanic);
         final float yaw = rotationToYaw(rotation);
         if (player.getGameMode() == GameMode.ADVENTURE)
             blockPlaceEvent.setCancelled(true);
@@ -208,10 +208,11 @@ public class FurnitureListener implements Listener {
         return FurnitureFactory.getInstance().getMechanic(item);
     }
 
-    private Rotation getRotation(final double yaw, final boolean restricted) {
+    private Rotation getRotation(final double yaw, FurnitureMechanic mechanic) {
+        FurnitureMechanic.RestrictedRotation restrictedRotation = mechanic.getRestrictedRotation();
         int id = (int) (((Location.normalizeYaw((float) yaw) + 180) * 8 / 360) + 0.5) % 8;
-        if (restricted && id % 2 != 0)
-            id -= 1;
+        int offset = restrictedRotation == FurnitureMechanic.RestrictedRotation.STRICT ? 0 : 1;
+        if (restrictedRotation != FurnitureMechanic.RestrictedRotation.NONE && id % 2 != 0) id -= offset;
         return Rotation.values()[id];
     }
 
@@ -372,9 +373,9 @@ public class FurnitureListener implements Listener {
 
         if (mechanic.hasSeat() && pdc != null && mechanic.isRotatable()) {
             if (!player.isSneaking()) FurnitureMechanic.sitOnSeat(pdc, player);
-            else FurnitureMechanic.rotateFurniture(baseEntity);
+            else mechanic.rotateFurniture(baseEntity);
         } else if (mechanic.hasSeat() && pdc != null) FurnitureMechanic.sitOnSeat(pdc, player);
-        else if (mechanic.isRotatable()) FurnitureMechanic.rotateFurniture(baseEntity);
+        else if (mechanic.isRotatable()) mechanic.rotateFurniture(baseEntity);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -34,6 +34,7 @@ import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryCreativeEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -380,38 +381,25 @@ public class FurnitureListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onMiddleClick(final InventoryCreativeEvent event) {
-        if (event.getClick() != ClickType.CREATIVE) return;
         final Player player = (Player) event.getInventory().getHolder();
-        if (player == null) return;
-        if (event.getCursor().getType() == Material.BARRIER) {
-            final RayTraceResult rayTraceResult = player.rayTraceBlocks(6.0);
-            if (rayTraceResult == null) return;
-            final Block block = rayTraceResult.getHitBlock();
-            if (block == null) return;
-            FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(block);
-            if (mechanic == null) return;
+        if (event.getClickedInventory() == null || player == null) return;
+        if (event.getClick() != ClickType.CREATIVE) return;
+        if (event.getSlotType() != InventoryType.SlotType.QUICKBAR) return;
+        if (event.getCursor().getType() != Material.BARRIER) return;
 
-            ItemStack item = OraxenItems.getItemById(mechanic.getItemID()).build();
-            for (int i = 0; i <= 8; i++) {
-                if (Objects.equals(OraxenItems.getIdByItem(player.getInventory().getItem(i)), mechanic.getItemID())) {
-                    player.getInventory().setHeldItemSlot(i);
-                    event.setCancelled(true);
-                    return;
-                }
+        final RayTraceResult rayTraceResult = player.rayTraceBlocks(8.0);
+        FurnitureMechanic mechanic = rayTraceResult != null ? OraxenFurniture.getFurnitureMechanic(rayTraceResult.getHitBlock()) : null;
+        if (mechanic == null) return;
+
+        ItemStack item = OraxenItems.getItemById(mechanic.getItemID()).build();
+        for (int i = 0; i <= 8; i++) {
+            if (Objects.equals(OraxenItems.getIdByItem(player.getInventory().getItem(i)), mechanic.getItemID())) {
+                player.getInventory().setHeldItemSlot(i);
+                event.setCancelled(true);
+                return;
             }
-            event.setCursor(item);
-        } else if (OraxenItems.getIdByItem(event.getCursor()) != null) {
-            String itemID = OraxenItems.getIdByItem(event.getCursor());
-            if (!OraxenFurniture.isFurniture(itemID)) return;
-            for (int i = 0; i <= 8; i++) {
-                if (Objects.equals(OraxenItems.getIdByItem(player.getInventory().getItem(i)), itemID)) {
-                    player.getInventory().setHeldItemSlot(i);
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-            event.setCursor(OraxenItems.getItemById(itemID).build());
         }
+        event.setCursor(item);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/limitedplacing/LimitedPlacing.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/limitedplacing/LimitedPlacing.java
@@ -5,8 +5,6 @@ import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.block.BlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
-import io.th0rgal.oraxen.utils.BlockHelpers;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -112,6 +110,7 @@ public class LimitedPlacing {
     }
 
     public boolean checkLimitedMechanic(Block block) {
+        if (blockTypes.isEmpty() && blockTags.isEmpty() && oraxenBlocks.isEmpty()) return type == LimitedPlacingType.ALLOW;
         String oraxenId = checkIfOraxenItem(block);
         if (oraxenId == null) {
             if (blockTypes.contains(block.getType())) return true;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -268,8 +268,8 @@ public class NoteBlockMechanicListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBreakingCustomBlock(final BlockBreakEvent event) {
-        if (OraxenBlocks.remove(event.getBlock().getLocation(), event.getPlayer()))
-            event.setDropItems(false);
+        if (OraxenBlocks.isOraxenNoteBlock(event.getBlock())) event.setDropItems(false);
+        OraxenBlocks.remove(event.getBlock().getLocation(), event.getPlayer());
     }
 
     @EventHandler

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -133,7 +133,7 @@ public class NoteBlockMechanicListener implements Listener {
         if (event.getClickedBlock().getType() != Material.NOTE_BLOCK) return;
         NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
         if (mechanic == null) return;
-        if (!EventUtils.callEvent(new OraxenNoteBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace())))
+        if (!EventUtils.callEvent(new OraxenNoteBlockInteractEvent(mechanic, event.getPlayer(), event.getItem(), event.getHand(), block, event.getBlockFace(), event.getAction())))
             event.setUseInteractedBlock(Event.Result.DENY);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/armor_effects/ArmorEffectsMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/armor_effects/ArmorEffectsMechanic.java
@@ -2,10 +2,10 @@ package io.th0rgal.oraxen.mechanics.provided.misc.armor_effects;
 
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.utils.PotionUtils;
 import io.th0rgal.oraxen.utils.customarmor.CustomArmorsTextures;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.apache.commons.lang3.StringUtils;
-import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -30,9 +30,7 @@ public class ArmorEffectsMechanic extends Mechanic {
 
     public void registersEffectFromSection(ConfigurationSection section) {
         String type = section.getName().toLowerCase();
-        PotionEffectType effectType = PotionEffectType.getByName(type);
-        if (effectType == null)
-            effectType = PotionEffectType.getByKey(type.contains(":") ? NamespacedKey.fromString(type) : NamespacedKey.minecraft(type));
+        PotionEffectType effectType = PotionUtils.getEffectType(type);
         if (effectType == null) {
             Logs.logError("Invalid potion effect: " + section.getName() + ", in " + StringUtils.substringBefore(section.getCurrentPath(), ".") + "!");
             return;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/consumablepotioneffects/ConsumablePotionEffectsMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/consumablepotioneffects/ConsumablePotionEffectsMechanic.java
@@ -2,9 +2,9 @@ package io.th0rgal.oraxen.mechanics.provided.misc.consumablepotioneffects;
 
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.utils.PotionUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.apache.commons.lang3.StringUtils;
-import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
@@ -27,9 +27,7 @@ public class ConsumablePotionEffectsMechanic extends Mechanic {
 
     public void registersEffectFromSection(ConfigurationSection section) {
         String type = section.getName().toLowerCase();
-        PotionEffectType effectType = PotionEffectType.getByName(type);
-        if (effectType == null)
-            effectType = PotionEffectType.getByKey(type.contains(":") ? NamespacedKey.fromString(type) : NamespacedKey.minecraft(type));
+        PotionEffectType effectType = PotionUtils.getEffectType(type);
         if (effectType == null) {
             Logs.logError("Invalid potion effect: " + section.getName() + ", in " + StringUtils.substringBefore(section.getCurrentPath(), ".") + "!");
             return;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
@@ -1,17 +1,15 @@
 package io.th0rgal.oraxen.mechanics.provided.misc.food;
 
-import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
-import io.th0rgal.oraxen.compatibilities.provided.mmoitems.WrappedMMOItem;
 import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.utils.PotionUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.Indyuce.mmoitems.MMOItems;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -47,9 +45,7 @@ public class FoodMechanic extends Mechanic {
 
     private void registerEffects(ConfigurationSection section) {
         String type = section.getName().toLowerCase();
-        PotionEffectType effectType = PotionEffectType.getByName(type);
-        if (effectType == null)
-            effectType = PotionEffectType.getByKey(type.contains(":") ? NamespacedKey.fromString(type) : NamespacedKey.minecraft(type));
+        PotionEffectType effectType = PotionUtils.getEffectType(type);
         if (effectType == null) {
             Logs.logError("Invalid potion effect: " + section.getName() + ", in " + StringUtils.substringBefore(section.getCurrentPath(), ".") + "!");
             return;

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -1,13 +1,9 @@
 package io.th0rgal.oraxen.nms;
 
-import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.utils.OraxenYaml;
-import io.th0rgal.oraxen.utils.VersionUtil;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -18,16 +14,9 @@ import java.util.Set;
 
 public interface NMSHandler {
 
-    @Nullable
-    ConfigurationSection paperSection = VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.19") ? OraxenYaml.loadConfiguration(OraxenPlugin.get().getDataFolder().toPath().toAbsolutePath().getParent().getParent().resolve("config").resolve("paper-global.yml").toFile()).getConfigurationSection("block-updates") : null;
+    boolean noteblockUpdatesDisabled();
 
-    default boolean noteblockUpdatesDisabled() {
-        return VersionUtil.isPaperServer() && paperSection != null && paperSection.getBoolean("disable-noteblock-updates", false);
-    }
-
-    default boolean tripwireUpdatesDisabled() {
-        return VersionUtil.isPaperServer() && paperSection != null && paperSection.getBoolean("disable-tripwire-updates", false);
-    }
+    boolean tripwireUpdatesDisabled();
 
     /**
      * Copies over all NBT-Tags from oldItem to newItem

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/AtlasGenerator.java
@@ -3,7 +3,6 @@ package io.th0rgal.oraxen.pack.generation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.Utils;
@@ -45,17 +44,25 @@ public class AtlasGenerator {
         OraxenItems.getItems().stream().filter(builder -> builder.hasOraxenMeta() && builder.getOraxenMeta().hasLayers())
                 .forEach(builder -> itemTextures.addAll(builder.getOraxenMeta().getLayers()));
 
-        Set<String> glyphTextures = new LinkedHashSet<>();
-        OraxenPlugin.get().getFontManager().getGlyphs()
-                .forEach(glyph -> glyphTextures.add(glyph.getTexture().replace(".png", "")));
+        Set<String> fontTextures = new LinkedHashSet<>();
+        Set<VirtualFile> fonts = output.stream().filter(v -> v.getPath().matches("assets/.*/font/.*.json")).collect(Collectors.toSet());
+        for (VirtualFile font : fonts) {
+            JsonObject fontObject = font.toJsonElement().getAsJsonObject();
+            fontObject.getAsJsonArray("providers").forEach(provider -> {
+                JsonObject providerObject = provider.getAsJsonObject();
+                if (providerObject.has("file")) {
+                    fontTextures.add(providerObject.get("file").getAsString().replace(".png", ""));
+                }
+            });
+        }
 
         for (Map.Entry<VirtualFile, String> entry : textureSubFolders.entrySet()) {
             VirtualFile virtual = entry.getKey();
             String path = entry.getValue();
 
-            // If a texture is for a glyph, do not add it to atlas, unless an item uses it
+            // If a texture is for a font, do not add it to atlas, unless an item uses it
             // Default example is required/exit_icon.png
-            if (glyphTextures.contains(path) && !itemTextures.contains(path)) continue;
+            if (fontTextures.contains(path) && !itemTextures.contains(path)) continue;
 
             JsonObject atlasEntry = new JsonObject();
             String namespace = virtual.getPath().replaceFirst("assets/", "").split("/")[0];

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -194,13 +194,13 @@ public class DuplicationHandler {
             List<String> newProviderChars = getNewProviderCharSet(newProviders);
             if (providers != null) for (JsonElement providerElement : providers) {
                 if (!providerElement.isJsonObject()) continue;
+                JsonObject provider = providerElement.getAsJsonObject();
                 if (newProviders.contains(providerElement)) continue;
-                if (!providerElement.getAsJsonObject().has("chars")) continue;
-                String chars = providerElement.getAsJsonObject().getAsJsonArray("chars").toString();
-                if (!newProviderChars.contains(chars))
-                    newProviders.add(providerElement);
-                else
-                    Logs.logWarning("Tried adding " + chars + " but it was already defined in this font");
+                if (provider.has("chars")) {
+                    String chars = provider.getAsJsonArray("chars").toString();
+                    if (!newProviderChars.contains(chars)) newProviders.add(provider);
+                    else Logs.logWarning("Tried adding " + chars + " but it was already defined in this font");
+                } else newProviders.add(provider);
             }
         }
         return newProviders;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -185,10 +185,7 @@ public class DuplicationHandler {
         for (VirtualFile font : duplicates) {
             JsonElement fontelement = font.toJsonElement();
 
-            if (!fontelement.isJsonObject()) {
-                Logs.logError("Not a json object");
-                continue;
-            }
+            if (fontelement == null || !fontelement.isJsonObject()) continue;
 
             JsonArray providers = fontelement.getAsJsonObject().getAsJsonArray("providers");
             List<String> newProviderChars = getNewProviderCharSet(newProviders);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.pack.upload;
 
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.api.events.OraxenPackPreUploadEvent;
 import io.th0rgal.oraxen.api.events.OraxenPackUploadEvent;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.config.Settings;
@@ -11,6 +12,7 @@ import io.th0rgal.oraxen.pack.receive.PackReceiver;
 import io.th0rgal.oraxen.pack.upload.hosts.HostingProvider;
 import io.th0rgal.oraxen.pack.upload.hosts.Polymath;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -57,8 +59,10 @@ public class UploadManager {
         }
 
         final long time = System.currentTimeMillis();
-        Message.PACK_UPLOADING.log();
         Bukkit.getScheduler().runTaskAsynchronously(OraxenPlugin.get(), () -> {
+            EventUtils.callEvent(new OraxenPackPreUploadEvent());
+
+            Message.PACK_UPLOADING.log();
             if (!hostingProvider.uploadPack(resourcePack.getFile())) {
                 Message.PACK_NOT_UPLOADED.log();
                 return;

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
@@ -48,8 +48,9 @@ public class RecipesEventsManager implements Listener {
         if (event.getSlot() != 2 || merchantInventory.getSelectedRecipe() == null) return;
 
         String first = OraxenItems.getIdByItem(merchantInventory.getItem(0)), second = OraxenItems.getIdByItem(merchantInventory.getItem(1));
-        List<ItemStack> ingredients = merchantInventory.getSelectedRecipe().getIngredients();
-        String firstIngredient = OraxenItems.getIdByItem(ingredients.get(0)), secondIngredient = OraxenItems.getIdByItem(ingredients.get(1));
+        ArrayList<ItemStack> ingredients = new ArrayList<>(merchantInventory.getSelectedRecipe().getIngredients());
+        String firstIngredient = ingredients.isEmpty() ? null : OraxenItems.getIdByItem(ingredients.get(0));
+        String secondIngredient = ingredients.size() < 2 ? null : OraxenItems.getIdByItem(ingredients.get(1));
         if (!Objects.equals(first, firstIngredient) || !Objects.equals(second, secondIngredient)) event.setCancelled(true);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
@@ -67,8 +67,7 @@ public class RecipesEventsManager implements Listener {
         if (!containsOraxenItem || recipe == null) return;
 
         CustomRecipe current = new CustomRecipe(null, recipe.getResult(), Arrays.asList(event.getInventory().getMatrix()));
-        if (whitelistedCraftRecipes.stream().anyMatch(w -> w.equals(current))) return;
-        if (current.isValidDyeRecipe()) return;
+        if (whitelistedCraftRecipes.stream().anyMatch(current::equals) || current.isValidDyeRecipe()) return;
 
         event.getInventory().setResult(null);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/EntityUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/EntityUtils.java
@@ -15,7 +15,7 @@ public class EntityUtils {
     private static Method spawnMethod;
 
     public static boolean isUnderWater(Entity entity) {
-        if (VersionUtil.atOrAbove("1.19")) {
+        if (VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.19")) {
             return entity.isUnderWater();
         } else return entity.isInWater();
     }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PotionUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PotionUtils.java
@@ -11,14 +11,15 @@ public class PotionUtils {
     @SuppressWarnings({"deprecation"})
     @Nullable
     public static PotionEffectType getEffectType(String effect) {
-        PotionEffectType effectType;
+        PotionEffectType effectType = null;
         try {
             effectType = Registry.POTION_EFFECT_TYPE.get(NamespacedKey.fromString(effect));
         } catch (Exception e) {
-            effectType = PotionEffectType.getByName(effect);
-            if (effectType == null)
-                effectType = PotionEffectType.getByKey(effect.contains(":") ? NamespacedKey.fromString(effect) : NamespacedKey.minecraft(effect));
         }
+        if (effectType == null)
+            effectType = PotionEffectType.getByName(effect);
+        if (effectType == null)
+            effectType = PotionEffectType.getByKey(effect.contains(":") ? NamespacedKey.fromString(effect) : NamespacedKey.minecraft(effect));
 
         return effectType;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PotionUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PotionUtils.java
@@ -11,6 +11,7 @@ public class PotionUtils {
     @SuppressWarnings({"deprecation"})
     @Nullable
     public static PotionEffectType getEffectType(String effect) {
+        if (effect == null || effect.isEmpty()) return null;
         PotionEffectType effectType = null;
         try {
             effectType = Registry.POTION_EFFECT_TYPE.get(NamespacedKey.fromString(effect));

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PotionUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PotionUtils.java
@@ -1,0 +1,25 @@
+package io.th0rgal.oraxen.utils;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.potion.PotionEffectType;
+
+import javax.annotation.Nullable;
+
+public class PotionUtils {
+
+    @SuppressWarnings({"deprecation"})
+    @Nullable
+    public static PotionEffectType getEffectType(String effect) {
+        PotionEffectType effectType;
+        try {
+            effectType = Registry.POTION_EFFECT_TYPE.get(NamespacedKey.fromString(effect));
+        } catch (Exception e) {
+            effectType = PotionEffectType.getByName(effect);
+            if (effectType == null)
+                effectType = PotionEffectType.getByKey(effect.contains(":") ? NamespacedKey.fromString(effect) : NamespacedKey.minecraft(effect));
+        }
+
+        return effectType;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorsTextures.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorsTextures.java
@@ -646,7 +646,7 @@ public class CustomArmorsTextures {
                          texCoord1 = UV1;
                          normal = ProjMat * ModelViewMat * vec4(Normal, 0.0);
                      }
-                    """;
+                    """.trim();
         }
 
         private static String getShaderFsh() {
@@ -791,7 +791,7 @@ public class CustomArmorsTextures {
                      
                          fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
                      }
-                    """.replace(SHADER_PARAMETER_PLACEHOLDER, String.valueOf((int) Settings.ARMOR_RESOLUTION.getValue()));
+                    """.replace(SHADER_PARAMETER_PLACEHOLDER, String.valueOf((int) Settings.ARMOR_RESOLUTION.getValue())).trim();
         }
 
         private static String getShaderJson() {
@@ -828,7 +828,7 @@ public class CustomArmorsTextures {
                              { "name": "GameTime", "type": "float", "count": 1, "values": [ 1.0 ] }
                          ]
                      }
-                    """;
+                    """.trim();
         }
 
         private static String getLicense() {
@@ -837,7 +837,7 @@ public class CustomArmorsTextures {
                                     
                     This allowed to commercially use with reference to original author.
                     Original license: https://github.com/Ancientkingg/fancyPants/blob/master/README.md
-                    """;
+                    """.trim();
         }
 
     }
@@ -888,7 +888,7 @@ public class CustomArmorsTextures {
                              { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
                              { "name": "GameTime", "type": "float", "count": 1, "values": [ 1.0 ] }
                          ]
-                     }""";
+                     }""".trim();
         }
 
         public static String getOutlineJson() {
@@ -914,7 +914,7 @@ public class CustomArmorsTextures {
                             { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
                             { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] }
                         ]
-                    }""";
+                    }""".trim();
         }
 
         public static String getArmorVsh() {
@@ -983,7 +983,7 @@ public class CustomArmorsTextures {
                                 tintColor = vec4(1);
                             }
                         }
-                    }""";
+                    }""".trim();
         }
 
         public static String getArmorFsh() {
@@ -1016,7 +1016,7 @@ public class CustomArmorsTextures {
                         color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
                         color *= vertexColor * lightColor; //shading
                         fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
-                    }""";
+                    }""".trim();
         }
 
         public static String getGlowingVsh() {
@@ -1046,7 +1046,7 @@ public class CustomArmorsTextures {
                         if (size.y >= 2*size.x && size.x < 256) {
                             uv.y /= 2.*size.y/size.x;
                         }
-                    }""";
+                    }""".trim();
         }
 
         public static String getGlowingFsh() {
@@ -1066,7 +1066,7 @@ public class CustomArmorsTextures {
                         vec4 color = texture(Sampler0, uv);
                         if (color.a == 0.0) discard;
                         fragColor = vec4(ColorModulator.rgb * vertexColor.rgb, ColorModulator.a);
-                    }""";
+                    }""".trim();
         }
 
         public static String getFogGlsl() {
@@ -1098,7 +1098,7 @@ public class CustomArmorsTextures {
                             float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
                             return max(distXZ, distY);
                         }
-                    }""";
+                    }""".trim();
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
@@ -1,7 +1,7 @@
 package io.th0rgal.oraxen.utils.inventories;
 
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
-import dev.triumphteam.gui.guis.PaginatedGui;
+import dev.triumphteam.gui.guis.BaseGui;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
 import org.bukkit.entity.Player;
 
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public class InvManager {
 
-    private Map<UUID, PaginatedGui> itemsViews = new HashMap<>();
+    private final Map<UUID, BaseGui> itemsViews = new HashMap<>();
 
     public InvManager() {
         regen();
@@ -22,7 +22,7 @@ public class InvManager {
         itemsViews.clear();
     }
 
-    public PaginatedGui getItemsView(Player player) {
+    public BaseGui getItemsView(Player player) {
         return itemsViews.computeIfAbsent(player.getUniqueId(), uuid -> new ItemsView().create());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.utils.inventories;
 
 import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import dev.triumphteam.gui.guis.PaginatedGui;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
 import org.bukkit.entity.Player;
 
@@ -11,7 +12,7 @@ import java.util.UUID;
 
 public class InvManager {
 
-    private Map<UUID, ChestGui> itemsViews = new HashMap<>();
+    private Map<UUID, PaginatedGui> itemsViews = new HashMap<>();
 
     public InvManager() {
         regen();
@@ -21,7 +22,7 @@ public class InvManager {
         itemsViews.clear();
     }
 
-    public ChestGui getItemsView(Player player) {
+    public PaginatedGui getItemsView(Player player) {
         return itemsViews.computeIfAbsent(player.getUniqueId(), uuid -> new ItemsView().create());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
@@ -1,16 +1,15 @@
 package io.th0rgal.oraxen.utils.inventories;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
-import com.github.stefvanschie.inventoryframework.pane.PaginatedPane;
-import com.github.stefvanschie.inventoryframework.pane.StaticPane;
-import com.github.stefvanschie.inventoryframework.pane.util.Slot;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
+import dev.triumphteam.gui.guis.PaginatedGui;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.ItemParser;
 import io.th0rgal.oraxen.items.ItemUpdater;
+import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.Utils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Material;
@@ -20,115 +19,96 @@ import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class ItemsView {
 
     private final YamlConfiguration settings = OraxenPlugin.get().getResourceManager().getSettings();
-    ChestGui mainGui;
+    PaginatedGui mainGui;
 
-    public ChestGui create() {
-        final Map<File, ChestGui> files = new HashMap<>();
+    public PaginatedGui create() {
+        final Map<File, PaginatedGui> files = new HashMap<>();
         for (final File file : OraxenItems.getMap().keySet()) {
             final List<ItemBuilder> unexcludedItems = OraxenItems.getUnexcludedItems(file);
             if (!unexcludedItems.isEmpty())
                 files.put(file, createSubGUI(file.getName(), unexcludedItems));
         }
-        mainGui = new ChestGui((int) Settings.ORAXEN_INV_ROWS.getValue(), Settings.ORAXEN_INV_TITLE.toString());
-        final StaticPane filesPane = new StaticPane(0, 0, 9, mainGui.getRows());
-        int i = 0;
+        int rows = (int) Settings.ORAXEN_INV_ROWS.getValue();
+        mainGui = Gui.paginated().pageSize((rows - 1) * 9).rows(rows).title(Settings.ORAXEN_INV_TITLE.toComponent()).create();
+        mainGui.disableAllInteractions();
 
-        Set<Integer> usedSlots = files.keySet().stream().map(e -> getItemStack(e).getRight()).filter(e -> e > -1).collect(Collectors.toSet());
-
-        for (final var entry : files.entrySet()) {
-            Pair<ItemStack, Integer> itemSlotPair = getItemStack(entry.getKey());
-            ItemStack itemStack = itemSlotPair.getLeft();
-            int slot = itemSlotPair.getRight() > -1 ? itemSlotPair.getRight() : getUnusedSlot(i, usedSlots);
-            final GuiItem item = new GuiItem(itemStack, event -> entry.getValue().show(event.getWhoClicked()));
-            filesPane.addItem(item, Slot.fromXY(slot % 9, slot / 9));
-            i++;
+        // Make a list of all slots to allow using mainGui.addItem easier
+        List<GuiItem> pageItems = new ArrayList<>(Collections.nCopies(files.size(), null));
+        // Make a list of all used slots to avoid using them later
+        for (Map.Entry<File, PaginatedGui> entry : files.entrySet()) {
+            int slot = getItemStack(entry.getKey()).getRight();
+            if (slot == -1) continue;
+            GuiItem guiItem = new GuiItem(getItemStack(entry.getKey()).getLeft(), e -> entry.getValue().open(e.getWhoClicked()));
+            pageItems.add(slot, guiItem);
         }
 
-        mainGui.addPane(filesPane);
-        mainGui.setOnTopClick(event -> event.setCancelled(true));
+        // Add all items without a specified slot to the earliest available slot
+        for (Map.Entry<File, PaginatedGui> entry : files.entrySet()) {
+            if (getItemStack(entry.getKey()).getRight() != -1) continue;
+            pageItems.add(new GuiItem(getItemStack(entry.getKey()).getLeft(), e -> entry.getValue().open(e.getWhoClicked())));
+        }
+
+        mainGui.addItem(pageItems.stream().filter(Objects::nonNull).toArray(GuiItem[]::new));
+
+        if (mainGui.getPagesNum() > 1) {
+            mainGui.setItem(6, 2, new GuiItem((OraxenItems.exists("arrow_previous_icon")
+                    ? new ItemBuilder(Material.ARROW).setDisplayName(AdventureUtils.parseLegacyThroughMiniMessage("<gray>Previous page"))
+                    : OraxenItems.getItemById("arrow_previous_icon")).build(), event -> mainGui.previous()
+            ));
+
+            mainGui.setItem(6, 8, new GuiItem((OraxenItems.exists("arrow_next_icon")
+                    ? new ItemBuilder(Material.ARROW).setDisplayName(AdventureUtils.parseLegacyThroughMiniMessage("<gray>Next page"))
+                    : OraxenItems.getItemById("arrow_next_icon")).build(), event -> mainGui.next()
+            ));
+        }
+
+        mainGui.setItem(6, 5, new GuiItem((OraxenItems.exists("exit_icon")
+                ? new ItemBuilder(Material.BARRIER).setDisplayName(AdventureUtils.parseLegacyThroughMiniMessage("<red>Exit"))
+                : OraxenItems.getItemById("exit_icon")).build(), event -> event.getWhoClicked().closeInventory())
+        );
+
         return mainGui;
     }
 
-    private int getUnusedSlot(int i, Set<Integer> usedSlots) {
-        int slot = usedSlots.contains(i) ? getUnusedSlot(i + 1, usedSlots) : i;
-        usedSlots.add(slot);
-        return slot;
-    }
+    private PaginatedGui createSubGUI(final String fileName, final List<ItemBuilder> items) {
+        final PaginatedGui gui = Gui.paginated().rows(6).pageSize(45).title(AdventureUtils.MINI_MESSAGE.deserialize(settings.getString(
+                        String.format("oraxen_inventory.menu_layout.%s.title", Utils.removeExtension(fileName)), Settings.ORAXEN_INV_TITLE.toString())
+                .replace("<main_menu_title>", Settings.ORAXEN_INV_TITLE.toString()))).create();
+        gui.disableAllInteractions();
 
-    private ChestGui createSubGUI(final String fileName, final List<ItemBuilder> items) {
-        final int rows = Math.min((items.size() - 1) / 9 + 2, 6);
-        final ChestGui gui = new ChestGui(6, settings.getString(
-                String.format("oraxen_inventory.menu_layout.%s.title", Utils.removeExtension(fileName)), Settings.ORAXEN_INV_TITLE.toString())
-                .replace("<main_menu_title>", Settings.ORAXEN_INV_TITLE.toString()));
-        final PaginatedPane pane = new PaginatedPane(9, rows);
+        for (ItemBuilder builder : items) {
+            if (builder == null) continue;
+            ItemStack itemStack = builder.build();
+            if (itemStack == null || itemStack.getType().isAir()) continue;
 
-        for (int i = 0; i < (items.size() - 1) / 45 + 1; i++) {
-            final List<ItemStack> itemStackList = extractPageItems(items, i);
-            final StaticPane staticPane = new StaticPane(9, Math.min((itemStackList.size() - 1) / 9 + 1, 5));
-            for (int itemIndex = 0; itemIndex < itemStackList.size(); itemIndex++) {
-                final ItemStack oraxenItem = itemStackList.get(itemIndex);
-                staticPane.addItem(new GuiItem(oraxenItem,
-                                event -> event.getWhoClicked().getInventory().addItem(ItemUpdater.updateItem(oraxenItem))),
-                        itemIndex % 9, itemIndex / 9);
-            }
-            pane.addPane(i, staticPane);
+            GuiItem guiItem = new GuiItem(itemStack);
+            guiItem.setAction(e -> e.getWhoClicked().getInventory().addItem(ItemUpdater.updateItem(guiItem.getItemStack())));
+            gui.addItem(guiItem);
         }
 
+        ItemStack nextPage = (Settings.ORAXEN_INV_NEXT_ICON.getValue() == null
+                ? new ItemBuilder(Material.ARROW) : OraxenItems.getItemById(Settings.ORAXEN_INV_NEXT_ICON.toString()))
+                .setDisplayName("Next Page").build();
+        ItemStack previousPage = (Settings.ORAXEN_INV_PREVIOUS_ICON.getValue() == null
+                ? new ItemBuilder(Material.ARROW) : OraxenItems.getItemById(Settings.ORAXEN_INV_PREVIOUS_ICON.toString()))
+                .setDisplayName("Previous Page").build();
+        ItemStack exitIcon = (Settings.ORAXEN_INV_EXIT.getValue() == null
+                ? new ItemBuilder(Material.BARRIER) : OraxenItems.getItemById(Settings.ORAXEN_INV_EXIT.toString()))
+                .setDisplayName("Exit").build();
 
-        //page selection
-        final StaticPane back = new StaticPane(2, 5, 1, 1);
-        final StaticPane forward = new StaticPane(6, 5, 1, 1);
-        final StaticPane exit = new StaticPane(4, 5, 9, 1);
+        if (gui.getPagesNum() > 1) {
+            gui.setItem(6, 2, new GuiItem(previousPage, event -> gui.previous()));
+            gui.setItem(6, 8, new GuiItem(nextPage, event -> gui.next()));
+        }
 
-        back.addItem(new GuiItem((OraxenItems.getItemById("arrow_previous_icon") == null
-                ? new ItemBuilder(Material.ARROW)
-                : OraxenItems.getItemById("arrow_previous_icon")).build(), event -> {
-            pane.setPage(pane.getPage() - 1);
+        gui.setItem(6, 5, new GuiItem(exitIcon, event -> mainGui.open(event.getWhoClicked())
+        ));
 
-            if (pane.getPage() == 0) back.setVisible(false);
-
-            forward.setVisible(true);
-            gui.update();
-        }), 0, 0);
-
-        back.setVisible(false);
-
-        forward.addItem(new GuiItem((OraxenItems.getItemById("arrow_next_icon") == null
-                ? new ItemBuilder(Material.ARROW)
-                : OraxenItems.getItemById("arrow_next_icon")).build(), event -> {
-            pane.setPage(pane.getPage() + 1);
-            if (pane.getPage() == pane.getPages() - 1) forward.setVisible(false);
-
-            back.setVisible(true);
-            gui.update();
-        }), 0, 0);
-        if (pane.getPages() <= 1)
-            forward.setVisible(false);
-
-        exit.addItem(new GuiItem((OraxenItems.getItemById("exit_icon") == null
-                ? new ItemBuilder(Material.BARRIER)
-                : OraxenItems.getItemById("exit_icon"))
-                .build(), event ->
-                mainGui.show(event.getWhoClicked())
-        ), 0, 0);
-
-        gui.addPane(back);
-        gui.addPane(forward);
-        gui.addPane(exit);
-        gui.addPane(pane);
-        gui.setOnGlobalClick(event -> event.setCancelled(true));
         return gui;
-    }
-
-    private List<ItemStack> extractPageItems(final List<ItemBuilder> items, final int page) {
-        final List<ItemStack> output = new ArrayList<>();
-        for (int i = page * 45; i < (page + 1) * 45 && i < items.size(); i++) output.add(items.get(i).build());
-        return output;
     }
 
     private Pair<ItemStack, Integer> getItemStack(final File file) {
@@ -155,10 +135,9 @@ public class ItemsView {
             }
         }
 
-        if (itemStack == null)
-            // avoid possible bug if isOraxenItems is available but can't be an itemstack
-            itemStack = new ItemBuilder(Material.PAPER).setDisplayName(displayName).build();
-
-        return Pair.of(itemStack, settings.getInt(String.format("oraxen_inventory.menu_layout.%s.slot", Utils.removeExtension(file.getName())), -1) - 1);
+        // avoid possible bug if isOraxenItems is available but can't be an itemstack
+        if (itemStack == null) itemStack = new ItemBuilder(Material.PAPER).setDisplayName(displayName).build();
+        int slot = settings.getInt(String.format("oraxen_inventory.menu_layout.%s.slot", Utils.removeExtension(file.getName())), -1) - 1;
+        return Pair.of(itemStack, Math.max(slot, -1));
     }
 }

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -339,6 +339,7 @@ Misc:
 
 oraxen_inventory:
   main_menu_title: "<shift:-18><glyph:menu_items><shift:-193>"
+  main_menu_type: PAGINATED # PAGINATED, SCROLL_HORIZONTAL, SCROLL_VERTICAL
   menu_rows: 6
   #exit_icon: exit_icon
   #next_page_icon: next_page_icon

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -340,6 +340,9 @@ Misc:
 oraxen_inventory:
   main_menu_title: "<shift:-18><glyph:menu_items><shift:-193>"
   menu_rows: 6
+  #exit_icon: exit_icon
+  #next_page_icon: next_page_icon
+  #previous_page_icon: previous_page_icon
   menu_layout:
     armors:
       slot: 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pluginVersion=1.169.0
-idofrontVersion=0.20.14
+pluginVersion=1.170.0
+idofrontVersion=0.21.12

--- a/v1_18_R1/src/main/java/io/th0rgal/oraxen/nms/v1_18_R1/NMSHandler.java
+++ b/v1_18_R1/src/main/java/io/th0rgal/oraxen/nms/v1_18_R1/NMSHandler.java
@@ -56,6 +56,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
 
     @Override
+    public boolean noteblockUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
+    public boolean tripwireUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
     public ItemStack copyItemNBTTags(@NotNull ItemStack oldItem, @NotNull ItemStack newItem) {
         CompoundTag oldTag = CraftItemStack.asNMSCopy(oldItem).getOrCreateTag();
         net.minecraft.world.item.ItemStack newNmsItem = CraftItemStack.asNMSCopy(newItem);

--- a/v1_18_R2/src/main/java/io/th0rgal/oraxen/nms/v1_18_R2/NMSHandler.java
+++ b/v1_18_R2/src/main/java/io/th0rgal/oraxen/nms/v1_18_R2/NMSHandler.java
@@ -65,6 +65,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
 
     @Override
+    public boolean noteblockUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
+    public boolean tripwireUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
     public ItemStack copyItemNBTTags(@NotNull ItemStack oldItem, @NotNull ItemStack newItem) {
         CompoundTag oldTag = CraftItemStack.asNMSCopy(oldItem).getOrCreateTag();
         net.minecraft.world.item.ItemStack newNmsItem = CraftItemStack.asNMSCopy(newItem);

--- a/v1_19_R1/src/main/java/io/th0rgal/oraxen/nms/v1_19_R1/NMSHandler.java
+++ b/v1_19_R1/src/main/java/io/th0rgal/oraxen/nms/v1_19_R1/NMSHandler.java
@@ -7,9 +7,7 @@ import io.netty.channel.*;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.GlyphHandlers;
-import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
@@ -17,7 +15,6 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -45,9 +42,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R1.inventory.CraftItemStack;
@@ -71,6 +65,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private final Map<Channel, ChannelHandler> encoder = Collections.synchronizedMap(new WeakHashMap<>());
     private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
+
+    @Override
+    public boolean noteblockUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
+    public boolean tripwireUpdatesDisabled() {
+        return false;
+    }
 
     @Override
     public ItemStack copyItemNBTTags(@NotNull ItemStack oldItem, @NotNull ItemStack newItem) {

--- a/v1_19_R2/src/main/java/io.th0rgal.oraxen.nms.v1_19_R2/NMSHandler.java
+++ b/v1_19_R2/src/main/java/io.th0rgal.oraxen.nms.v1_19_R2/NMSHandler.java
@@ -7,16 +7,13 @@ import io.netty.channel.*;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.GlyphHandlers;
-import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -45,9 +42,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R2.inventory.CraftItemStack;
@@ -71,6 +65,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private final Map<Channel, ChannelHandler> encoder = Collections.synchronizedMap(new WeakHashMap<>());
     private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
+
+    @Override
+    public boolean noteblockUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
+    public boolean tripwireUpdatesDisabled() {
+        return false;
+    }
 
     @Override
     public ItemStack copyItemNBTTags(@NotNull ItemStack oldItem, @NotNull ItemStack newItem) {

--- a/v1_19_R3/src/main/java/io.th0rgal.oraxen.nms.v1_19_R3/NMSHandler.java
+++ b/v1_19_R3/src/main/java/io.th0rgal.oraxen.nms.v1_19_R3/NMSHandler.java
@@ -7,16 +7,13 @@ import io.netty.channel.*;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.nms.GlyphHandlers;
-import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.kyori.adventure.text.Component;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -46,9 +43,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
@@ -72,6 +66,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private final Map<Channel, ChannelHandler> encoder = Collections.synchronizedMap(new WeakHashMap<>());
     private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
+
+    @Override
+    public boolean noteblockUpdatesDisabled() {
+        return false;
+    }
+
+    @Override
+    public boolean tripwireUpdatesDisabled() {
+        return false;
+    }
 
     @Override
     public ItemStack copyItemNBTTags(@NotNull ItemStack oldItem, @NotNull ItemStack newItem) {


### PR DESCRIPTION
**[New]**
- `restricted_rotation` for furniture
  * STRICT restricts to 8 rotations **(Default)**
  * VERY_STRICT restricts rotation to 4 rotations

**[Changes]**
- Oraxen is now enabled during server STARTUP instead of POSTWORLD
- Oraxen Inventory now supports pages & scrolling
  * Arrow icons can be defined in settings.yml `oraxen_inventory.next_page_icon|previous_page_icon`
  * `main_menu_type: PAGINATED # PAGINATED, SCROLL_HORIZONTAL, SCROLL_VERTICAL`

**[API]**
- Added OraxenPackPreUploadEvent
- Added getAction to OraxenNoteBlockInteractEvent

**[Fixes]**
- MipMap-level being lowered when importing font-textures
- Duplicate fonts not properly merging some properties
- LabyMod causing pack to not load due to shader incompatibility
- LimitedPlacing with ALLOW as type not allowing placement if lists are empty
- LimitedPlacing#oraxen_blocks not working properly
- Nullpointer in Villager Trades
- Buggy behaviour with middle-click feature in Creative Inventory
- NoteBlocks sometimes dropping when breaking custom blocks "too fast"
- / not allowed in modelname regex when `auto_generated_models_follow_texture_path` is enabled
- Making unstackable item not unstackable anymore not updating old items