### PR TITLE
Make Oraxen compatible with JDK 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,10 +7,10 @@ import kotlin.io.path.listDirectoryEntries
 plugins {
     id("java")
     //id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("xyz.jpenilla.run-paper") version "2.2.4"
+    id("xyz.jpenilla.run-paper") version "2.3.0"
     id("net.minecrell.plugin-yml.bukkit") version "0.6.0" // Generates plugin.yml
     id("io.papermc.paperweight.userdev") version "1.7.1" apply false
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
     alias(libs.plugins.mia.publication)
 }
 
@@ -114,6 +114,10 @@ allprojects {
 
         implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }
     }
+
+    tasks.compileJava {
+        options.compilerArgs.addAll(listOf("-source", "17", "-target", "17")) // Make Oraxen compatible with JDK 17
+    }
 }
 
 dependencies {
@@ -147,7 +151,7 @@ tasks {
         downloadPlugins {
             url("https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/build/libs/ProtocolLib.jar")
         }
-        minecraftVersion("1.20.4")
+        minecraftVersion("1.21")
     }
 
     shadowJar {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
     //id("io.papermc.paperweight.userdev") version "1.6.0"
     id("maven-publish")
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
     id("org.ajoberstar.grgit.service") version "5.2.0"
 }
 

--- a/v1_18_R1/build.gradle.kts
+++ b/v1_18_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_18_R2/build.gradle.kts
+++ b/v1_18_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_19_R1/build.gradle.kts
+++ b/v1_19_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_19_R2/build.gradle.kts
+++ b/v1_19_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_19_R3/build.gradle.kts
+++ b/v1_19_R3/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_20_R1/build.gradle.kts
+++ b/v1_20_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_20_R2/build.gradle.kts
+++ b/v1_20_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_20_R3/build.gradle.kts
+++ b/v1_20_R3/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {
@@ -18,8 +18,4 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
     }
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }

--- a/v1_20_R4/build.gradle.kts
+++ b/v1_20_R4/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_21_R1/build.gradle.kts
+++ b/v1_21_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {


### PR DESCRIPTION
![화면 캡처 2024-07-15 225139](https://github.com/user-attachments/assets/4dcebfbc-3ad2-440a-976a-770ed5d06f4d)
This commit will force Oraxen to build with class version 61(Java 17) even it's toolchain is 21.  
This will make it compatible with 1.20.1 or lower version of Bukkit.