### PR TITLE
Add NumberFormatException to hex2Rgb method

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -45,7 +45,7 @@ public class CommandsManager {
                 .register();
     }
 
-    private Color hex2Rgb(String colorStr) {
+    private Color hex2Rgb(String colorStr) throws NumberFormatException {
         return Color.fromRGB(
                 Integer.valueOf(colorStr.substring(1, 3), 16),
                 Integer.valueOf(colorStr.substring(3, 5), 16),
@@ -61,7 +61,7 @@ public class CommandsManager {
                         Color hexColor;
                         try {
                             hexColor = hex2Rgb((String) args.get("color"));
-                        } catch (StringIndexOutOfBoundsException e) {
+                        } catch (StringIndexOutOfBoundsException | NumberFormatException e) {
                             Message.DYE_WRONG_COLOR.send(sender);
                             return;
                         }


### PR DESCRIPTION
The hex2Rgb method in the CommandsManager class has thrown an NumberFormatException before this change and caused an error while executing the command. This issue should be fixed with this commit.

**Example:** /oraxen dye cyan

**Exception thrown before:**

[21:48:00 INFO]: Splatcrafter issued server command: /oraxen dye cyan
[21:48:00 ERROR]: [CommandAPI] Unhandled exception executing '/oraxen dye cyan'
java.lang.NumberFormatException: For input string: "ya" under radix 16
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
        at java.lang.Integer.parseInt(Integer.java:668) ~[?:?]
        at java.lang.Integer.valueOf(Integer.java:973) ~[?:?]
        at io.th0rgal.oraxen.commands.CommandsManager.hex2Rgb(CommandsManager.java:50) ~[oraxen-1.173.0.jar:?]
        at io.th0rgal.oraxen.commands.CommandsManager.lambda$getDyeCommand$1(CommandsManager.java:63) ~[oraxen-1.173.0.jar:?]
        at dev.jorel.commandapi.executors.CommandExecutor.run(CommandExecutor.java:49) ~[?:?]
        at dev.jorel.commandapi.executors.NormalExecutor.executeWith(NormalExecutor.java:44) ~[?:?]
        at dev.jorel.commandapi.CommandAPIExecutor.execute(CommandAPIExecutor.java:137) ~[?:?]
        at dev.jorel.commandapi.CommandAPIExecutor.execute(CommandAPIExecutor.java:124) ~[?:?]
        at dev.jorel.commandapi.CommandAPIExecutor.execute(CommandAPIExecutor.java:91) ~[?:?]
        at dev.jorel.commandapi.CommandAPIHandler.lambda$generateCommand$0(CommandAPIHandler.java:258) ~[?:?]
        at com.mojang.brigadier.CommandDispatcher.execute(CommandDispatcher.java:265) ~[paper-1.20.1.jar:?]
        at net.minecraft.commands.Commands.performCommand(Commands.java:324) ~[?:?]
        at net.minecraft.commands.Commands.performCommand(Commands.java:308) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.performChatCommand(ServerGamePacketListenerImpl.java:2301) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$20(ServerGamePacketListenerImpl.java:2261) ~[?:?]
        at net.minecraft.util.thread.BlockableEventLoop.lambda$submitAsync$0(BlockableEventLoop.java:59) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1339) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:197) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1316) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1309) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1287) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1175) ~[paper-1.20.1.jar:git-Paper-108]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:318) ~[paper-1.20.1.jar:git-Paper-108]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]