### PR TITLE
Check once if it is a Paper (or Fork) or Folia server.

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -10,6 +10,8 @@ import java.util.*;
 
 public class VersionUtil {
     private static final Map<NMSVersion, Map<Integer, MinecraftVersion>> versionMap = new HashMap<>();
+    private static int IS_PAPER = -1;
+    private static int IS_FOLIA = -1;
 
     public enum NMSVersion {
         v1_20_R3,
@@ -28,6 +30,8 @@ public class VersionUtil {
     }
 
     static {
+        initializePaperCheck();
+        initializeFoliaCheck();
         versionMap.put(NMSVersion.v1_20_R3, Map.of(11, new MinecraftVersion("1.20.3"), 12, new MinecraftVersion("1.20.4")));
         versionMap.put(NMSVersion.v1_20_R2, Map.of(10, new MinecraftVersion("1.20.2")));
         versionMap.put(NMSVersion.v1_20_R1, Map.of(8, new MinecraftVersion("1.20"), 9, new MinecraftVersion("1.20.1")));
@@ -55,23 +59,35 @@ public class VersionUtil {
      * @throws IllegalArgumentException if server is null
      */
     public static boolean isPaperServer() {
+        return IS_PAPER == 1;
+    }
+
+    private static void initializePaperCheck() {
         Server server = Bukkit.getServer();
         Validate.notNull(server, "Server cannot be null");
-        if (server.getName().equalsIgnoreCase("Paper")) return true;
-
         try {
             Class.forName("com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent");
-            return true;
+            IS_PAPER = 1;
         } catch (ClassNotFoundException e) {
-            return false;
+            IS_PAPER = 0;
         }
     }
 
     public static boolean isFoliaServer() {
+        return IS_FOLIA == 1;
+    }
+
+    private static void initializeFoliaCheck() {
         Server server = Bukkit.getServer();
         Validate.notNull(server, "Server cannot be null");
-
-        return server.getName().equalsIgnoreCase("Folia");
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            IS_PAPER = 1;
+            IS_FOLIA = 1;
+        } catch (ClassNotFoundException e) {
+            IS_PAPER = 0;
+            IS_FOLIA = 0;
+        }
     }
 
     public static boolean isSupportedVersion(@NotNull NMSVersion serverVersion, @NotNull NMSVersion... supportedVersions) {


### PR DESCRIPTION
Currently, every time we check if it's a Paper server, we check if the class exists. The server does not change when it is running, so if it is yes it will remain YES. I also focused on checking Folia. Also I removed the String check, even if it is much faster than a Class check, we do not need to check later. Especially since forks like Purpur lose performance because it checks the class as a result.