### PR TITLE
Adds Pack.generation.merge-other-resource-pack option.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("xyz.jpenilla.run-paper") version "2.2.4"
     id("net.minecrell.plugin-yml.bukkit") version "0.6.0" // Generates plugin.yml
     id("io.papermc.paperweight.userdev") version "1.7.1" apply false
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
     alias(libs.plugins.mia.publication)
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
     //id("io.papermc.paperweight.userdev") version "1.6.0"
     id("maven-publish")
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
     id("org.ajoberstar.grgit.service") version "5.2.0"
 }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VirtualFile.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VirtualFile.java
@@ -8,9 +8,9 @@ import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 public class VirtualFile implements Comparable<VirtualFile> {
 
@@ -27,6 +27,14 @@ public class VirtualFile implements Comparable<VirtualFile> {
                 : parentFolder;
         this.name = name;
         this.inputStream = inputStream;
+    }
+
+    public static VirtualFile of(String parent, File file) {
+        try {
+            return new VirtualFile(parent, file.getName(), new BufferedInputStream(new FileInputStream(file)));
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public InputStream getInputStream() {
@@ -49,6 +57,19 @@ public class VirtualFile implements Comparable<VirtualFile> {
                 ? newParent.replace("\\", "/")
                 : newParent;
         this.name = newPath.substring(newPath.lastIndexOf("/") + 1);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VirtualFile that = (VirtualFile) o;
+        return Objects.equals(getPath(), that.getPath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getPath());
     }
 
     @Override

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -106,6 +106,8 @@ Pack:
      \nplugin and any complete or partial
      \nuse must comply with the terms and
      \nconditions of Oraxen."
+    merge-other-resource-pack:
+      - ModelEngine/resource pack
 
   import:
     # Merges duplicate font files, most often default.json into the final pack.

--- a/v1_18_R1/build.gradle.kts
+++ b/v1_18_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_18_R2/build.gradle.kts
+++ b/v1_18_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_19_R1/build.gradle.kts
+++ b/v1_19_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_19_R2/build.gradle.kts
+++ b/v1_19_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_19_R3/build.gradle.kts
+++ b/v1_19_R3/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_20_R1/build.gradle.kts
+++ b/v1_20_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_20_R2/build.gradle.kts
+++ b/v1_20_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_20_R3/build.gradle.kts
+++ b/v1_20_R3/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_20_R4/build.gradle.kts
+++ b/v1_20_R4/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {

--- a/v1_21_R1/build.gradle.kts
+++ b/v1_21_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "1.7.1"
-    id("io.github.goooler.shadow") version "8.1.7"
+    id("io.github.goooler.shadow") version "8.1.8"
 }
 
 repositories {


### PR DESCRIPTION
```yaml
Pack:
  generation:
    generate: true # Unlike Plugin.generation.default_assets, this will enable/disable all pack generation
    # List of file extensions that will not be included in the final zipped ResourcePack
    excluded_file_extensions: []
    verify_pack_files: true # Checks all textures and models to make sure they abide by valid Resourcepack formatting
    fix_force_unicode_glyphs: true # Fixes glyphs not being shown when Force Unicode is enabled
    texture_slicer: true # Slices default-texture overrides into new 1.20.2 format
    atlas:
      exclude_malformed_from_atlas: true # If a texture is malformed, it will not be included in the atlas
      generate: true
      type: "SPRITE" # "SPRITE" or "DIRECTORY"
    auto_generated_models_follow_texture_path: false
    compression: BEST_COMPRESSION # see Deflater.class
    # protection will use several methods to make your pack impossible to extract
    # with usual tools (native windows unzip, 7zip, winrar, etc) without altering
    # its integrity. Be careful if you activate this option to not try to extract
    # the pack, or you might fill your disk.
    protection: false
    comment: "The content of this texture pack
     \nbelongs to the owner of the Oraxen
     \nplugin and any complete or partial
     \nuse must comply with the terms and
     \nconditions of Oraxen."
    merge-other-resource-pack:
      - ModelEngine/resource pack
      - BetterHud/build
```
This commit will make Oraxen can merge other plugin's resource pack when zipped.
![화면 캡처 2024-08-05 212555](https://github.com/user-attachments/assets/14de3485-b6bb-47a9-b665-cae13a986dac)
![2024-08-05_21 26 17](https://github.com/user-attachments/assets/c1807324-3a63-4e15-9644-82be1ca40a00)
