### PR TITLE
Remove is standing inside check for Stringblock placement

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -404,7 +404,7 @@ public class StringBlockMechanicListener implements Listener {
                 blockPlaceEvent.setCancelled(true);
             else blockAbove.setType(Material.TRIPWIRE);
         }
-        if (BlockHelpers.isStandingInside(player, target) || !ProtectionLib.canBuild(player, target.getLocation())) blockPlaceEvent.setCancelled(true);
+        if (!ProtectionLib.canBuild(player, target.getLocation())) blockPlaceEvent.setCancelled(true);
         //if (player.getGameMode() == GameMode.ADVENTURE) blockPlaceEvent.setCancelled(true);
         if (!worldHeightRange.contains(target.getY()))
             blockPlaceEvent.setCancelled(true);


### PR DESCRIPTION
Before if you try to put a custom stringblock on where you're standing it wouldn't let you because there was a isStandingInside block check, it doesn't need a check for that if the stringblock is a block you can walk through