### PR TITLE
fix: thread deadlock issue with breaker system

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -56,6 +56,7 @@ public class OraxenPlugin extends JavaPlugin {
     private InvManager invManager;
     private ResourcePack resourcePack;
     private ClickActionManager clickActionManager;
+    private BreakerSystem breakerSystem;
     public static boolean supportsDisplayEntities;
 
     public OraxenPlugin() {
@@ -94,7 +95,8 @@ public class OraxenPlugin extends JavaPlugin {
         if (Settings.KEEP_UP_TO_DATE.toBool())
             new SettingsUpdater().handleSettingsUpdate();
         if (PluginUtils.isEnabled("ProtocolLib")) {
-            new BreakerSystem().registerListener();
+            breakerSystem = new BreakerSystem();
+            breakerSystem.registerListener();
             if (Settings.FORMAT_INVENTORY_TITLES.toBool())
                 ProtocolLibrary.getProtocolManager().addPacketListener(new InventoryPacketListener());
             ProtocolLibrary.getProtocolManager().addPacketListener(new TitlePacketListener());
@@ -145,6 +147,9 @@ public class OraxenPlugin extends JavaPlugin {
         FurnitureFactory.unregisterEvolution();
         for (Player player : Bukkit.getOnlinePlayers())
             if (GlyphHandlers.isNms()) NMSHandlers.getHandler().glyphHandler().uninject(player);
+
+        if (breakerSystem != null)
+            breakerSystem.unregisterListener();
 
         CompatibilitiesManager.disableCompatibilities();
         CommandAPI.onDisable();

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.utils.breaker;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.async.AsyncListenerHandler;
 import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
@@ -200,6 +201,7 @@ public class BreakerSystem {
             }
         }
     };
+    private AsyncListenerHandler asyncListenerHandler;
 
     private List<Location> furnitureBarrierLocations(FurnitureMechanic furnitureMechanic, Block block) {
         BukkitScheduler scheduler = breakerPerLocation.get(block.getLocation());
@@ -291,7 +293,15 @@ public class BreakerSystem {
     }
 
     public void registerListener() {
-        ProtocolLibrary.getProtocolManager().addPacketListener(listener);
+        asyncListenerHandler = ProtocolLibrary.getProtocolManager().getAsynchronousManager().registerAsyncHandler(listener);
+        asyncListenerHandler.start();
+    }
+
+    public void unregisterListener() {
+        if (asyncListenerHandler != null) {
+            asyncListenerHandler.stop();
+            ProtocolLibrary.getProtocolManager().getAsynchronousManager().unregisterAsyncHandler(listener);
+        }
     }
 
     private BlockSounds getBlockSounds(Block block) {


### PR DESCRIPTION
Until now, the breaker system packet listener was executed directly in the Netty thread.
At the same time, the breaker system synchronizes with the main thread when accessing the block type. 
If all netty threads are occupied by the breaker system, a race condition may occur, with the main thread waiting for a free netty thread and the breaker system waiting for a free main thread. 
As a result, the entire server will deadlock. With lower TPS, there is a greater chance that a deadlock will occur.

This fix uses an asynchronous packet listener that is supported by the ProtocolLib plugin. This prevents the netty thread from being busy while waiting for the main thread, and thus deadlock race condition cannot occur.