### PR TITLE
fix wood hit sound again (forgot to move curly braces)

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockSoundListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockSoundListener.java
@@ -79,13 +79,13 @@ public class NoteBlockSoundListener implements Listener {
                         block.setType(Material.AIR, false), 1);
                 return;
             }
-            if (soundGroup.getHitSound() != Sound.BLOCK_WOOD_HIT) return;
-            if (breakerPlaySound.containsKey(location)) return;
-
-            BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
-                    BlockHelpers.playCustomBlockSound(location, VANILLA_WOOD_HIT, VANILLA_HIT_VOLUME, VANILLA_HIT_PITCH), 2L, 4L);
-            breakerPlaySound.put(location, task);
         }
+        if (soundGroup.getHitSound() != Sound.BLOCK_WOOD_HIT) return;
+        if (breakerPlaySound.containsKey(location)) return;
+
+        BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () ->
+                BlockHelpers.playCustomBlockSound(location, VANILLA_WOOD_HIT, VANILLA_HIT_VOLUME, VANILLA_HIT_PITCH), 2L, 4L);
+        breakerPlaySound.put(location, task);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
it would only run the wood hit sound if it was a noteblock or mushroom stem because I forgot to move the curly braces before when I was dealing with a conflict