### PR TITLE
fix: tall blocks breaking when attempting to place custom block while inside tall block

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/CustomBlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/CustomBlockHelpers.java
@@ -18,6 +18,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.sign.Side;
 import org.bukkit.entity.FallingBlock;
@@ -44,6 +45,7 @@ public class CustomBlockHelpers {
             else if (Tag.DOORS.isTagged(target.getType())) return;
         }
 
+        final Block blockBelow = target.getRelative(BlockFace.DOWN);
         final Block blockAbove = target.getRelative(BlockFace.UP);
         final BlockData oldData = target.getBlockData();
         Enum<InteractionResult> result = null;
@@ -57,7 +59,7 @@ public class CustomBlockHelpers {
         }
 
         if (newData != null)
-            if (result == null) target.setBlockData(newData);
+            if (result == null) target.setBlockData(newData, false);
             else target.setBlockData(target.getBlockData(), false);
 
         final BlockPlaceEvent blockPlaceEvent = new BlockPlaceEvent(target, target.getState(), placedAgainst, item, player, true, hand);
@@ -110,9 +112,18 @@ public class CustomBlockHelpers {
                 return;
             }
 
+            BlockData blockBelowData = blockBelow.getBlockData();
+            if (oldData instanceof Bisected) {
+                if (blockBelowData instanceof Bisected)
+                    blockBelow.breakNaturally(true);
+            }
+
+            if (!blockBelow.canPlace(blockBelowData)) blockBelow.breakNaturally(true);
+            if (!blockAbove.canPlace(blockAbove.getBlockData())) blockAbove.breakNaturally(true);
+
             // Handle Falling NoteBlock-Mechanic blocks
             if (newMechanic instanceof NoteBlockMechanic noteMechanic) {
-                if (noteMechanic.isFalling() && target.getRelative(BlockFace.DOWN).getType().isAir()) {
+                if (noteMechanic.isFalling() && blockBelow.getType().isAir()) {
                     Location fallingLocation = BlockHelpers.toCenterBlockLocation(target.getLocation());
                     OraxenBlocks.remove(target.getLocation(), null);
                     if (fallingLocation.getNearbyEntitiesByType(FallingBlock.class, 0.25).isEmpty())

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/CustomBlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/CustomBlockHelpers.java
@@ -113,9 +113,8 @@ public class CustomBlockHelpers {
             }
 
             BlockData blockBelowData = blockBelow.getBlockData();
-            if (oldData instanceof Bisected) {
-                if (blockBelowData instanceof Bisected)
-                    blockBelow.breakNaturally(true);
+            if (oldData instanceof Bisected && blockBelowData instanceof Bisected) {
+                blockBelow.breakNaturally(true);
             }
 
             if (!blockBelow.canPlace(blockBelowData)) blockBelow.breakNaturally(true);


### PR DESCRIPTION
attempting to place custom block while the player is standing inside the tall block would actually break the tall block below and keep the other half of the tall block flying on the air, made a fix for it here