### PR TITLE
1.179.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,35 +239,8 @@ if (pluginPath != null) {
             }
         }
 
-        // Create individual copy tasks for each destination
-        val copyToDevPluginPathTask = register<Copy>("copyToDevPluginPath") {
-            dependsOn(shadowJar, jar)
-            from(defaultPath)
-            devPluginPath?.let { into(it) }
-            doLast { println("Copied to plugin directory $devPluginPath") }
-        }
-
-        val copyToFoliaPluginPathTask = register<Copy>("copyToFoliaPluginPath") {
-            dependsOn(shadowJar, jar)
-            from(defaultPath)
-            foliaPluginPath?.let { into(it) }
-            doLast { println("Copied to plugin directory $foliaPluginPath") }
-        }
-
-        val copyToSpigotPluginPathTask = register<Copy>("copyToSpigotPluginPath") {
-            dependsOn(shadowJar, jar)
-            from(defaultPath)
-            spigotPluginPath?.let { into(it) }
-            doLast { println("Copied to plugin directory $spigotPluginPath") }
-        }
-
         // Make the build task depend on all individual copy tasks
-        named<DefaultTask>("build").get().dependsOn(
-            copyJarTask,
-            copyToDevPluginPathTask,
-            copyToFoliaPluginPathTask,
-            copyToSpigotPluginPathTask
-        )
+        named<DefaultTask>("build").get().dependsOn(copyJarTask)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -215,6 +215,8 @@ bukkit {
         "net.kyori:adventure-platform-bukkit:$platformVersion",
         "com.google.code.gson:gson:$googleGsonVersion",
         "org.apache.commons:commons-lang3:$apacheLang3Version",
+        "team.unnamed:creative-api:1.7.3",
+        "team.unnamed:creative-serializer-minecraft:1.7.3",
         "gs.mclo:java:2.2.1",
     )
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,10 +60,10 @@ allprojects {
         maven("https://mvn.lumine.io/repository/maven-public/") { metadataSources { artifact() } }// MythicMobs
         maven("https://repo.mineinabyss.com/releases") // PlayerAnimator
         maven("https://s01.oss.sonatype.org/content/repositories/snapshots") // commandAPI snapshots
-        maven("https://repo.auxilor.io/repository/maven-public/") // EcoItems
-        maven("https://maven.enginehub.org/repo/")
         maven("https://repo.oraxen.com/releases")
         maven("https://repo.oraxen.com/snapshots")
+        maven("https://repo.auxilor.io/repository/maven-public/") // EcoItems
+        maven("https://maven.enginehub.org/repo/")
         maven("https://jitpack.io") // JitPack
         maven("https://nexus.phoenixdevt.fr/repository/maven-public/") // MMOItems
         maven("https://repo.codemc.org/repository/maven-public/") // BlockLocker
@@ -103,7 +103,7 @@ allprojects {
 
         implementation("dev.jorel:commandapi-bukkit-shade:$commandApiVersion")
         implementation("org.bstats:bstats-bukkit:3.0.0")
-        implementation("io.th0rgal:protectionlib:1.5.8")
+        implementation("io.th0rgal:protectionlib:1.6.0")
         implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
         implementation("com.jeff-media:custom-block-data:2.2.2")
         implementation("com.jeff_media:MorePersistentDataTypes:2.4.0")
@@ -198,7 +198,7 @@ bukkit {
         "ProtocolLib",
         "LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "MythicMobs", "BossShopPro",
         "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared",
-        "NBTAPI", "ModelEngine", "CrashClaim", "ViaBackwards", "HuskClaims", "BentoBox"
+        "NBTAPI", "ModelEngine", "ViaBackwards", "HuskClaims", "HuskTowns", "BentoBox"
     )
     loadBefore = listOf("Realistic_World")
     permissions.create("oraxen.command") {

--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java
@@ -1,6 +1,8 @@
 package io.th0rgal.oraxen.api;
 
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
+import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.ItemParser;
@@ -9,12 +11,19 @@ import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.pack.generation.DuplicationHandler;
 import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.OraxenYaml;
+import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import net.Indyuce.mmoitems.MMOItems;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.components.FoodComponent;
 import org.bukkit.persistence.PersistentDataType;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.*;
 import java.util.Map.Entry;
@@ -24,7 +33,6 @@ import java.util.stream.Stream;
 public class OraxenItems {
 
     public static final NamespacedKey ITEM_ID = new NamespacedKey(OraxenPlugin.get(), "id");
-    // configuration sections : their OraxenItem wrapper
     private static Map<File, Map<String, ItemBuilder>> map;
     private static Set<String> items;
 
@@ -38,6 +46,56 @@ public class OraxenItems {
         items = new HashSet<>();
         for (final Map<String, ItemBuilder> subMap : map.values())
             items.addAll(subMap.keySet());
+
+        ensureComponentDataHandled();
+    }
+
+    /**
+     * Primarily for handling data that requires OraxenItem's<br>
+     * For example FoodComponent#getUsingConvertsTo
+     */
+    private static void ensureComponentDataHandled() {
+        if (VersionUtil.atOrAbove("1.21")) for (final Entry<File, Map<String, ItemBuilder>> entry : map.entrySet()) {
+            Map<String, ItemBuilder> subMap = entry.getValue();
+            for (final Entry<String, ItemBuilder> subEntry : subMap.entrySet()) {
+                String itemId = subEntry.getKey();
+                ItemBuilder itemBuilder = subEntry.getValue();
+                if (itemBuilder == null) continue;
+                FoodComponent foodComponent = itemBuilder.getFoodComponent();
+                if (foodComponent == null) continue;
+
+                ConfigurationSection section = OraxenYaml.loadConfiguration(entry.getKey()).getConfigurationSection(itemId + ".Components.food.replacement");
+                ItemStack replacementItem = parseFoodComponentReplacement(section);
+                foodComponent.setUsingConvertsTo(replacementItem);
+                itemBuilder.setFoodComponent(foodComponent).regen();
+            }
+        }
+    }
+
+    @Nullable
+    private static ItemStack parseFoodComponentReplacement(@Nullable ConfigurationSection section) {
+        if (section == null) return null;
+
+        ItemStack replacementItem;
+        if (section.isString("minecraft_type")) {
+            Material material = Material.getMaterial(Objects.requireNonNull(section.getString("minecraft_type")));
+            if (material == null) {
+                Logs.logError("Invalid material: " + section.getString("minecraft_type"));
+                replacementItem = null;
+            } else replacementItem = new ItemStack(material);
+        } else if (section.isString("oraxen_item"))
+            replacementItem = OraxenItems.getItemById(section.getString("oraxen_item")).build();
+        else if (section.isString("crucible_item"))
+            replacementItem = new WrappedCrucibleItem(section.getString("crucible_item")).build();
+        else if (section.isString("mmoitems_id") && section.isString("mmoitems_type"))
+            replacementItem = MMOItems.plugin.getItem(section.getString("mmoitems_type"), section.getString("mmoitems_id"));
+        else if (section.isString("ecoitem_id"))
+            replacementItem = new WrappedEcoItem(section.getString("ecoitem_id")).build();
+        else if (section.isItemStack("minecraft_item"))
+            replacementItem = section.getItemStack("minecraft_item");
+        else replacementItem = null;
+
+        return replacementItem;
     }
 
     public static String getIdByItem(final ItemBuilder item) {

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -10,6 +10,7 @@ import io.th0rgal.oraxen.pack.generation.DuplicationHandler;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.Utils;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Material;
@@ -20,6 +21,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class ConfigsManager {
@@ -272,19 +274,17 @@ public class ConfigsManager {
                 ModelData.DATAS.computeIfAbsent(material, k -> new HashMap<>()).put(key, modelData);
             }
 
-            if (fileChanged) {
-                try {
-                    configuration.save(file);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+            if (fileChanged) try {
+                configuration.save(file);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }
 
     public void parseAllItemTemplates() {
         for (File file : getItemFiles()) {
-            if (!file.exists()) continue;
+            if (file == null || !file.exists()) continue;
             YamlConfiguration configuration = OraxenYaml.loadConfiguration(file);
             for (String key : configuration.getKeys(false)) {
                 ConfigurationSection itemSection = configuration.getConfigurationSection(key);
@@ -327,12 +327,24 @@ public class ConfigsManager {
             if (itemParser.isConfigUpdated())
                 configUpdated = true;
         }
-        if (configUpdated)
+
+        if (configUpdated) {
+            String content = config.saveToString();
+            if (VersionUtil.atOrAbove("1.20.5"))
+                content = content.replace("displayname: ", "itemname: ");
+            else content = content.replace("itemname: ", "displayname: ");
+
             try {
-                config.save(itemFile);
-            } catch (IOException e) {
-                e.printStackTrace();
+                FileUtils.writeStringToFile(itemFile, content, StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                if (Settings.DEBUG.toBool()) e.printStackTrace();
+                try {
+                    config.save(itemFile);
+                } catch (Exception e1) {
+                    if (Settings.DEBUG.toBool()) e1.printStackTrace();
+                }
             }
+        }
 
         return map;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -306,7 +306,6 @@ public class ConfigsManager {
         Map<String, ItemParser> parseMap = new LinkedHashMap<>();
 
         for (String itemKey : config.getKeys(false)) {
-            //Utils.ensureStringFormat(itemKey);
             ConfigurationSection itemSection = config.getConfigurationSection(itemKey);
             if (itemSection == null || ItemTemplate.isTemplate(itemKey)) continue;
             parseMap.put(itemKey, new ItemParser(itemSection));

--- a/core/src/main/java/io/th0rgal/oraxen/config/ResourcesManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ResourcesManager.java
@@ -3,12 +3,16 @@ package io.th0rgal.oraxen.config;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.ReflectionUtils;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.customarmor.CustomArmorType;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.AbstractMap;
 import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
@@ -80,7 +84,41 @@ public class ResourcesManager {
             if (customArmorType != CustomArmorType.SHADER) return;
             if (!Settings.CUSTOM_ARMOR_SHADER_GENERATE_CUSTOM_TEXTURES.toBool() && entry.getName().startsWith("pack/textures/models/armor/leather_layer")) return;
         }
-        plugin.saveResource(entry.getName(), true);
+        if (entry.getName().startsWith("items/")) extractVersionSpecificItemConfig(entry);
+        else plugin.saveResource(entry.getName(), true);
+    }
+
+    private void extractVersionSpecificItemConfig(ZipEntry entry) {
+        if (!entry.getName().startsWith("items/")) return;
+        if (!entry.getName().endsWith(".yml")) return;
+        if (!VersionUtil.atOrAbove("1.20.5")) {
+            plugin.saveResource(entry.getName(), true);
+            return;
+        }
+
+        try(InputStream inputStream = plugin.getResource(entry.getName())) {
+            YamlConfiguration itemYaml = OraxenYaml.loadConfiguration(new InputStreamReader(inputStream));
+            for (String itemId : itemYaml.getKeys(false)) {
+                ConfigurationSection itemSection = itemYaml.getConfigurationSection(itemId);
+                if (itemSection == null) continue;
+                ConfigurationSection mechanicSection = itemSection.getConfigurationSection("Mechanics");
+                if (mechanicSection == null) continue;
+
+                ConfigurationSection componentSection = itemSection.getConfigurationSection("Components");
+                if (componentSection == null) componentSection = itemSection.createSection("Components");
+
+                Object durability = mechanicSection.get("durability.value");
+                mechanicSection.set("durability", null);
+                componentSection.set("durability", durability);
+
+                if (mechanicSection.getKeys(false).isEmpty()) itemSection.set("Mechanics", null);
+                if (componentSection.getKeys(false).isEmpty()) itemSection.set("Components", null);
+            }
+            File itemFile = plugin.getDataFolder().toPath().resolve(entry.getName()).toFile();
+            itemYaml.save(itemFile);
+        } catch (Exception e) {
+            plugin.saveResource(entry.getName(), true);
+        }
     }
 
     private void extractFileAccordingToExtension(ZipEntry entry, String folder, String fileExtension) {

--- a/core/src/main/java/io/th0rgal/oraxen/config/ResourcesManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ResourcesManager.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.ReflectionUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.customarmor.CustomArmorType;
+import org.apache.commons.io.FileUtils;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Map.Entry;
 import java.util.zip.ZipEntry;
@@ -101,6 +103,7 @@ public class ResourcesManager {
             for (String itemId : itemYaml.getKeys(false)) {
                 ConfigurationSection itemSection = itemYaml.getConfigurationSection(itemId);
                 if (itemSection == null) continue;
+
                 ConfigurationSection mechanicSection = itemSection.getConfigurationSection("Mechanics");
                 if (mechanicSection == null) continue;
 
@@ -115,7 +118,10 @@ public class ResourcesManager {
                 if (componentSection.getKeys(false).isEmpty()) itemSection.set("Components", null);
             }
             File itemFile = plugin.getDataFolder().toPath().resolve(entry.getName()).toFile();
-            itemYaml.save(itemFile);
+
+            if (VersionUtil.atOrAbove("1.20.5"))
+                FileUtils.writeStringToFile(itemFile, itemYaml.saveToString().replace("displayname", "itemname"), StandardCharsets.UTF_8);
+            else itemYaml.save(itemFile);
         } catch (Exception e) {
             plugin.saveResource(entry.getName(), true);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/font/packets/ScoreboardPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/packets/ScoreboardPacketListener.java
@@ -1,12 +1,11 @@
 package io.th0rgal.oraxen.font.packets;
 
 import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.events.ListenerPriority;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.events.PacketEvent;
-import io.papermc.paper.scoreboard.numbers.NumberFormat;
+import com.comphenix.protocol.events.*;
+import com.comphenix.protocol.wrappers.WrappedNumberFormat;
 import io.th0rgal.oraxen.OraxenPlugin;
+
+import java.util.Optional;
 
 public class ScoreboardPacketListener extends PacketAdapter {
 
@@ -14,12 +13,13 @@ public class ScoreboardPacketListener extends PacketAdapter {
         super(OraxenPlugin.get(), ListenerPriority.MONITOR, PacketType.Play.Server.SCOREBOARD_OBJECTIVE);
     }
 
+    private final Optional<InternalStructure> numberFormat = Optional.of(InternalStructure.getConverter().getSpecific(WrappedNumberFormat.blank().getHandle()));
     @Override
     public void onPacketSending(PacketEvent event) {
         PacketContainer packet = event.getPacket();
         try {
             if (packet.getIntegers().read(0) == 1) return;
-            packet.getModifier().write(3, NumberFormat.blank());
+            packet.getOptionalStructures().write(0, numberFormat);
         } catch (Exception ignored) {
             ignored.printStackTrace();
         }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -596,12 +596,11 @@ public class ItemBuilder {
         itemMeta.setUnbreakable(unbreakable);
 
         PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-        if (!VersionUtil.atOrAbove("1.20.5") && displayName != null) {
-            pdc.set(ORIGINAL_NAME_KEY, DataType.STRING, displayName);
+        if (displayName != null) {
+            if (!VersionUtil.atOrAbove("1.20.5")) pdc.set(ORIGINAL_NAME_KEY, DataType.STRING, displayName);
             if (VersionUtil.isPaperServer()) {
                 Component displayName = AdventureUtils.MINI_MESSAGE.deserialize(this.displayName);
-                displayName = displayName.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE);
-                displayName = displayName.colorIfAbsent(NamedTextColor.WHITE);
+                displayName = displayName.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE).colorIfAbsent(NamedTextColor.WHITE);
                 itemMeta.displayName(displayName);
             } else itemMeta.setDisplayName(displayName);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -29,6 +29,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.*;
 import org.bukkit.inventory.meta.components.FoodComponent;
 import org.bukkit.inventory.meta.components.JukeboxPlayableComponent;
+import org.bukkit.inventory.meta.components.ToolComponent;
 import org.bukkit.inventory.meta.trim.ArmorTrim;
 import org.bukkit.inventory.meta.trim.TrimMaterial;
 import org.bukkit.inventory.meta.trim.TrimPattern;
@@ -78,6 +79,8 @@ public class ItemBuilder {
     @Nullable
     private FoodComponent foodComponent;
     @Nullable
+    private ToolComponent toolComponent;
+    @Nullable
     private Boolean enchantmentGlintOverride;
     @Nullable
     private Integer maxStackSize;
@@ -86,7 +89,7 @@ public class ItemBuilder {
     @Nullable
     private Boolean fireResistant;
     @Nullable
-    private Boolean hideToolTips;
+    private Boolean hideToolTip;
     @Nullable
     private ItemRarity rarity;
     @Nullable
@@ -190,8 +193,9 @@ public class ItemBuilder {
 
             durability = (itemMeta instanceof Damageable damageable) && damageable.hasMaxDamage() ? damageable.getMaxDamage() : null;
             fireResistant = itemMeta.isFireResistant() ? true : null;
-            hideToolTips = itemMeta.isHideTooltip() ? true : null;
+            hideToolTip = itemMeta.isHideTooltip() ? true : null;
             foodComponent = itemMeta.hasFood() ? itemMeta.getFood() : null;
+            toolComponent = itemMeta.hasTool() ? itemMeta.getTool() : null;
             enchantmentGlintOverride = itemMeta.hasEnchantmentGlintOverride() ? itemMeta.getEnchantmentGlintOverride() : null;
             rarity = itemMeta.hasRarity() ? itemMeta.getRarity() : null;
             maxStackSize = itemMeta.hasMaxStackSize() ? itemMeta.getMaxStackSize() : null;
@@ -353,6 +357,20 @@ public class ItemBuilder {
         return this;
     }
 
+    public boolean hasToolComponent() {
+        return VersionUtil.atOrAbove("1.20.5") && toolComponent != null;
+    }
+
+    @Nullable
+    public ToolComponent getToolComponent() {
+        return toolComponent;
+    }
+
+    public ItemBuilder setToolComponent(ToolComponent toolComponent) {
+        this.toolComponent = toolComponent;
+        return this;
+    }
+
     public boolean hasJukeboxPlayable() {
         return VersionUtil.atOrAbove("1.21") && jukeboxPlayable != null;
     }
@@ -400,8 +418,8 @@ public class ItemBuilder {
         return this;
     }
 
-    public ItemBuilder setHideToolTips(boolean hideToolTips) {
-        this.hideToolTips = hideToolTips;
+    public ItemBuilder setHideToolTip(boolean hideToolTip) {
+        this.hideToolTip = hideToolTip;
         return this;
     }
 
@@ -568,8 +586,9 @@ public class ItemBuilder {
             if (hasEnchantmentGlindOverride()) itemMeta.setEnchantmentGlintOverride(enchantmentGlintOverride);
             if (hasRarity()) itemMeta.setRarity(rarity);
             if (hasFoodComponent()) itemMeta.setFood(foodComponent);
+            if (hasToolComponent()) itemMeta.setTool(toolComponent);
             if (fireResistant != null) itemMeta.setFireResistant(fireResistant);
-            if (hideToolTips != null) itemMeta.setHideTooltip(hideToolTips);
+            if (hideToolTip != null) itemMeta.setHideTooltip(hideToolTip);
         }
 
         if (VersionUtil.atOrAbove("1.21")) {

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -9,10 +9,7 @@ import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
 import io.th0rgal.oraxen.compatibilities.provided.mmoitems.WrappedMMOItem;
 import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.config.Settings;
-import io.th0rgal.oraxen.utils.AdventureUtils;
-import io.th0rgal.oraxen.utils.OraxenYaml;
-import io.th0rgal.oraxen.utils.PotionUtils;
-import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.*;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -142,7 +139,7 @@ public class ItemBuilder {
             color = mapMeta.getColor();
 
         if (itemMeta instanceof FireworkEffectMeta effectMeta)
-            color = effectMeta.hasEffect() ? effectMeta.getEffect().getColors().get(0) : Color.WHITE;
+            color = effectMeta.hasEffect() ? Utils.getOrDefault(effectMeta.getEffect().getColors(), 0, Color.WHITE) : Color.WHITE;
 
         if (VersionUtil.atOrAbove("1.20") && itemMeta instanceof ArmorMeta armorMeta && armorMeta.hasTrim())
             trimPattern = armorMeta.getTrim().getMaterial().key();

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -108,11 +108,15 @@ public class ItemParser {
     }
 
     private ItemBuilder applyConfig(ItemBuilder item) {
-        if (!VersionUtil.atOrAbove("1.20.5") && section.contains("displayname"))
-            item.setDisplayName(section.getString("displayname", ""));
+        if (section.contains("displayname")) {
+            if (VersionUtil.atOrAbove("1.20.5")) configUpdated = true;
+            else item.setDisplayName(section.getString("displayname", ""));
+        }
 
-        if (VersionUtil.atOrAbove("1.20.5") && section.contains("customname"))
-            item.setDisplayName(section.getString("customname"));
+        if (section.contains("customname")) {
+            if (!VersionUtil.atOrAbove("1.20.5")) configUpdated = true;
+            else item.setDisplayName(section.getString("customname", ""));
+        }
 
         //if (section.contains("type")) item.setType(Material.getMaterial(section.getString("type", "PAPER")));
         if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(AdventureUtils::parseMiniMessage).toList());

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -148,6 +148,8 @@ public class ItemParser {
             foodComponent.setSaturation((float) foodSection.getDouble("saturation", 0.0));
             foodComponent.setCanAlwaysEat(foodSection.getBoolean("can_always_eat"));
             foodComponent.setEatSeconds((float) foodSection.getDouble("eat_seconds", 1.6));
+            // Handled in {@link OraxenItems#ensureComponentDataHandled}
+            //foodComponent.setUsingConvertsTo(itemStack);
 
             ConfigurationSection effectsSection = foodSection.getConfigurationSection("effects");
             if (effectsSection != null) for (String effect : effectsSection.getKeys(false)) {

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -157,14 +157,16 @@ public class ItemParser {
                 if (effectType == null)
                     Logs.logError("Invalid potion effect: " + effect + ", in " + StringUtils.substringBefore(effectsSection.getCurrentPath(), ".") + " food-property!");
                 else {
+                    ConfigurationSection effectSection = effectsSection.getConfigurationSection(effect);
+                    if (effectSection == null) continue;
                     foodComponent.addEffect(
                             new PotionEffect(effectType,
-                                    foodSection.getInt("duration", 1) * 20,
-                                    foodSection.getInt("amplifier", 0),
-                                    foodSection.getBoolean("ambient", true),
-                                    foodSection.getBoolean("show_particles", true),
-                                    foodSection.getBoolean("show_icon", true)),
-                            (float) foodSection.getDouble("probability", 1.0)
+                                    effectSection.getInt("duration", 1) * 20,
+                                    effectSection.getInt("amplifier", 0),
+                                    effectSection.getBoolean("ambient", true),
+                                    effectSection.getBoolean("show_particles", true),
+                                    effectSection.getBoolean("show_icon", true)),
+                            (float) effectSection.getDouble("probability", 1.0)
                     );
                 }
             }

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -111,6 +111,9 @@ public class ItemParser {
         if (!VersionUtil.atOrAbove("1.20.5") && section.contains("displayname"))
             item.setDisplayName(section.getString("displayname", ""));
 
+        if (VersionUtil.atOrAbove("1.20.5") && section.contains("customname"))
+            item.setDisplayName(section.getString("customname"));
+
         //if (section.contains("type")) item.setType(Material.getMaterial(section.getString("type", "PAPER")));
         if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(AdventureUtils::parseMiniMessage).toList());
         if (section.contains("unbreakable")) item.setUnbreakable(section.getBoolean("unbreakable", false));

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -15,8 +15,10 @@ import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
 import org.apache.commons.lang3.StringUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.configuration.ConfigurationSection;
@@ -26,9 +28,11 @@ import org.bukkit.inventory.ItemRarity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.components.FoodComponent;
 import org.bukkit.inventory.meta.components.JukeboxPlayableComponent;
+import org.bukkit.inventory.meta.components.ToolComponent;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.function.Function;
@@ -139,39 +143,12 @@ public class ItemParser {
         }
         if (components.contains("rarity")) item.setRarity(ItemRarity.valueOf(components.getString("rarity")));
         if (components.contains("fire_resistant")) item.setFireResistant(components.getBoolean("fire_resistant"));
-        if (components.contains("hide_tooltips")) item.setHideToolTips(components.getBoolean("hide_tooltips"));
+        if (components.contains("hide_tooltip")) item.setHideToolTip(components.getBoolean("hide_tooltip"));
 
         ConfigurationSection foodSection = components.getConfigurationSection("food");
-        if (foodSection != null) {
-            FoodComponent foodComponent = new ItemStack(Material.PAPER).getItemMeta().getFood();
-            foodComponent.setNutrition(foodSection.getInt("nutrition"));
-            foodComponent.setSaturation((float) foodSection.getDouble("saturation", 0.0));
-            foodComponent.setCanAlwaysEat(foodSection.getBoolean("can_always_eat"));
-            foodComponent.setEatSeconds((float) foodSection.getDouble("eat_seconds", 1.6));
-            // Handled in {@link OraxenItems#ensureComponentDataHandled}
-            //foodComponent.setUsingConvertsTo(itemStack);
-
-            ConfigurationSection effectsSection = foodSection.getConfigurationSection("effects");
-            if (effectsSection != null) for (String effect : effectsSection.getKeys(false)) {
-                PotionEffectType effectType = PotionUtils.getEffectType(effect);
-                if (effectType == null)
-                    Logs.logError("Invalid potion effect: " + effect + ", in " + StringUtils.substringBefore(effectsSection.getCurrentPath(), ".") + " food-property!");
-                else {
-                    ConfigurationSection effectSection = effectsSection.getConfigurationSection(effect);
-                    if (effectSection == null) continue;
-                    foodComponent.addEffect(
-                            new PotionEffect(effectType,
-                                    effectSection.getInt("duration", 1) * 20,
-                                    effectSection.getInt("amplifier", 0),
-                                    effectSection.getBoolean("ambient", true),
-                                    effectSection.getBoolean("show_particles", true),
-                                    effectSection.getBoolean("show_icon", true)),
-                            (float) effectSection.getDouble("probability", 1.0)
-                    );
-                }
-            }
-            item.setFoodComponent(foodComponent);
-        }
+        if (foodSection != null) parseFoodComponent(item, foodSection);
+        ConfigurationSection toolSection = components.getConfigurationSection("tool");
+        if (toolSection != null) parseToolComponent(item, toolSection);
 
         if (!VersionUtil.atOrAbove("1.21")) return;
 
@@ -182,6 +159,107 @@ public class ItemParser {
             jukeboxPlayable.setSongKey(NamespacedKey.fromString(jukeboxSection.getString("song_key")));
             item.setJukeboxPlayable(jukeboxPlayable);
         }
+    }
+
+    @SuppressWarnings({"UnstableApiUsage", "unchecked"})
+    private void parseToolComponent(ItemBuilder item, @NotNull ConfigurationSection toolSection) {
+        ToolComponent toolComponent = new ItemStack(Material.PAPER).getItemMeta().getTool();
+        toolComponent.setDamagePerBlock(Math.min(toolSection.getInt("damage_per_block", 1), 0));
+        toolComponent.setDefaultMiningSpeed(Math.min((float) toolSection.getDouble("default_mining_speed", 1.0), 0f));
+
+        for (Map<?, ?> ruleEntry : toolSection.getMapList("rules")) {
+            float speed;
+            try {
+                speed = Float.parseFloat(String.valueOf(ruleEntry.get("speed")));
+            } catch (Exception e) {
+                speed = 1f;
+            }
+            boolean correctForDrops = Boolean.parseBoolean(String.valueOf(ruleEntry.get("correct_for_drops")));
+            Set<Material> materials = new HashSet<>();
+            Set<Tag<Material>> tags = new HashSet<>();
+
+            if (ruleEntry.containsKey("material")) {
+                try {
+                    Material material = Material.valueOf(String.valueOf(ruleEntry.get("material")));
+                    if (material.isBlock()) materials.add(material);
+                } catch (Exception e) {
+                    Logs.logWarning("Error parsing rule-entry in " + section.getName());
+                    Logs.logWarning("Malformed \"material\"-section");
+                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                }
+            }
+
+            if (ruleEntry.containsKey("materials")) {
+                try {
+                    List<String> materialIds = (List<String>) ruleEntry.get("materials");
+                    for (String materialId : materialIds) {
+                        Material material = Material.valueOf(materialId);
+                        if (material.isBlock()) materials.add(material);
+                    }
+                } catch (Exception e) {
+                    Logs.logWarning("Error parsing rule-entry in " + section.getName());
+                    Logs.logWarning("Malformed \"materials\"-section");
+                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                }
+            }
+
+            if (ruleEntry.containsKey("tag")) {
+                try {
+                    NamespacedKey tagKey = NamespacedKey.fromString(String.valueOf(ruleEntry.get("tag")));
+                    if (tagKey != null) tags.add(Bukkit.getTag(Tag.REGISTRY_BLOCKS, tagKey, Material.class));
+                } catch (Exception e) {
+                    Logs.logWarning("Error parsing rule-entry in " + section.getName());
+                    Logs.logWarning("Malformed \"tag\"-section");
+                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                }
+            }
+
+            if (ruleEntry.containsKey("tags")) {
+                try {
+                    for (String tagString : (List<String>) ruleEntry.get("tags")) {
+                        NamespacedKey tagKey = NamespacedKey.fromString(tagString);
+                        if (tagKey != null) tags.add(Bukkit.getTag(Tag.REGISTRY_BLOCKS, tagKey, Material.class));
+                    }
+                } catch (Exception e) {
+                    Logs.logWarning("Error parsing rule-entry in " + section.getName());
+                    Logs.logWarning("Malformed \"material\"-section");
+                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                }
+            }
+
+            if (!materials.isEmpty()) toolComponent.addRule(materials, speed, correctForDrops);
+            for (Tag<Material> tag : tags) toolComponent.addRule(tag, speed, correctForDrops);
+        }
+
+        item.setToolComponent(toolComponent);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private void parseFoodComponent(ItemBuilder item, @NotNull ConfigurationSection foodSection) {
+        FoodComponent foodComponent = new ItemStack(Material.PAPER).getItemMeta().getFood();
+        foodComponent.setNutrition(foodSection.getInt("nutrition"));
+        foodComponent.setSaturation((float) foodSection.getDouble("saturation", 0.0));
+        foodComponent.setCanAlwaysEat(foodSection.getBoolean("can_always_eat"));
+        foodComponent.setEatSeconds((float) foodSection.getDouble("eat_seconds", 1.6));
+
+        ConfigurationSection effectsSection = foodSection.getConfigurationSection("effects");
+        if (effectsSection != null) for (String effect : effectsSection.getKeys(false)) {
+            PotionEffectType effectType = PotionUtils.getEffectType(effect);
+            if (effectType == null)
+                Logs.logError("Invalid potion effect: " + effect + ", in " + StringUtils.substringBefore(effectsSection.getCurrentPath(), ".") + " food-property!");
+            else {
+                foodComponent.addEffect(
+                        new PotionEffect(effectType,
+                                foodSection.getInt("duration", 1) * 20,
+                                foodSection.getInt("amplifier", 0),
+                                foodSection.getBoolean("ambient", true),
+                                foodSection.getBoolean("show_particles", true),
+                                foodSection.getBoolean("show_icon", true)),
+                        (float) foodSection.getDouble("probability", 1.0)
+                );
+            }
+        }
+        item.setFoodComponent(foodComponent);
     }
 
     private void parseMiscOptions(ItemBuilder item) {

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
@@ -246,7 +246,7 @@ public class ItemUpdater implements Listener {
             // Thus removing the need for this logic
             if (!VersionUtil.atOrAbove("1.20.5")) {
 
-                String oldDisplayName = AdventureUtils.parseLegacy(VersionUtil.isPaperServer() ? AdventureUtils.MINI_MESSAGE.serialize(oldMeta.displayName()) : AdventureUtils.parseLegacy(oldMeta.getDisplayName()));
+                String oldDisplayName = oldMeta.hasDisplayName() ? AdventureUtils.parseLegacy(VersionUtil.isPaperServer() ? AdventureUtils.MINI_MESSAGE.serialize(oldMeta.displayName()) : AdventureUtils.parseLegacy(oldMeta.getDisplayName())) : null;
                 String originalName = AdventureUtils.parseLegacy(oldPdc.getOrDefault(ORIGINAL_NAME_KEY, DataType.STRING, ""));
 
                 if (Settings.OVERRIDE_RENAMED_ITEMS.toBool()) {

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
@@ -164,7 +164,7 @@ public class ItemUpdater implements Listener {
 
             // Transfer over durability from old item
             if (itemMeta instanceof Damageable damageable && oldMeta instanceof Damageable oldDmg) {
-                damageable.setDamage(oldDmg.getDamage());
+                if (oldDmg.hasDamage()) damageable.setDamage(oldDmg.getDamage());
             }
 
             if (oldMeta.isUnbreakable()) itemMeta.setUnbreakable(true);

--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -291,7 +291,7 @@ public class OraxenMeta {
     }
 
     public List<String> getLayers() {
-        return layers;
+        return layers != null ? layers : new ArrayList<>();
     }
 
     public boolean hasLayersMap() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/music_disc/MusicDiscListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/music_disc/MusicDiscListener.java
@@ -8,6 +8,7 @@ import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
@@ -48,8 +49,20 @@ public class MusicDiscListener implements Listener {
         boolean playing = insertAndPlayCustomDisc(event.getClickedBlock(), itemStack, player);
         if (!playing) return;
         player.swingMainHand();
-        Component message = AdventureUtils.MINI_MESSAGE.deserialize(Message.MECHANICS_JUKEBOX_NOW_PLAYING.toString(),
-                AdventureUtils.tagResolver("disc", AdventureUtils.parseLegacy(itemStack.getItemMeta().getDisplayName())));
+
+        Component discName = null;
+        if (itemStack.hasItemMeta()) {
+            if (VersionUtil.atOrAbove("1.20.5") && itemStack.getItemMeta().hasItemName()) {
+                if (VersionUtil.isPaperServer()) discName = itemStack.getItemMeta().itemName();
+                else discName = AdventureUtils.LEGACY_SERIALIZER.deserialize(itemStack.getItemMeta().getItemName());
+            } else if (itemStack.getItemMeta().hasDisplayName()) {
+                if (VersionUtil.isPaperServer()) discName = itemStack.getItemMeta().displayName();
+                else discName = AdventureUtils.LEGACY_SERIALIZER.deserialize(itemStack.getItemMeta().getDisplayName());
+            }
+        }
+        if (discName == null) discName = Component.empty();
+
+        Component message = AdventureUtils.MINI_MESSAGE.deserialize(Message.MECHANICS_JUKEBOX_NOW_PLAYING.toString(), AdventureUtils.tagResolver("disc", discName));
         OraxenPlugin.get().getAudience().player(player).sendActionBar(message);
         event.setCancelled(true);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -487,6 +487,7 @@ public class DuplicationHandler {
         }
     }
 
+    @Deprecated(forRemoval = true)
     public static void convertOldMigrateItemConfig() {
         File oldMigrateConfigFile = OraxenPlugin.get().getDataFolder().toPath().resolve("items/migrated_duplicates.yml").toFile();
         if (!oldMigrateConfigFile.exists()) return;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelGenerator.java
@@ -2,7 +2,9 @@ package io.th0rgal.oraxen.pack.generation;
 
 import com.google.gson.JsonObject;
 import io.th0rgal.oraxen.items.OraxenMeta;
+import io.th0rgal.oraxen.utils.Utils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ModelGenerator {
@@ -12,41 +14,43 @@ public class ModelGenerator {
     public ModelGenerator(OraxenMeta oraxenMeta) {
         JsonObject textures = new JsonObject();
         String parentModel = oraxenMeta.getParentModel();
+        List<String> layers = new ArrayList<>(oraxenMeta.getLayers());
+        String defaultTexture = Utils.getOrDefault(layers, 0, "");
 
         json.addProperty("parent", parentModel);
         if (oraxenMeta.hasLayersMap()) { //Check if oraxen meta uses new texture system
             oraxenMeta.getLayersMap().forEach(textures::addProperty);
         } else if (oraxenMeta.hasLayers()) { //Use old texture system
-            List<String> layers = oraxenMeta.getLayers();
+
             if (parentModel.equals("block/cube") || parentModel.equals("block/cube_directional") || parentModel.equals("block/cube_mirrored")) {
-                textures.addProperty("particle", layers.get(2));
-                textures.addProperty("down", layers.get(0));
-                textures.addProperty("up", layers.get(1));
-                textures.addProperty("north", layers.get(2));
-                textures.addProperty("south", layers.get(3));
-                textures.addProperty("west", layers.get(4));
-                textures.addProperty("east", layers.get(5));
+                textures.addProperty("particle", Utils.getOrDefault(layers, 2, defaultTexture));
+                textures.addProperty("down", defaultTexture);
+                textures.addProperty("up", Utils.getOrDefault(layers, 1, defaultTexture));
+                textures.addProperty("north", Utils.getOrDefault(layers, 2, defaultTexture));
+                textures.addProperty("south", Utils.getOrDefault(layers, 3, defaultTexture));
+                textures.addProperty("west", Utils.getOrDefault(layers, 4, defaultTexture));
+                textures.addProperty("east", Utils.getOrDefault(layers, 5, defaultTexture));
             } else if (parentModel.equals("block/cube_all") || parentModel.equals("block/cube_mirrored_all")) {
-                textures.addProperty("all", layers.get(0));
+                textures.addProperty("all", defaultTexture);
             } else if (parentModel.equals("block/cross")) {
-                textures.addProperty("cross", layers.get(0));
+                textures.addProperty("cross", defaultTexture);
             } else if (parentModel.startsWith("block/orientable")) {
-                textures.addProperty("front", layers.get(0));
-                textures.addProperty("side", layers.get(1));
+                textures.addProperty("front", defaultTexture);
+                textures.addProperty("side", Utils.getOrDefault(layers, 1, defaultTexture));
                 if (!parentModel.endsWith("vertical"))
-                    textures.addProperty("top", layers.get(2));
+                    textures.addProperty("top", Utils.getOrDefault(layers, 2, defaultTexture));
                 if (parentModel.endsWith("with_bottom"))
-                    textures.addProperty("bottom", layers.get(3));
+                    textures.addProperty("bottom", Utils.getOrDefault(layers, 3, defaultTexture));
             } else if (parentModel.startsWith("block/cube_column")) {
-                textures.addProperty("end", layers.get(0));
-                textures.addProperty("side", layers.get(1));
+                textures.addProperty("end", defaultTexture);
+                textures.addProperty("side", Utils.getOrDefault(layers, 1, defaultTexture));
             } else if (parentModel.equals("block/cube_bottom_top")) {
-                textures.addProperty("top", layers.get(0));
-                textures.addProperty("side", layers.get(1));
-                textures.addProperty("bottom", layers.get(2));
+                textures.addProperty("top", defaultTexture);
+                textures.addProperty("side", Utils.getOrDefault(layers, 1, defaultTexture));
+                textures.addProperty("bottom", Utils.getOrDefault(layers, 2, defaultTexture));
             } else if (parentModel.equals("block/cube_top")) {
-                textures.addProperty("top", layers.get(0));
-                textures.addProperty("side", layers.get(1));
+                textures.addProperty("top", defaultTexture);
+                textures.addProperty("side", Utils.getOrDefault(layers, 1, defaultTexture));
             } else {
                 for (int i = 0; i < layers.size(); i++)
                     textures.addProperty("layer" + i, layers.get(i));

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PredicatesGenerator.java
@@ -13,10 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
-import org.bukkit.inventory.meta.PotionMeta;
-import org.bukkit.inventory.meta.SpawnEggMeta;
+import org.bukkit.inventory.meta.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +39,9 @@ public class PredicatesGenerator {
         if (material == Material.TIPPED_ARROW) {
             textures.addProperty("layer0", "item/tipped_arrow_head");
             textures.addProperty("layer1", "item/tipped_arrow_base");
+        } else if (material == Material.FIREWORK_STAR) {
+            textures.addProperty("layer0", vanillaTextureName);
+            textures.addProperty("layer1", vanillaTextureName + "_overlay");
         } else if (exampleMeta instanceof PotionMeta) {
             textures.addProperty("layer0", "item/potion_overlay");
             textures.addProperty("layer1", vanillaTextureName);

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/listeners/RecipesEventsManager.java
@@ -71,7 +71,7 @@ public class RecipesEventsManager implements Listener {
         boolean containsOraxenItem = Arrays.stream(event.getInventory().getMatrix()).anyMatch(OraxenItems::exists);
         if (!containsOraxenItem || recipe == null) return;
 
-        if (whitelistedCraftRecipes.stream().anyMatch(customRecipe::equals) || customRecipe.isValidDyeRecipe()) return;
+        if (customRecipe == null || whitelistedCraftRecipes.stream().anyMatch(customRecipe::equals) || customRecipe.isValidDyeRecipe()) return;
 
         event.getInventory().setResult(customRecipe.getResult());
     }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/AdventureUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/AdventureUtils.java
@@ -164,4 +164,8 @@ public class AdventureUtils {
     public static TagResolver tagResolver(String string, String tag) {
         return TagResolver.resolver(string, Tag.selfClosingInserting(AdventureUtils.MINI_MESSAGE.deserialize(tag)));
     }
+
+    public static TagResolver tagResolver(String string, Component tag) {
+        return TagResolver.resolver(string, Tag.selfClosingInserting(tag));
+    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/Utils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/Utils.java
@@ -175,4 +175,20 @@ public class Utils {
 
         return new IntegerRange(minAmount, maxAmount);
     }
+
+    public static <T> T getOrNull(List<T> list, int index) {
+        try {
+            return list.get(index);
+        } catch (IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    public static <T> T getOrDefault(List<T> list, int index, T defaultValue) {
+        try {
+            return list.get(index);
+        } catch (IndexOutOfBoundsException e) {
+            return defaultValue;
+        }
+    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorListener.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.utils.customarmor;
 
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.InventoryUtils;
@@ -7,6 +8,7 @@ import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.armorequipevent.ArmorEquipEvent;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -36,6 +38,18 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Locale;
 
 public class CustomArmorListener implements Listener {
+
+    public CustomArmorListener() {
+        if (!VersionUtil.isPaperServer()) return;
+        Bukkit.getPluginManager().registerEvents(new Listener() {
+            @EventHandler
+            public void onPlayerPickup(PlayerAttemptPickupItemEvent event) {
+                ItemStack item = event.getItem().getItemStack();
+                setVanillaArmorTrim(item);
+                event.getItem().setItemStack(item);
+            }
+        }, OraxenPlugin.get());
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onCustomArmorRepair(PrepareAnvilEvent event) {
@@ -82,13 +96,6 @@ public class CustomArmorListener implements Listener {
     public void updateVanillaArmor(PlayerJoinEvent event) {
         for (ItemStack item : event.getPlayer().getInventory().getContents())
             setVanillaArmorTrim(item);
-    }
-
-    @EventHandler
-    public void onPlayerPickup(PlayerAttemptPickupItemEvent event) {
-        ItemStack item = event.getItem().getItemStack();
-        setVanillaArmorTrim(item);
-        event.getItem().setItemStack(item);
     }
 
     @EventHandler

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/ItemsView.java
@@ -134,7 +134,7 @@ public class ItemsView {
 
         itemStack = icon.map(OraxenItems::getItemById).map(ItemBuilder::clone)
                 .orElse(OraxenItems.getMap().get(file).values().stream().findFirst().orElse(new ItemBuilder(Material.PAPER)))
-                .clone().addItemFlags(ItemFlag.HIDE_ATTRIBUTES).setDisplayName(displayName).setLore(new ArrayList<>()).build();
+                .clone().addItemFlags(ItemFlag.HIDE_ATTRIBUTES).setItemName(displayName).setDisplayName(displayName).setLore(new ArrayList<>()).build();
 
         // avoid possible bug if isOraxenItems is available but can't be an itemstack
         if (itemStack == null) itemStack = new ItemBuilder(Material.PAPER).setDisplayName(displayName).build();

--- a/core/src/main/resources/items/items.yml
+++ b/core/src/main/resources/items/items.yml
@@ -10,7 +10,6 @@ example_sword:
   displayname: "<gradient:#FA7CBB:#F14658><bold>My Custom Sword"
   material: WOODEN_SWORD
   injectID: false # allow Oraxen to recognise the item if true or not set
-  durability: 10 # Only for 1.20.5+ servers
 
   ItemFlags:
     - HIDE_ENCHANTS

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pluginVersion=1.178.0
+pluginVersion=1.179.0
 idofrontVersion=0.21.12


### PR DESCRIPTION
**[New]**
- Add support for replacement item in FoodComponent (1.21+ only)
- Support for [ToolComponent](https://docs.oraxen.com/configuration/items-advanced#id-1.20.5-specific-properties)

**[Changes]**
- Support for HuskTowns added
- Support for CrashClaims removed
- `displayname`-> `itemname` for OraxenItem configs on 1.20.5+
- `customname` to allow legacy usage of DisplayName over ItemName on 1.20.5+
- Extract default item-configs with correct version properties
  * Durability-Mechanic -> Durability Component
  * Food-Mechanic -> Food Component
  * displayname -> itemname

**[Fixes]**
- `hide_scoreboard_numbers` not working on 1.20.4+
- MusicDisc-mechanic not showing tooltip correctly
- Default item-configs extracting with deprecated durability-mechanic
- Issues with updating DisplayName of items on 1.20.4 & below
- Missing parent-model definitions
- Several issues when using FIREWORK_STAR as base-material
- Minor recipe issues
- Minor Spigot server issues