### PR TITLE
fix: fix ModelEngine model not render

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -560,7 +560,7 @@ public class FurnitureMechanic extends Mechanic {
     void spawnModelEngineFurniture(Entity entity) {
         ModeledEntity modelEntity = ModelEngineAPI.getOrCreateModeledEntity(entity);
         ActiveModel activeModel = ModelEngineAPI.createActiveModel(getModelEngineID());
-        ModelEngineUtils.addModel(modelEntity, activeModel, false);
+        ModelEngineUtils.addModel(modelEntity, activeModel, true);
         ModelEngineUtils.setRotationLock(modelEntity, false);
         modelEntity.setBaseEntityVisible(false);
     }


### PR DESCRIPTION
If the entity hitbox not overrided, the entity will be judged as blocked, so the model will be skip render by the Network-Optimization options of ModelEngine.