### PR TITLE
Fix nms.NMSHandlers.getHandler() is null error on folia

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandlers.java
@@ -17,10 +17,12 @@ public class NMSHandlers {
 
     @Nullable
     public static NMSHandler getHandler() {
-        if (handler != null) return handler;
-        else setup();
+        if (handler == null) {
+            setup();
+        }
         return handler;
     }
+    
 
     public static String getVersion() {
         return version;


### PR DESCRIPTION
There is a error that occurs because of nms.NMSHandlers.getHandler() is being null and cannot use some crucial commands. This change fixes it but even though still the plugin generates a wrong resource pack after this issue has been solved.