### PR TITLE
1.176.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ increase oraxen features.
 
 ## Contributing
 If you want to contribute to Oraxen, you can do so by creating a pull request.\
-You should make a pull-request to the `develop` branch.\
+You should make a pull-request to the `develop` branch.
 1. Fork Oraxen on GitHub
 2. Clone your forked repository (`git clone`)
 3. Create your feature branch (`git checkout -b my-feature`)
@@ -152,7 +152,8 @@ compileOnly 'io.th0rgal:oraxen:VERSION'
 </dependency>
 ```
 </details>
-Snapshot builds are also available at [https://repo.oraxen.com/snapshots](https://repo.oraxen.com/snapshots). \
+
+Snapshot builds are also available at [https://repo.oraxen.com/snapshots](https://repo.oraxen.com/snapshots).
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,7 +178,7 @@ tasks {
     shadowJar {
         SUPPORTED_VERSIONS.forEach { dependsOn(":${it.nmsVersion}:reobfJar") }
 
-        //archiveClassifier = null
+        archiveClassifier = null
         relocate("org.bstats", "io.th0rgal.oraxen.shaded.bstats")
         relocate("dev.triumphteam.gui", "io.th0rgal.oraxen.shaded.triumphteam.gui")
         relocate("com.jeff_media", "io.th0rgal.oraxen.shaded.jeff_media")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ val spigotPluginPath = project.findProperty("oraxen_spigot_plugin_path")?.toStri
 val pluginVersion: String by project
 val commandApiVersion = "9.5.0-SNAPSHOT"
 val adventureVersion = "4.17.0"
-val platformVersion = "4.3.2"
+val platformVersion = "4.3.3"
 val googleGsonVersion = "2.10.1"
 val apacheLang3Version = "3.14.0"
 group = "io.th0rgal"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,7 +129,7 @@ allprojects {
         implementation(files("../libs/CommandAPI-9.5.0-SNAPSHOT.jar"))
         //implementation("dev.jorel:commandapi-bukkit-shade:$commandApiVersion")
         implementation("org.bstats:bstats-bukkit:3.0.0")
-        implementation("io.th0rgal:protectionlib:1.5.7")
+        implementation("io.th0rgal:protectionlib:1.5.8")
         implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
         implementation("com.jeff-media:custom-block-data:2.2.2")
         implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,7 +172,7 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.18.2")
+        minecraftVersion("1.19.4")
     }
 
     shadowJar {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.*
+import kotlin.io.path.Path
+import kotlin.io.path.listDirectoryEntries
 
 plugins {
     id("java")
@@ -250,6 +252,10 @@ if (pluginPath != null) {
         val copyJarTask = register<Copy>("copyJar") {
             this.doNotTrackState("Overwrites the plugin jar to allow for easier reloading")
             dependsOn(shadowJar, jar)
+            Path(pluginPath).listDirectoryEntries()
+                .filter { it.fileName.toString().matches("oraxen-.*.jar".toRegex()) }
+                .filterNot { it.fileName.toString().endsWith("$pluginVersion.jar") }
+                .forEach { delete(it) }
             from(defaultPath)
             into(pluginPath)
             doLast { println("Copied to plugin directory $pluginPath") }

--- a/core/src/main/java/io/th0rgal/oraxen/commands/AdminCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/AdminCommand.java
@@ -34,7 +34,7 @@ public class AdminCommand {
                     } else {
                         Location loc = (Location) args.getOptional("location").orElse(player.getLocation());
                         String type = (String) args.get("type");
-                        int radius = (int) args.getOptional("radius").orElse(10);
+                        int radius = (int) args.getOptional("radius").orElse(1);
                         boolean isRandom = (boolean) args.getOptional("random").orElse(false);
                         for (Block block : getBlocks(loc, radius, isRandom)) {
                             if (type == null) continue;

--- a/core/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -96,7 +96,7 @@ public enum Message {
     public void send(final CommandSender sender, final TagResolver... placeholders) {
         if (sender == null) return;
         String lang = OraxenPlugin.get().getConfigsManager().getLanguage().getString(path);
-        if (lang == null) return;
+        if (lang == null || lang.isEmpty()) return;
         OraxenPlugin.get().getAudience().sender(sender).sendMessage(
                 AdventureUtils.MINI_MESSAGE.deserialize(lang, TagResolver.resolver(placeholders))
         );

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -57,9 +57,9 @@ public class FontManager {
                 }
             }, HashMap::putAll);
         }
-        glyphMap = new HashMap<>();
-        glyphByPlaceholder = new HashMap<>();
-        reverse = new HashMap<>();
+        glyphMap = new LinkedHashMap<>();
+        glyphByPlaceholder = new LinkedHashMap<>();
+        reverse = new LinkedHashMap<>();
         fontEvents = new FontEvents(this);
         fonts = new HashSet<>();
         loadGlyphs(configsManager.parseGlyphConfigs());

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -145,8 +145,10 @@ public class ItemBuilder {
             patternColor = tropicalFishBucketMeta.getPatternColor();
         }
 
-        if (itemMeta.hasDisplayName())
-            displayName = itemMeta.getDisplayName();
+        if (itemMeta.hasDisplayName()) {
+            if (VersionUtil.isPaperServer()) displayName = AdventureUtils.MINI_MESSAGE.serialize(itemMeta.displayName());
+            else displayName = itemMeta.getDisplayName();
+        }
 
         unbreakable = itemMeta.isUnbreakable();
         unstackable = itemMeta.getPersistentDataContainer().has(UNSTACKABLE_KEY, DataType.UUID);
@@ -162,8 +164,10 @@ public class ItemBuilder {
         if (itemMeta.hasCustomModelData())
             customModelData = itemMeta.getCustomModelData();
 
-        if (itemMeta.hasLore())
-            lore = itemMeta.getLore();
+        if (itemMeta.hasLore()) {
+            if (VersionUtil.isPaperServer()) lore = itemMeta.lore().stream().map(AdventureUtils.MINI_MESSAGE::serialize).toList();
+            else lore = itemMeta.getLore();
+        }
 
         persistentDataContainer = itemMeta.getPersistentDataContainer();
 
@@ -538,7 +542,8 @@ public class ItemBuilder {
         PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
         if (!VersionUtil.atOrAbove("1.20.5") && displayName != null) {
             pdc.set(ORIGINAL_NAME_KEY, DataType.STRING, displayName);
-            itemMeta.setDisplayName(displayName);
+            if (VersionUtil.isPaperServer()) itemMeta.displayName(AdventureUtils.MINI_MESSAGE.deserialize(displayName));
+            else itemMeta.setDisplayName(displayName);
         }
 
         if (itemFlags != null)
@@ -562,7 +567,8 @@ public class ItemBuilder {
             for (final Map.Entry<PersistentDataSpace, Object> dataSpace : persistentDataMap.entrySet())
                 pdc.set(dataSpace.getKey().namespacedKey(), (PersistentDataType<?, Object>) dataSpace.getKey().dataType(), dataSpace.getValue());
 
-        itemMeta.setLore(lore);
+        if (VersionUtil.isPaperServer()) itemMeta.lore(lore != null? lore.stream().map(AdventureUtils.MINI_MESSAGE::deserialize).toList() : null);
+        else itemMeta.setLore(lore);
 
         itemStack.setItemMeta(itemMeta);
         finalItemStack = itemStack;

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -96,7 +96,7 @@ public class ItemParser {
     public static String parseComponentItemName(@Nullable String miniString) {
         if (miniString == null) return null;
         if (miniString.isEmpty()) return miniString;
-        Component component = AdventureUtils.MINI_MESSAGE.deserialize(miniString);
+        Component component = AdventureUtils.MINI_MESSAGE.deserialize(miniString.replace("§", "\\§"));
         // If it has no formatting, set color to WHITE to prevent Italic
         return AdventureUtils.LEGACY_SERIALIZER.serialize(component.colorIfAbsent(NamedTextColor.WHITE));
     }
@@ -120,11 +120,10 @@ public class ItemParser {
     }
 
     private ItemBuilder applyConfig(ItemBuilder item) {
-        if (!VersionUtil.atOrAbove("1.20.5"))
-            item.setDisplayName(parseComponentItemName(section.getString("displayname", "")));
+        if (!VersionUtil.atOrAbove("1.20.5")) item.setDisplayName(AdventureUtils.parseMiniMessage(section.getString("displayname", "")));
 
         //if (section.contains("type")) item.setType(Material.getMaterial(section.getString("type", "PAPER")));
-        if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(ItemParser::parseComponentLore).toList());
+        if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(AdventureUtils::parseMiniMessage).toList());
         if (section.contains("unbreakable")) item.setUnbreakable(section.getBoolean("unbreakable", false));
         if (section.contains("unstackable")) item.setUnstackable(section.getBoolean("unstackable", false));
         if (section.contains("color")) item.setColor(Utils.toColor(section.getString("color", "#FFFFFF")));
@@ -146,8 +145,8 @@ public class ItemParser {
         else if (section.contains("max_stack_size")) item.setMaxStackSize(Math.min(Math.max(section.getInt("max_stack_size"), 1), 99));
         if (item.hasMaxStackSize() && item.getMaxStackSize() == 1) item.setUnstackable(true);
 
-        if (section.contains("itemname")) item.setItemName(parseComponentItemName(section.getString("itemname", "")));
-        else item.setItemName(parseComponentItemName(section.getString("displayname", "")));
+        if (section.contains("itemname")) item.setItemName(AdventureUtils.parseMiniMessage(section.getString("itemname", "")));
+        else item.setItemName(AdventureUtils.parseMiniMessage(section.getString("displayname", "")));
 
         if (section.contains("enchantment_glint_override")) item.setEnchantmentGlindOverride(section.getBoolean("enchantment_glint_override"));
         if (section.contains("durability")) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
@@ -47,6 +47,7 @@ public class FoodMechanicListener implements Listener {
                 ItemStack itemInHand = event.getItem();
                 ItemUtils.subtract(itemInHand, 1);
                 event.setItem(itemInHand);
+                if (mechanic.hasReplacement()) inventory.addItem(mechanic.getReplacement());
 
 
                 if (mechanic.hasEffects() && Math.random() <= mechanic.getEffectProbability())
@@ -55,10 +56,7 @@ public class FoodMechanicListener implements Listener {
 
             player.setFoodLevel(player.getFoodLevel() + Math.min(mechanic.getHunger(), 20));
             player.setSaturation(player.getSaturation() + Math.min(mechanic.getSaturation(), 20));
-        }/* else {
-            if (itemStack.hasItemMeta() && itemStack.getItemMeta().hasFood() && player.getGameMode() != GameMode.CREATIVE && mechanic.hasReplacement())
-                inventory.addItem(mechanic.getReplacement());
-        }*/
+        }
 
 
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanicListener.java
@@ -11,7 +11,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
@@ -45,8 +44,9 @@ public class FoodMechanicListener implements Listener {
             event.setCancelled(true);
 
             if (player.getGameMode() != GameMode.CREATIVE) {
-                ItemStack itemInHand = (event.getHand() == EquipmentSlot.HAND ? inventory.getItemInMainHand() : inventory.getItemInOffHand());
+                ItemStack itemInHand = event.getItem();
                 ItemUtils.subtract(itemInHand, 1);
+                event.setItem(itemInHand);
 
 
                 if (mechanic.hasEffects() && Math.random() <= mechanic.getEffectProbability())

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -5,7 +5,6 @@ import com.google.gson.*;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.api.events.OraxenPackGeneratedEvent;
-import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.config.ResourcesManager;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.font.Font;
@@ -549,8 +548,7 @@ public class ResourcePack {
     private InputStream processJsonFile(File file) throws IOException {
         InputStream newStream;
         String content;
-        if (!file.exists())
-            return new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
+        if (!file.exists()) return new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
         try {
             content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
         } catch (IOException | NullPointerException e) {
@@ -570,18 +568,12 @@ public class ResourcePack {
     }
 
     private InputStream processJson(String content) {
-        InputStream newStream;
-        // Deserialize said component to a string to handle other tags like glyphs
-        String parsedContent = AdventureUtils.parseMiniMessage(AdventureUtils.parseLegacy(content), AdventureUtils.tagResolver("prefix", Message.PREFIX.toString()));
-        // Deserialize adventure component to legacy format due to resourcepacks not supporting adventure components
-        parsedContent = AdventureUtils.parseLegacyThroughMiniMessage(content);
-        newStream = new ByteArrayInputStream(parsedContent.getBytes(StandardCharsets.UTF_8));
-        try {
-            newStream.close();
+        String parsedContent = AdventureUtils.parseLegacyThroughMiniMessage(content).replace("\\<", "<");
+        try (InputStream newStream = new ByteArrayInputStream(parsedContent.getBytes(StandardCharsets.UTF_8))) {
+            return newStream;
         } catch (IOException e) {
             return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
         }
-        return newStream;
     }
 
     private String getZipFilePath(String path, String newFolder) throws IOException {

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
@@ -15,7 +15,10 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantInventory;
+import org.bukkit.inventory.Recipe;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -57,8 +60,9 @@ public class RecipesEventsManager implements Listener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onCrafted(PrepareItemCraftEvent event) {
         Recipe recipe = event.getRecipe();
+        CustomRecipe customRecipe = CustomRecipe.fromRecipe(recipe);
         Player player = (Player) event.getView().getPlayer();
-        if (!hasPermission(player, CustomRecipe.fromRecipe(recipe))) event.getInventory().setResult(null);
+        if (!hasPermission(player, customRecipe)) event.getInventory().setResult(null);
 
         ItemStack result = event.getInventory().getResult();
         if (result == null) return;
@@ -66,10 +70,9 @@ public class RecipesEventsManager implements Listener {
         boolean containsOraxenItem = Arrays.stream(event.getInventory().getMatrix()).anyMatch(OraxenItems::exists);
         if (!containsOraxenItem || recipe == null) return;
 
-        CustomRecipe current = new CustomRecipe(null, recipe.getResult(), Arrays.asList(event.getInventory().getMatrix()));
-        if (whitelistedCraftRecipes.stream().anyMatch(current::equals) || current.isValidDyeRecipe()) return;
+        if (whitelistedCraftRecipes.stream().anyMatch(customRecipe::equals) || customRecipe.isValidDyeRecipe()) return;
 
-        event.getInventory().setResult(null);
+        event.getInventory().setResult(customRecipe.getResult());
     }
 
     @EventHandler

--- a/core/src/main/java/io/th0rgal/oraxen/utils/Utils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/Utils.java
@@ -1,23 +1,20 @@
 package io.th0rgal.oraxen.utils;
 
-import io.th0rgal.oraxen.utils.logs.Logs;
+import dev.jorel.commandapi.wrappers.IntegerRange;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.text.DecimalFormat;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Consumer;
 
 public class Utils {
 
@@ -153,5 +150,29 @@ public class Utils {
 
         if (remainder > step / 2) roundedValue += step;
         return Float.parseFloat(String.format("%.2f", roundedValue).replace(",", "."));
+    }
+
+    public static IntegerRange parseToRange(String string) {
+        return parseToRange(string, new IntegerRange(1,1));
+    }
+
+    public static IntegerRange parseToRange(String string, IntegerRange integerRange) {
+        int minAmount, maxAmount;
+        try {
+            minAmount = Integer.parseInt(StringUtils.substringBefore(string, ".."));
+        } catch (NumberFormatException e) {
+            minAmount = 1;
+        }
+
+        try {
+            maxAmount = Integer.parseInt(StringUtils.substringAfter(string, ".."));
+        } catch (NumberFormatException e) {
+            maxAmount = Math.max(minAmount, 1);
+        }
+
+        minAmount = Math.max(0, minAmount);
+        maxAmount = Math.max(0, maxAmount);
+
+        return new IntegerRange(minAmount, maxAmount);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/actions/ClickAction.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/actions/ClickAction.java
@@ -1,7 +1,7 @@
 package io.th0rgal.oraxen.utils.actions;
 
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.utils.logs.Logs;
+import io.th0rgal.oraxen.config.Settings;
 import me.gabytm.util.actions.actions.Action;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -87,7 +87,7 @@ public class ClickAction {
                     return false;
                 }
             } catch (ParseException | SpelEvaluationException e) {
-                e.printStackTrace();
+                if (Settings.DEBUG.toBool()) e.printStackTrace();
             }
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -5,8 +5,8 @@ import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
 import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.items.ItemUpdater;
+import io.th0rgal.oraxen.utils.Utils;
 import net.Indyuce.mmoitems.MMOItems;
-import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -25,9 +25,7 @@ public class Loot {
     public Loot(LinkedHashMap<String, Object> config, String sourceID) {
         this.probability = Double.parseDouble(config.getOrDefault("probability", 1).toString());
         if (config.getOrDefault("amount", "") instanceof String amount && amount.contains("..")) {
-            int minAmount = Integer.getInteger(StringUtils.substringBefore(amount, ".."), 1);
-            int maxAmount = Math.max(Integer.getInteger(StringUtils.substringAfter(amount, ".."), 1), minAmount);
-            this.amount = new IntegerRange(minAmount, maxAmount);
+            this.amount = Utils.parseToRange(amount);
         } else this.amount = new IntegerRange(1,1);
         this.config = config;
         this.sourceID = sourceID;

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
@@ -131,7 +131,7 @@ public class ItemsView {
         String fileName = Utils.removeExtension(file.getName());
         //Material of category itemstack. if no material is set, set it to the first item of the category
         Optional<String> icon = Optional.ofNullable(settings.getString(String.format("oraxen_inventory.menu_layout.%s.icon", fileName)));
-        String displayName = ItemParser.parseComponentItemName(settings.getString(String.format("oraxen_inventory.menu_layout.%s.displayname", fileName), "<green>" + file.getName()));
+        String displayName = settings.getString(String.format("oraxen_inventory.menu_layout.%s.displayname", fileName), "<green>" + file.getName());
 
         itemStack = icon.map(OraxenItems::getItemById).map(ItemBuilder::clone)
                 .orElse(OraxenItems.getMap().get(file).values().stream().findFirst().orElse(new ItemBuilder(Material.PAPER)))

--- a/core/src/main/resources/pack/font/balance_hud.json
+++ b/core/src/main/resources/pack/font/balance_hud.json
@@ -2,7 +2,7 @@
   "providers": [
     {
       "type": "bitmap",
-      "file": "minecraft:required/ascii_offset.png",
+      "file": "minecraft:font/ascii.png",
       "ascent": -13,
       "chars": [
         "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pluginVersion=1.175.0
+pluginVersion=1.176.0
 idofrontVersion=0.21.12

--- a/v1_20_R4/src/main/java/io/th0rgal/oraxen/nms/v1_20_R4/ItemProperties.java
+++ b/v1_20_R4/src/main/java/io/th0rgal/oraxen/nms/v1_20_R4/ItemProperties.java
@@ -4,6 +4,8 @@ import io.th0rgal.oraxen.items.helpers.FoodComponentWrapper;
 import io.th0rgal.oraxen.items.helpers.FoodEffectWrapper;
 import io.th0rgal.oraxen.items.helpers.ItemPropertyHandler;
 import io.th0rgal.oraxen.items.helpers.ItemRarityWrapper;
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import net.kyori.adventure.text.Component;
 import net.minecraft.world.food.FoodProperties;
 import org.bukkit.craftbukkit.inventory.components.CraftFoodComponent;
@@ -39,7 +41,8 @@ public class ItemProperties implements ItemPropertyHandler {
 
     @Override
     public void setItemName(ItemMeta itemMeta, @Nullable String itemName) {
-        itemMeta.setItemName(itemName);
+        if (VersionUtil.isPaperServer()) itemMeta.itemName(itemName != null ? AdventureUtils.MINI_MESSAGE.deserialize(itemName) : null);
+        else itemMeta.setItemName(itemName);
     }
 
     @Override


### PR DESCRIPTION
**[Changes]**
- Add <amount>-argument to `/oraxen take`-command
- Change default radius in `/oraxen admin` command to 1

**[Fixes]**
- Glyphs not retaining their order in `/oraxen emojis`
- HuskClaims compatibility
- itemname, displayname & lore serializing to legacy
  * Caused some tags not to work
- Safely fail building item when legacy-formatting is used
- Empty Language-file entries sending empty message
- Food-Mechanic not working on 1.18 servers
- Food-mechanic replacement_item not working
- Improperly parsing MiniMessage-tags in lang-files
- Minor issues with recipes
- Amount not parsing correctly in Loot