### PR TITLE
Bug Fix: Correct Tool Component Default Values in `ComponentParser`

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/ComponentParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ComponentParser.java
@@ -81,8 +81,8 @@ public class ComponentParser {
         if (toolSection == null) return;
 
         ToolComponent toolComponent = new ItemStack(Material.PAPER).getItemMeta().getTool();
-        toolComponent.setDamagePerBlock(Math.min(toolSection.getInt("damage_per_block", 1), 0));
-        toolComponent.setDefaultMiningSpeed(Math.min((float) toolSection.getDouble("default_mining_speed", 1.0), 0f));
+        toolComponent.setDamagePerBlock(Math.max(toolSection.getInt("damage_per_block", 1), 0));
+        toolComponent.setDefaultMiningSpeed(Math.max((float) toolSection.getDouble("default_mining_speed", 1.0), 0f));
 
         for (Map<?, ?> ruleEntry : toolSection.getMapList("rules")) {
             float speed = ParseUtils.parseFloat(String.valueOf(ruleEntry.get("speed")), 1.0f);


### PR DESCRIPTION
**Note:** The documentation didn't say where to put PRs for 2.0, so I'm sending them to the 2.0/master branch. If it's the wrong place, I'm sorry.

**Description:**
- Fixed a bug where `default_mining_speed` and `damage_per_block` tool components were set to 0 when called in configuration files.

**Changes:**
- Updated `setDamagePerBlock` and `setDefaultMiningSpeed` calls to use `Math.max` instead of `Math.min`.

**Testing:**
- Verified that `default_mining_speed` and `damage_per_block` are correctly set for various tool configurations.
- Verified that when `default_mining_speed` and `damage_per_block`  are set to the minimum 0 on items when the config contains values below 0.