### PR TITLE
call World#playEffect on block break only if server is 1.20 or above

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
@@ -275,7 +275,7 @@ public class OraxenBlocks {
             World world = block.getWorld();
 
             world.sendGameEvent(player, GameEvent.BLOCK_DESTROY, loc.toVector());
-            world.playEffect(loc, Effect.STEP_SOUND, VersionUtil.atOrAbove("1.20") ? block.getBlockData() : null);
+            if (VersionUtil.atOrAbove("1.20")) world.playEffect(loc, Effect.STEP_SOUND, block.getBlockData());
         }
         if (drop != null) drop.spawns(loc, itemInHand);
 


### PR DESCRIPTION
Fixes "java.lang.IllegalArgumentException: Wrong kind of data for this effect!" error for 1.19 servers, even though the data field is annotated as nullable it will still throw that error