### PR TITLE
Fixed HIDE_ATTRIBUTES not hiding on recent versions of Minecraft.

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -610,6 +610,12 @@ public class ItemBuilder {
             } else itemMeta.setDisplayName(displayName);
         }
 
+        if (hasAttributeModifiers) {
+            itemMeta.setAttributeModifiers(attributeModifiers);
+        } else {
+            itemMeta.setAttributeModifiers(HashMultimap.create());
+        }
+
         if (itemFlags != null)
             itemMeta.addItemFlags(itemFlags.toArray(new ItemFlag[0]));
 
@@ -620,9 +626,6 @@ public class ItemBuilder {
                 itemMeta.addEnchant(enchant.getKey(), lvl, true);
             }
         }
-
-        if (hasAttributeModifiers)
-            itemMeta.setAttributeModifiers(attributeModifiers);
 
         if (hasCustomModelData)
             itemMeta.setCustomModelData(customModelData);


### PR DESCRIPTION
Version Minecraft : (My own Fork Folia)
```
Loading Bloom 1.21.1-24-ver/1.21@75d4e0b (2024-08-31T18:00:05Z) for Minecraft 1.21.1
```

Before : 
![image](https://github.com/user-attachments/assets/2b7d9493-e8f3-491e-8739-1aeaa485a4a5)


After : 
![image](https://github.com/user-attachments/assets/9cb49497-bbef-4665-b926-6b938fd088d8)

How reproduce bug : 
```yml
pht1:
  itemname: test pickaxe
  material: NETHERITE_PICKAXE
  injectID: false
  unbreakable: true
  Enchantments:
    efficiency: 5
    fortune: 3
  ItemFlags:
    - HIDE_ENCHANTS
    - HIDE_ATTRIBUTES
    - HIDE_UNBREAKABLE
    - HIDE_DESTROYS
    - HIDE_PLACED_ON
    - HIDE_POTION_EFFECTS
    - HIDE_ADDITIONAL_TOOLTIP
    - HIDE_DYE
    - HIDE_ARMOR_TRIM
    - HIDE_STORED_ENCHANTS
```