### PR TITLE
OraxenBlockDropLootEvent for the new API

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
@@ -2,9 +2,10 @@ package io.th0rgal.oraxen.api;
 
 import com.jeff_media.morepersistentdatatypes.DataType;
 import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.api.events.custom_block.OraxenBlockDropLootEvent;
 import io.th0rgal.oraxen.api.events.custom_block.noteblock.OraxenNoteBlockBreakEvent;
+import io.th0rgal.oraxen.api.events.custom_block.noteblock.OraxenNoteBlockDropLootEvent;
 import io.th0rgal.oraxen.api.events.custom_block.stringblock.OraxenStringBlockBreakEvent;
+import io.th0rgal.oraxen.api.events.custom_block.stringblock.OraxenStringBlockDropLootEvent;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.BreakableMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.noteblock.NoteBlockMechanic;
@@ -280,7 +281,7 @@ public class OraxenBlocks {
         if (drop != null) {
             List<DroppedLoot> loots = drop.spawns(loc, itemInHand);
             if (!loots.isEmpty()) {
-                EventUtils.callEvent(new OraxenBlockDropLootEvent(mechanic, block, player, loots));
+                EventUtils.callEvent(new OraxenNoteBlockDropLootEvent(mechanic, block, player, loots));
             }
         }
 
@@ -315,7 +316,7 @@ public class OraxenBlocks {
 
         if (drop != null) {
             List<DroppedLoot> loots = drop.spawns(block.getLocation(), itemInHand);
-            EventUtils.callEvent(new OraxenBlockDropLootEvent(mechanic, block, player, loots));
+            EventUtils.callEvent(new OraxenStringBlockDropLootEvent(mechanic, block, player, loots));
         }
 
         final Block blockAbove = block.getRelative(BlockFace.UP);

--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
@@ -280,7 +280,7 @@ public class OraxenBlocks {
 
         if (drop != null) {
             List<DroppedLoot> loots = drop.spawns(loc, itemInHand);
-            if (!loots.isEmpty()) {
+            if (!loots.isEmpty() && player != null) {
                 EventUtils.callEvent(new OraxenNoteBlockDropLootEvent(mechanic, block, player, loots));
             }
         }
@@ -316,7 +316,9 @@ public class OraxenBlocks {
 
         if (drop != null) {
             List<DroppedLoot> loots = drop.spawns(block.getLocation(), itemInHand);
-            EventUtils.callEvent(new OraxenStringBlockDropLootEvent(mechanic, block, player, loots));
+            if (!loots.isEmpty() && player != null) {
+                EventUtils.callEvent(new OraxenStringBlockDropLootEvent(mechanic, block, player, loots));
+            }
         }
 
         final Block blockAbove = block.getRelative(BlockFace.UP);

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/OraxenBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/OraxenBlockDropLootEvent.java
@@ -1,0 +1,55 @@
+package io.th0rgal.oraxen.api.events.custom_block;
+
+import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
+import io.th0rgal.oraxen.utils.drops.DroppedLoot;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class OraxenBlockDropLootEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final CustomBlockMechanic mechanic;
+    private final Player player;
+    private final Block block;
+    private final List<DroppedLoot> loots;
+
+    public OraxenBlockDropLootEvent(@NotNull final CustomBlockMechanic mechanic, @NotNull final Block block, final Player player, @NotNull List<DroppedLoot> loots) {
+        this.mechanic = mechanic;
+        this.block = block;
+        this.player = player;
+        this.loots = loots;
+    }
+
+    @Nullable
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public CustomBlockMechanic getMechanic() {
+        return mechanic;
+    }
+
+    public List<DroppedLoot> getLoots() {
+        return loots;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/OraxenCustomBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/OraxenCustomBlockDropLootEvent.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -19,14 +18,13 @@ public class OraxenCustomBlockDropLootEvent extends Event {
     private final Block block;
     private final List<DroppedLoot> loots;
 
-    public OraxenCustomBlockDropLootEvent(@NotNull final CustomBlockMechanic mechanic, @NotNull final Block block, final Player player, @NotNull List<DroppedLoot> loots) {
+    public OraxenCustomBlockDropLootEvent(@NotNull final CustomBlockMechanic mechanic, @NotNull final Block block, @NotNull final Player player, @NotNull List<DroppedLoot> loots) {
         this.mechanic = mechanic;
         this.block = block;
         this.player = player;
         this.loots = loots;
     }
 
-    @Nullable
     public Player getPlayer() {
         return player;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/OraxenCustomBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/OraxenCustomBlockDropLootEvent.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class OraxenBlockDropLootEvent extends Event {
+public class OraxenCustomBlockDropLootEvent extends Event {
     private static final HandlerList HANDLERS = new HandlerList();
 
     private final CustomBlockMechanic mechanic;
@@ -19,7 +19,7 @@ public class OraxenBlockDropLootEvent extends Event {
     private final Block block;
     private final List<DroppedLoot> loots;
 
-    public OraxenBlockDropLootEvent(@NotNull final CustomBlockMechanic mechanic, @NotNull final Block block, final Player player, @NotNull List<DroppedLoot> loots) {
+    public OraxenCustomBlockDropLootEvent(@NotNull final CustomBlockMechanic mechanic, @NotNull final Block block, final Player player, @NotNull List<DroppedLoot> loots) {
         this.mechanic = mechanic;
         this.block = block;
         this.player = player;

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/noteblock/OraxenNoteBlockBreakEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/noteblock/OraxenNoteBlockBreakEvent.java
@@ -1,7 +1,6 @@
 package io.th0rgal.oraxen.api.events.custom_block.noteblock;
 
 import io.th0rgal.oraxen.api.events.custom_block.OraxenBlockBreakEvent;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.noteblock.NoteBlockMechanic;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -15,7 +14,7 @@ public class OraxenNoteBlockBreakEvent extends OraxenBlockBreakEvent implements 
      * @param block    The block that was damaged
      * @param player   The player who damaged this block
      */
-    public OraxenNoteBlockBreakEvent(@NotNull CustomBlockMechanic mechanic, @NotNull Block block, @NotNull Player player) {
+    public OraxenNoteBlockBreakEvent(@NotNull NoteBlockMechanic mechanic, @NotNull Block block, @NotNull Player player) {
         super(mechanic, block, player);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/noteblock/OraxenNoteBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/noteblock/OraxenNoteBlockDropLootEvent.java
@@ -1,7 +1,6 @@
 package io.th0rgal.oraxen.api.events.custom_block.noteblock;
 
 import io.th0rgal.oraxen.api.events.custom_block.OraxenCustomBlockDropLootEvent;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.utils.drops.DroppedLoot;
 import org.bukkit.block.Block;
@@ -11,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class OraxenNoteBlockDropLootEvent extends OraxenCustomBlockDropLootEvent {
-    public OraxenNoteBlockDropLootEvent(@NotNull CustomBlockMechanic mechanic, @NotNull Block block, Player player, @NotNull List<DroppedLoot> loots) {
+    public OraxenNoteBlockDropLootEvent(@NotNull NoteBlockMechanic mechanic, @NotNull Block block, @NotNull Player player, @NotNull List<DroppedLoot> loots) {
         super(mechanic, block, player, loots);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/noteblock/OraxenNoteBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/noteblock/OraxenNoteBlockDropLootEvent.java
@@ -1,0 +1,26 @@
+package io.th0rgal.oraxen.api.events.custom_block.noteblock;
+
+import io.th0rgal.oraxen.api.events.custom_block.OraxenCustomBlockDropLootEvent;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.noteblock.NoteBlockMechanic;
+import io.th0rgal.oraxen.utils.drops.DroppedLoot;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class OraxenNoteBlockDropLootEvent extends OraxenCustomBlockDropLootEvent {
+    public OraxenNoteBlockDropLootEvent(@NotNull CustomBlockMechanic mechanic, @NotNull Block block, Player player, @NotNull List<DroppedLoot> loots) {
+        super(mechanic, block, player, loots);
+    }
+
+    /**
+     * @return The NoteBlockMechanic of this block
+     */
+    @NotNull
+    @Override
+    public NoteBlockMechanic getMechanic() {
+        return (NoteBlockMechanic) super.getMechanic();
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/stringblock/OraxenStringBlockBreakEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/stringblock/OraxenStringBlockBreakEvent.java
@@ -1,7 +1,6 @@
 package io.th0rgal.oraxen.api.events.custom_block.stringblock;
 
 import io.th0rgal.oraxen.api.events.custom_block.OraxenBlockBreakEvent;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.stringblock.StringBlockMechanic;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -10,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class OraxenStringBlockBreakEvent extends OraxenBlockBreakEvent implements Cancellable {
 
-    public OraxenStringBlockBreakEvent(@NotNull CustomBlockMechanic mechanic, @NotNull Block block, @NotNull Player player) {
+    public OraxenStringBlockBreakEvent(@NotNull StringBlockMechanic mechanic, @NotNull Block block, @NotNull Player player) {
         super(mechanic, block, player);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/stringblock/OraxenStringBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/stringblock/OraxenStringBlockDropLootEvent.java
@@ -1,0 +1,27 @@
+package io.th0rgal.oraxen.api.events.custom_block.stringblock;
+
+import io.th0rgal.oraxen.api.events.custom_block.OraxenCustomBlockDropLootEvent;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.stringblock.StringBlockMechanic;
+import io.th0rgal.oraxen.utils.drops.DroppedLoot;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class OraxenStringBlockDropLootEvent extends OraxenCustomBlockDropLootEvent {
+    public OraxenStringBlockDropLootEvent(@NotNull CustomBlockMechanic mechanic, @NotNull Block block, Player player, @NotNull List<DroppedLoot> loots) {
+        super(mechanic, block, player, loots);
+    }
+
+    /**
+     * @return The StringBlockMechanic of this block
+     */
+    @NotNull
+    @Override
+    public StringBlockMechanic getMechanic() {
+        return (StringBlockMechanic) super.getMechanic();
+    }
+
+}

--- a/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/stringblock/OraxenStringBlockDropLootEvent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/events/custom_block/stringblock/OraxenStringBlockDropLootEvent.java
@@ -1,7 +1,6 @@
 package io.th0rgal.oraxen.api.events.custom_block.stringblock;
 
 import io.th0rgal.oraxen.api.events.custom_block.OraxenCustomBlockDropLootEvent;
-import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.CustomBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.stringblock.StringBlockMechanic;
 import io.th0rgal.oraxen.utils.drops.DroppedLoot;
 import org.bukkit.block.Block;
@@ -11,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class OraxenStringBlockDropLootEvent extends OraxenCustomBlockDropLootEvent {
-    public OraxenStringBlockDropLootEvent(@NotNull CustomBlockMechanic mechanic, @NotNull Block block, Player player, @NotNull List<DroppedLoot> loots) {
+    public OraxenStringBlockDropLootEvent(@NotNull StringBlockMechanic mechanic, @NotNull Block block, @NotNull Player player, @NotNull List<DroppedLoot> loots) {
         super(mechanic, block, player, loots);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/stringblock/StringBlockMechanicPhysicsListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/stringblock/StringBlockMechanicPhysicsListener.java
@@ -3,7 +3,7 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.stringblock;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.api.OraxenFurniture;
-import io.th0rgal.oraxen.api.events.custom_block.OraxenBlockDropLootEvent;
+import io.th0rgal.oraxen.api.events.custom_block.OraxenCustomBlockDropLootEvent;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.drops.DroppedLoot;
@@ -61,8 +61,7 @@ public class StringBlockMechanicPhysicsListener implements Listener {
 
             block.setType(Material.AIR, false);
 
-            List<DroppedLoot> loots = mechanic.breakable().drop().spawns(block.getLocation(), new ItemStack(Material.AIR));
-            EventUtils.callEvent(new OraxenBlockDropLootEvent(mechanic, block, null, loots));
+            mechanic.breakable().drop().spawns(block.getLocation(), new ItemStack(Material.AIR));
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/stringblock/StringBlockMechanicPhysicsListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/custom_block/stringblock/StringBlockMechanicPhysicsListener.java
@@ -3,7 +3,10 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.custom_block.stringblock;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.api.OraxenFurniture;
+import io.th0rgal.oraxen.api.events.custom_block.OraxenBlockDropLootEvent;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.EventUtils;
+import io.th0rgal.oraxen.utils.drops.DroppedLoot;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -58,7 +61,8 @@ public class StringBlockMechanicPhysicsListener implements Listener {
 
             block.setType(Material.AIR, false);
 
-            mechanic.breakable().drop().spawns(block.getLocation(), new ItemStack(Material.AIR));
+            List<DroppedLoot> loots = mechanic.breakable().drop().spawns(block.getLocation(), new ItemStack(Material.AIR));
+            EventUtils.callEvent(new OraxenBlockDropLootEvent(mechanic, block, null, loots));
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/Drop.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/Drop.java
@@ -2,12 +2,10 @@ package io.th0rgal.oraxen.utils.drops;
 
 import dev.jorel.commandapi.wrappers.IntegerRange;
 import io.th0rgal.oraxen.api.OraxenItems;
-import io.th0rgal.oraxen.api.events.custom_block.OraxenBlockDropLootEvent;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureHelpers;
 import io.th0rgal.oraxen.mechanics.provided.misc.itemtype.ItemTypeMechanic;
 import io.th0rgal.oraxen.mechanics.provided.misc.itemtype.ItemTypeMechanicFactory;
 import io.th0rgal.oraxen.utils.BlockHelpers;
-import io.th0rgal.oraxen.utils.EventUtils;
 import io.th0rgal.oraxen.utils.ItemUtils;
 import io.th0rgal.oraxen.utils.wrappers.EnchantmentWrapper;
 import org.bukkit.Location;

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/DroppedLoot.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/DroppedLoot.java
@@ -1,0 +1,4 @@
+package io.th0rgal.oraxen.utils.drops;
+
+public record DroppedLoot(Loot loot, int amount) {
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -84,6 +84,10 @@ public class Loot {
         return this;
     }
 
+    public String sourceID() {
+        return sourceID;
+    }
+
     public double probability() {
         return probability;
     }
@@ -92,9 +96,11 @@ public class Loot {
         return this.amount;
     }
 
-    public void dropNaturally(Location location, int amountMultiplier) {
-        if (Math.random() <= probability)
-            dropItems(location, amountMultiplier);
+    public int dropNaturally(Location location, int amountMultiplier) {
+        if (Math.random() <= probability) {
+            return dropItems(location, amountMultiplier);
+        }
+        return 0;
     }
 
     public ItemStack getItem(int amountMultiplier) {
@@ -104,7 +110,12 @@ public class Loot {
         return ItemUpdater.updateItem(stack);
     }
 
-    private void dropItems(Location location, int amountMultiplier) {
-        if (location.getWorld() != null) location.getWorld().dropItemNaturally(location, getItem(amountMultiplier));
+    private int dropItems(Location location, int amountMultiplier) {
+        ItemStack item = getItem(amountMultiplier);
+        if (location.getWorld() != null) {
+            location.getWorld().dropItemNaturally(location, item);
+            return item.getAmount();
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
This PR adds a new non-cancellable event named OraxenBlockDropLootEvent.  This event will be fired after the loot has been dropped from the custom block. It contains information about the triggered mechanic, vanilla Block and Player if applicable. Additionally it also has a List<DroppedLoot> which contains every loot that was dropped before with the dropped amounts.

This event will be useful for plugins that are trying to implement something like a Hypixel collections plugin or generally just for saving/monitoring stats. 

I haven't tested if this actually work in game, since I never used custom block mechanics in Oraxen, but I don't see any reason why wouldn't it work.

I also tried not to break existing APIs. Usually just the return types changed from void in the method signatures.