### PR TITLE
Fix sound for when a block is inside a furniture and you break it

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSoundListener.java
@@ -65,7 +65,7 @@ public class FurnitureSoundListener implements Listener {
         }
 
         if (block.getBlockData().getSoundGroup().getBreakSound() != Sound.BLOCK_STONE_BREAK) return;
-        if (OraxenFurniture.isFurniture(block)) return;
+        if (OraxenFurniture.isFurniture(block) && block.getType() == Material.BARRIER || block.isEmpty()) return;
 
         if (!event.isCancelled() && ProtectionLib.canBreak(event.getPlayer(), location))
             BlockHelpers.playCustomBlockSound(location, VANILLA_STONE_BREAK, VANILLA_BREAK_VOLUME, VANILLA_BREAK_PITCH);


### PR DESCRIPTION
If you break a block and said block was inside a furniture it won't play any block break sound, this PR fixes that.