### PR TITLE
fix: remove mining fatigue, cancel task if BlockPlaceEvent is cancelled

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerManager.java
@@ -89,7 +89,7 @@ public class BreakerManager {
                 activeBreakerData.sendBreakProgress();
 
                 for (ActiveBreakerData alterBreakerData : activeBreakerDataMap.values()) {
-                    if (alterBreakerData.breaker.getUniqueId().equals(breakerUUID)) continue;
+                    if (!alterBreakerData.breaker.getUniqueId().equals(breakerUUID)) continue;
                     if (!alterBreakerData.location.equals(activeBreakerData.location)) continue;
 
                     OraxenPlugin.get().breakerManager().stopBlockBreak(alterBreakerData.breaker);
@@ -99,7 +99,7 @@ public class BreakerManager {
                 block.setType(Material.AIR);
                 activeBreakerData.cancelTasks();
                 this.activeBreakerDataMap.remove(breakerUUID);
-            }
+            } else activeBreakerData.cancelTasks();
         }, 1,1);
     }
 


### PR DESCRIPTION
Fixes removing mining fatigue when player fully mined the block
Cancel the task if BlockPlaceEvent is cancelled, before it would keep the timer running