### PR TITLE
1.185.0 Jukebox Update

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -43,6 +43,7 @@ public enum Message {
     PLUGIN_UNLOADED("logs.unloaded"),
     NO_ARMOR_ITEM("logs.no_armor_item"),
     DUPLICATE_ARMOR_COLOR("logs.duplicate_armor_color"),
+    DATAPACK_GENERATED("logs.datapack_generated"),
 
     // command
     COMMAND_HELP("command.help"),
@@ -83,7 +84,6 @@ public enum Message {
         this.path = path;
     }
 
-
     public String getPath() {
         return path;
     }
@@ -94,12 +94,13 @@ public enum Message {
     }
 
     public void send(final CommandSender sender, final TagResolver... placeholders) {
-        if (sender == null) return;
+        if (sender == null)
+            return;
         String lang = OraxenPlugin.get().getConfigsManager().getLanguage().getString(path);
-        if (lang == null || lang.isEmpty()) return;
+        if (lang == null || lang.isEmpty())
+            return;
         OraxenPlugin.get().getAudience().sender(sender).sendMessage(
-                AdventureUtils.MINI_MESSAGE.deserialize(lang, TagResolver.resolver(placeholders))
-        );
+                AdventureUtils.MINI_MESSAGE.deserialize(lang, TagResolver.resolver(placeholders)));
     }
 
     @NotNull

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -58,19 +58,26 @@ public class ItemParser {
     public ItemParser(ConfigurationSection section) {
         this.section = section;
 
-        if (section.isString("template")) templateItem = ItemTemplate.getParserTemplate(section.getString("template"));
+        if (section.isString("template"))
+            templateItem = ItemTemplate.getParserTemplate(section.getString("template"));
 
         ConfigurationSection crucibleSection = section.getConfigurationSection("crucible");
         ConfigurationSection mmoSection = section.getConfigurationSection("mmoitem");
         ConfigurationSection ecoItemSection = section.getConfigurationSection("ecoitem");
-        if (crucibleSection != null) crucibleItem = new WrappedCrucibleItem(crucibleSection);
-        else if (section.isString("crucible_id")) crucibleItem = new WrappedCrucibleItem(section.getString("crucible_id"));
-        else if (ecoItemSection != null) ecoItem = new WrappedEcoItem(ecoItemSection);
-        else if (section.isString("ecoitem_id")) ecoItem = new WrappedEcoItem(section.getString("ecoitem_id"));
-        else if (mmoSection != null) mmoItem = new WrappedMMOItem(mmoSection);
+        if (crucibleSection != null)
+            crucibleItem = new WrappedCrucibleItem(crucibleSection);
+        else if (section.isString("crucible_id"))
+            crucibleItem = new WrappedCrucibleItem(section.getString("crucible_id"));
+        else if (ecoItemSection != null)
+            ecoItem = new WrappedEcoItem(ecoItemSection);
+        else if (section.isString("ecoitem_id"))
+            ecoItem = new WrappedEcoItem(section.getString("ecoitem_id"));
+        else if (mmoSection != null)
+            mmoItem = new WrappedMMOItem(mmoSection);
 
         Material material = Material.getMaterial(section.getString("material", ""));
-        if (material == null) material = usesTemplate() ? templateItem.type : Material.PAPER;
+        if (material == null)
+            material = usesTemplate() ? templateItem.type : Material.PAPER;
         type = material;
 
         oraxenMeta = templateItem != null ? templateItem.oraxenMeta : new OraxenMeta();
@@ -85,7 +92,7 @@ public class ItemParser {
     }
 
     public boolean usesMMOItems() {
-        return crucibleItem == null && ecoItem == null  && mmoItem != null && mmoItem.build() != null;
+        return crucibleItem == null && ecoItem == null && mmoItem != null && mmoItem.build() != null;
     }
 
     public boolean usesCrucibleItems() {
@@ -103,10 +110,14 @@ public class ItemParser {
     public ItemBuilder buildItem() {
         ItemBuilder item;
 
-        if (usesCrucibleItems()) item = new ItemBuilder(crucibleItem);
-        else if (usesMMOItems()) item = new ItemBuilder(mmoItem);
-        else if (usesEcoItems()) item = new ItemBuilder(ecoItem);
-        else item = new ItemBuilder(type);
+        if (usesCrucibleItems())
+            item = new ItemBuilder(crucibleItem);
+        else if (usesMMOItems())
+            item = new ItemBuilder(mmoItem);
+        else if (usesEcoItems())
+            item = new ItemBuilder(ecoItem);
+        else
+            item = new ItemBuilder(type);
 
         // If item has a template, apply the template ontop of the builder made above
         return applyConfig(usesTemplate() ? templateItem.applyConfig(item) : item);
@@ -114,21 +125,31 @@ public class ItemParser {
 
     private ItemBuilder applyConfig(ItemBuilder item) {
         if (section.contains("displayname")) {
-            if (VersionUtil.atOrAbove("1.20.5")) configUpdated = true;
-            else item.setDisplayName(section.getString("displayname", ""));
+            if (VersionUtil.atOrAbove("1.20.5"))
+                configUpdated = true;
+            else
+                item.setDisplayName(section.getString("displayname", ""));
         }
 
         if (section.contains("customname")) {
-            if (!VersionUtil.atOrAbove("1.20.5")) configUpdated = true;
-            else item.setDisplayName(section.getString("customname", ""));
+            if (!VersionUtil.atOrAbove("1.20.5"))
+                configUpdated = true;
+            else
+                item.setDisplayName(section.getString("customname", ""));
         }
 
-        //if (section.contains("type")) item.setType(Material.getMaterial(section.getString("type", "PAPER")));
-        if (section.contains("lore")) item.setLore(section.getStringList("lore").stream().map(AdventureUtils::parseMiniMessage).toList());
-        if (section.contains("unbreakable")) item.setUnbreakable(section.getBoolean("unbreakable", false));
-        if (section.contains("unstackable")) item.setUnstackable(section.getBoolean("unstackable", false));
-        if (section.contains("color")) item.setColor(Utils.toColor(section.getString("color", "#FFFFFF")));
-        if (section.contains("trim_pattern")) item.setTrimPattern(Key.key(section.getString("trim_pattern", "")));
+        // if (section.contains("type"))
+        // item.setType(Material.getMaterial(section.getString("type", "PAPER")));
+        if (section.contains("lore"))
+            item.setLore(section.getStringList("lore").stream().map(AdventureUtils::parseMiniMessage).toList());
+        if (section.contains("unbreakable"))
+            item.setUnbreakable(section.getBoolean("unbreakable", false));
+        if (section.contains("unstackable"))
+            item.setUnstackable(section.getBoolean("unstackable", false));
+        if (section.contains("color"))
+            item.setColor(Utils.toColor(section.getString("color", "#FFFFFF")));
+        if (section.contains("trim_pattern"))
+            item.setTrimPattern(Key.key(section.getString("trim_pattern", "")));
 
         parseDataComponents(item);
         parseMiscOptions(item);
@@ -140,67 +161,90 @@ public class ItemParser {
 
     private void parseDataComponents(ItemBuilder item) {
         ConfigurationSection section = mergeWithTemplateSection();
-        if (section.contains("itemname") && VersionUtil.atOrAbove("1.20.5")) item.setItemName(section.getString("itemname"));
-        else if (section.contains("displayname")) item.setItemName(section.getString("displayname"));
+        if (section.contains("itemname") && VersionUtil.atOrAbove("1.20.5"))
+            item.setItemName(section.getString("itemname"));
+        else if (section.contains("displayname"))
+            item.setItemName(section.getString("displayname"));
 
         ConfigurationSection components = section.getConfigurationSection("Components");
-        if (components == null || !VersionUtil.atOrAbove("1.20.5")) return;
+        if (components == null || !VersionUtil.atOrAbove("1.20.5"))
+            return;
 
-        if (components.contains("max_stack_size")) item.setMaxStackSize(Math.clamp(components.getInt("max_stack_size"), 1, 99));
+        if (components.contains("max_stack_size"))
+            item.setMaxStackSize(Math.clamp(components.getInt("max_stack_size"), 1, 99));
 
-        if (components.contains("enchantment_glint_override")) item.setEnchantmentGlindOverride(components.getBoolean("enchantment_glint_override"));
+        if (components.contains("enchantment_glint_override"))
+            item.setEnchantmentGlindOverride(components.getBoolean("enchantment_glint_override"));
         if (components.contains("durability")) {
             item.setDamagedOnBlockBreak(components.getBoolean("durability.damage_block_break"));
             item.setDamagedOnEntityHit(components.getBoolean("durability.damage_entity_hit"));
             item.setDurability(Math.max(components.getInt("durability.value"), components.getInt("durability", 1)));
         }
-        if (components.contains("rarity")) item.setRarity(ItemRarity.valueOf(components.getString("rarity")));
-        if (components.contains("fire_resistant")) item.setFireResistant(components.getBoolean("fire_resistant"));
-        if (components.contains("hide_tooltip")) item.setHideToolTip(components.getBoolean("hide_tooltip"));
+        if (components.contains("rarity"))
+            item.setRarity(ItemRarity.valueOf(components.getString("rarity")));
+        if (components.contains("fire_resistant"))
+            item.setFireResistant(components.getBoolean("fire_resistant"));
+        if (components.contains("hide_tooltip"))
+            item.setHideToolTip(components.getBoolean("hide_tooltip"));
 
-        Optional.ofNullable(components.getConfigurationSection("food")).ifPresent(food ->NMSHandlers.getHandler().foodComponent(item, food));
-        Optional.ofNullable(components.getConfigurationSection("tool")).ifPresent(toolSection -> parseToolComponent(item, toolSection));
+        Optional.ofNullable(components.getConfigurationSection("food"))
+                .ifPresent(food -> NMSHandlers.getHandler().foodComponent(item, food));
+        Optional.ofNullable(components.getConfigurationSection("tool"))
+                .ifPresent(toolSection -> parseToolComponent(item, toolSection));
 
-        if (!VersionUtil.atOrAbove("1.21")) return;
+        if (!VersionUtil.atOrAbove("1.21"))
+            return;
 
         ConfigurationSection jukeboxSection = components.getConfigurationSection("jukebox_playable");
         if (jukeboxSection != null) {
-            JukeboxPlayableComponent jukeboxPlayable = new ItemStack(Material.MUSIC_DISC_CREATOR).getItemMeta().getJukeboxPlayable();
+            JukeboxPlayableComponent jukeboxPlayable = new ItemStack(Material.MUSIC_DISC_CREATOR).getItemMeta()
+                    .getJukeboxPlayable();
             jukeboxPlayable.setShowInTooltip(jukeboxSection.getBoolean("show_in_tooltip"));
             jukeboxPlayable.setSongKey(NamespacedKey.fromString(jukeboxSection.getString("song_key", "")));
             item.setJukeboxPlayable(jukeboxPlayable);
         }
 
-        if (!VersionUtil.atOrAbove("1.21.2")) return;
+        if (!VersionUtil.atOrAbove("1.21.2"))
+            return;
         Optional.ofNullable(components.getConfigurationSection("equippable"))
                 .ifPresent(equippable -> parseEquippableComponent(item, equippable));
 
         Optional.ofNullable(components.getConfigurationSection("use_cooldown")).ifPresent((cooldownSection) -> {
             UseCooldownComponent useCooldownComponent = new ItemStack(Material.PAPER).getItemMeta().getUseCooldown();
-            String group = Optional.ofNullable(cooldownSection.getString("group")).orElse("oraxen:" + OraxenItems.getIdByItem(item));
-            if (!group.isEmpty()) useCooldownComponent.setCooldownGroup(NamespacedKey.fromString(group));
+            String group = Optional.ofNullable(cooldownSection.getString("group"))
+                    .orElse("oraxen:" + OraxenItems.getIdByItem(item));
+            if (!group.isEmpty())
+                useCooldownComponent.setCooldownGroup(NamespacedKey.fromString(group));
             useCooldownComponent.setCooldownSeconds((float) Math.max(cooldownSection.getDouble("seconds", 1.0), 0f));
             item.setUseCooldownComponent(useCooldownComponent);
         });
 
-        Optional.ofNullable(components.getConfigurationSection("use_remainder")).ifPresent(useRemainder -> parseUseRemainderComponent(item, useRemainder));
-        Optional.ofNullable(components.getString("damage_resistant")).map(NamespacedKey::fromString).ifPresent(damageResistantKey ->
-                item.setDamageResistant(Bukkit.getTag(DamageTypeTags.REGISTRY_DAMAGE_TYPES, damageResistantKey, DamageType.class))
-        );
+        Optional.ofNullable(components.getConfigurationSection("use_remainder"))
+                .ifPresent(useRemainder -> parseUseRemainderComponent(item, useRemainder));
+        Optional.ofNullable(components.getString("damage_resistant")).map(NamespacedKey::fromString)
+                .ifPresent(damageResistantKey -> item.setDamageResistant(
+                        Bukkit.getTag(DamageTypeTags.REGISTRY_DAMAGE_TYPES, damageResistantKey, DamageType.class)));
 
-        Optional.ofNullable(components.getString("tooltip_style")).map(NamespacedKey::fromString).ifPresent(item::setTooltipStyle);
+        Optional.ofNullable(components.getString("tooltip_style")).map(NamespacedKey::fromString)
+                .ifPresent(item::setTooltipStyle);
 
         Optional.ofNullable(components.getString("item_model")).map(NamespacedKey::fromString)
                 .ifPresentOrElse(item::setItemModel, () -> {
-                    if (oraxenMeta == null || !oraxenMeta.hasPackInfos()) return;
-                    if (oraxenMeta.getCustomModelData() != null) return;
-                    Optional.ofNullable(components.getString("item_model")).map(NamespacedKey::fromString).ifPresent(item::setItemModel);
+                    if (oraxenMeta == null || !oraxenMeta.hasPackInfos())
+                        return;
+                    if (oraxenMeta.getCustomModelData() != null)
+                        return;
+                    Optional.ofNullable(components.getString("item_model")).map(NamespacedKey::fromString)
+                            .ifPresent(item::setItemModel);
                 });
 
-        if (components.contains("enchantable")) item.setEnchantable(components.getInt("enchantable"));
-        if (components.contains("glider")) item.setGlider(components.getBoolean("glider"));
+        if (components.contains("enchantable"))
+            item.setEnchantable(components.getInt("enchantable"));
+        if (components.contains("glider"))
+            item.setGlider(components.getBoolean("glider"));
 
-        Optional.ofNullable(components.getConfigurationSection("consumable")).ifPresent(consumableSection -> NMSHandlers.getHandler().consumableComponent(item, consumableSection));
+        Optional.ofNullable(components.getConfigurationSection("consumable"))
+                .ifPresent(consumableSection -> NMSHandlers.getHandler().consumableComponent(item, consumableSection));
 
     }
 
@@ -209,24 +253,29 @@ public class ItemParser {
         int amount = useRemainderSection.getInt("amount", 1);
 
         if (useRemainderSection.contains("oraxen_item"))
-            result = ItemUpdater.updateItem(OraxenItems.getItemById(useRemainderSection.getString("oraxen_item")).build());
+            result = ItemUpdater
+                    .updateItem(OraxenItems.getItemById(useRemainderSection.getString("oraxen_item")).build());
         else if (useRemainderSection.contains("crucible_item"))
             result = new WrappedCrucibleItem(useRemainderSection.getString("crucible_item")).build();
         else if (useRemainderSection.contains("mmoitems_id") && useRemainderSection.isString("mmoitems_type"))
-            result = MMOItems.plugin.getItem(useRemainderSection.getString("mmoitems_type"), useRemainderSection.getString("mmoitems_id"));
+            result = MMOItems.plugin.getItem(useRemainderSection.getString("mmoitems_type"),
+                    useRemainderSection.getString("mmoitems_id"));
         else if (useRemainderSection.contains("ecoitem_id"))
             result = new WrappedEcoItem(useRemainderSection.getString("ecoitem_id")).build();
         else if (useRemainderSection.contains("minecraft_type")) {
             Material material = Material.getMaterial(useRemainderSection.getString("minecraft_type", "AIR"));
-            if (material == null || material.isAir()) return;
+            if (material == null || material.isAir())
+                return;
             result = new ItemStack(material);
-        } else result = useRemainderSection.getItemStack("minecraft_item");
+        } else
+            result = useRemainderSection.getItemStack("minecraft_item");
 
-        if (result != null) result.setAmount(amount);
+        if (result != null)
+            result.setAmount(amount);
         item.setUseRemainder(result);
     }
 
-    @SuppressWarnings({"UnstableApiUsage", "unchecked"})
+    @SuppressWarnings({ "UnstableApiUsage", "unchecked" })
     private void parseToolComponent(ItemBuilder item, @NotNull ConfigurationSection toolSection) {
         ToolComponent toolComponent = new ItemStack(type).getItemMeta().getTool();
         toolComponent.setDamagePerBlock(Math.max(toolSection.getInt("damage_per_block", 1), 0));
@@ -241,11 +290,13 @@ public class ItemParser {
             if (ruleEntry.containsKey("material")) {
                 try {
                     Material material = Material.valueOf(String.valueOf(ruleEntry.get("material")));
-                    if (material.isBlock()) materials.add(material);
+                    if (material.isBlock())
+                        materials.add(material);
                 } catch (Exception e) {
                     Logs.logWarning("Error parsing rule-entry in " + section.getName());
                     Logs.logWarning("Malformed \"material\"-section");
-                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                    if (Settings.DEBUG.toBool())
+                        e.printStackTrace();
                 }
             }
 
@@ -254,23 +305,27 @@ public class ItemParser {
                     List<String> materialIds = (List<String>) ruleEntry.get("materials");
                     for (String materialId : materialIds) {
                         Material material = Material.valueOf(materialId);
-                        if (material.isBlock()) materials.add(material);
+                        if (material.isBlock())
+                            materials.add(material);
                     }
                 } catch (Exception e) {
                     Logs.logWarning("Error parsing rule-entry in " + section.getName());
                     Logs.logWarning("Malformed \"materials\"-section");
-                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                    if (Settings.DEBUG.toBool())
+                        e.printStackTrace();
                 }
             }
 
             if (ruleEntry.containsKey("tag")) {
                 try {
                     NamespacedKey tagKey = NamespacedKey.fromString(String.valueOf(ruleEntry.get("tag")));
-                    if (tagKey != null) tags.add(Bukkit.getTag(Tag.REGISTRY_BLOCKS, tagKey, Material.class));
+                    if (tagKey != null)
+                        tags.add(Bukkit.getTag(Tag.REGISTRY_BLOCKS, tagKey, Material.class));
                 } catch (Exception e) {
                     Logs.logWarning("Error parsing rule-entry in " + section.getName());
                     Logs.logWarning("Malformed \"tag\"-section");
-                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                    if (Settings.DEBUG.toBool())
+                        e.printStackTrace();
                 }
             }
 
@@ -278,17 +333,21 @@ public class ItemParser {
                 try {
                     for (String tagString : (List<String>) ruleEntry.get("tags")) {
                         NamespacedKey tagKey = NamespacedKey.fromString(tagString);
-                        if (tagKey != null) tags.add(Bukkit.getTag(Tag.REGISTRY_BLOCKS, tagKey, Material.class));
+                        if (tagKey != null)
+                            tags.add(Bukkit.getTag(Tag.REGISTRY_BLOCKS, tagKey, Material.class));
                     }
                 } catch (Exception e) {
                     Logs.logWarning("Error parsing rule-entry in " + section.getName());
                     Logs.logWarning("Malformed \"material\"-section");
-                    if (Settings.DEBUG.toBool()) e.printStackTrace();
+                    if (Settings.DEBUG.toBool())
+                        e.printStackTrace();
                 }
             }
 
-            if (!materials.isEmpty()) toolComponent.addRule(materials, speed, correctForDrops);
-            for (Tag<Material> tag : tags) toolComponent.addRule(tag, speed, correctForDrops);
+            if (!materials.isEmpty())
+                toolComponent.addRule(materials, speed, correctForDrops);
+            for (Tag<Material> tag : tags)
+                toolComponent.addRule(tag, speed, correctForDrops);
         }
 
         item.setToolComponent(toolComponent);
@@ -310,15 +369,23 @@ public class ItemParser {
             return;
         }
 
-        List<EntityType> entityTypes = equippableSection.getStringList("allowed_entity_types").stream().map(e -> EnumUtils.getEnum(EntityType.class, e)).toList();
-        if (equippableSection.contains("allowed_entity_types")) equippableComponent.setAllowedEntities(entityTypes.isEmpty() ? null : entityTypes);
-        if (equippableSection.contains("damage_on_hurt")) equippableComponent.setDamageOnHurt(equippableSection.getBoolean("damage_on_hurt", true));
-        if (equippableSection.contains("dispensable")) equippableComponent.setDispensable(equippableSection.getBoolean("dispensable", true));
-        if (equippableSection.contains("swappable")) equippableComponent.setSwappable(equippableSection.getBoolean("swappable", true));
+        List<EntityType> entityTypes = equippableSection.getStringList("allowed_entity_types").stream()
+                .map(e -> EnumUtils.getEnum(EntityType.class, e)).toList();
+        if (equippableSection.contains("allowed_entity_types"))
+            equippableComponent.setAllowedEntities(entityTypes.isEmpty() ? null : entityTypes);
+        if (equippableSection.contains("damage_on_hurt"))
+            equippableComponent.setDamageOnHurt(equippableSection.getBoolean("damage_on_hurt", true));
+        if (equippableSection.contains("dispensable"))
+            equippableComponent.setDispensable(equippableSection.getBoolean("dispensable", true));
+        if (equippableSection.contains("swappable"))
+            equippableComponent.setSwappable(equippableSection.getBoolean("swappable", true));
 
-        Optional.ofNullable(equippableSection.getString("model", null)).map(NamespacedKey::fromString).ifPresent(equippableComponent::setModel);
-        Optional.ofNullable(equippableSection.getString("camera_overlay")).map(NamespacedKey::fromString).ifPresent(equippableComponent::setCameraOverlay);
-        Optional.ofNullable(equippableSection.getString("equip_sound")).map(Key::key).map(Registry.SOUNDS::get).ifPresent(equippableComponent::setEquipSound);
+        Optional.ofNullable(equippableSection.getString("model", null)).map(NamespacedKey::fromString)
+                .ifPresent(equippableComponent::setModel);
+        Optional.ofNullable(equippableSection.getString("camera_overlay")).map(NamespacedKey::fromString)
+                .ifPresent(equippableComponent::setCameraOverlay);
+        Optional.ofNullable(equippableSection.getString("equip_sound")).map(Key::key).map(Registry.SOUNDS::get)
+                .ifPresent(equippableComponent::setEquipSound);
 
         item.setEquippableComponent(equippableComponent);
     }
@@ -334,7 +401,7 @@ public class ItemParser {
         oraxenMeta.setExcludedFromCommands(section.getBoolean("excludeFromCommands", false));
     }
 
-    @SuppressWarnings({"unchecked", "deprecation"})
+    @SuppressWarnings({ "unchecked", "deprecation" })
     private void parseVanillaSections(ItemBuilder item) {
         ConfigurationSection section = mergeWithTemplateSection();
         if (section.contains("ItemFlags")) {
@@ -347,10 +414,13 @@ public class ItemParser {
             @SuppressWarnings("unchecked") // because this sections must always return a List<LinkedHashMap<String, ?>>
             List<LinkedHashMap<String, Object>> potionEffects = (List<LinkedHashMap<String, Object>>) section
                     .getList("PotionEffects");
-            if (potionEffects == null) return;
+            if (potionEffects == null)
+                return;
             for (Map<String, Object> serializedPotionEffect : potionEffects) {
-                PotionEffectType effect = PotionUtils.getEffectType((String) serializedPotionEffect.getOrDefault("type", ""));
-                if (effect == null) return;
+                PotionEffectType effect = PotionUtils
+                        .getEffectType((String) serializedPotionEffect.getOrDefault("type", ""));
+                if (effect == null)
+                    return;
                 int duration = (int) serializedPotionEffect.getOrDefault("duration", 60);
                 int amplifier = (int) serializedPotionEffect.getOrDefault("amplifier", 0);
                 boolean ambient = (boolean) serializedPotionEffect.getOrDefault("ambient", true);
@@ -379,41 +449,47 @@ public class ItemParser {
 
         if (section.contains("AttributeModifiers")) {
             @SuppressWarnings("unchecked") // because this sections must always return a List<LinkedHashMap<String, ?>>
-            List<LinkedHashMap<String, Object>> attributes = (List<LinkedHashMap<String, Object>>) section.getList("AttributeModifiers");
-            if (attributes != null) for (LinkedHashMap<String, Object> attributeJson : attributes) {
-                attributeJson.putIfAbsent("uuid", UUID.randomUUID().toString());
-                attributeJson.putIfAbsent("name", "oraxen:modifier");
-                attributeJson.putIfAbsent("key", "oraxen:modifier");
-                AttributeModifier attributeModifier = AttributeModifier.deserialize(attributeJson);
-                Attribute attribute = AttributeWrapper.fromString((String) attributeJson.get("attribute"));
-                item.addAttributeModifiers(attribute, attributeModifier);
-            }
+            List<LinkedHashMap<String, Object>> attributes = (List<LinkedHashMap<String, Object>>) section
+                    .getList("AttributeModifiers");
+            if (attributes != null)
+                for (LinkedHashMap<String, Object> attributeJson : attributes) {
+                    attributeJson.putIfAbsent("uuid", UUID.randomUUID().toString());
+                    attributeJson.putIfAbsent("name", "oraxen:modifier");
+                    attributeJson.putIfAbsent("key", "oraxen:modifier");
+                    AttributeModifier attributeModifier = AttributeModifier.deserialize(attributeJson);
+                    Attribute attribute = AttributeWrapper.fromString((String) attributeJson.get("attribute"));
+                    item.addAttributeModifiers(attribute, attributeModifier);
+                }
         }
 
         if (section.contains("Enchantments")) {
             ConfigurationSection enchantSection = section.getConfigurationSection("Enchantments");
-            if (enchantSection != null) for (String enchant : enchantSection.getKeys(false))
-                item.addEnchant(EnchantmentWrapper.getByKey(NamespacedKey.minecraft(enchant)),
-                        enchantSection.getInt(enchant));
+            if (enchantSection != null)
+                for (String enchant : enchantSection.getKeys(false))
+                    item.addEnchant(EnchantmentWrapper.getByKey(NamespacedKey.minecraft(enchant)),
+                            enchantSection.getInt(enchant));
         }
     }
 
     private void parseOraxenSections(ItemBuilder item) {
         ConfigurationSection merged = mergeWithTemplateSection();
         ConfigurationSection mechanicsSection = merged.getConfigurationSection("Mechanics");
-        if (mechanicsSection != null) for (String mechanicID : mechanicsSection.getKeys(false)) {
-            MechanicFactory factory = MechanicsManager.getMechanicFactory(mechanicID);
+        if (mechanicsSection != null)
+            for (String mechanicID : mechanicsSection.getKeys(false)) {
+                MechanicFactory factory = MechanicsManager.getMechanicFactory(mechanicID);
 
-            if (factory != null) {
-                ConfigurationSection mechanicSection = mechanicsSection.getConfigurationSection(mechanicID);
-                if (mechanicSection == null) continue;
-                Mechanic mechanic = factory.parse(mechanicSection);
-                if (mechanic == null) continue;
-                // Apply item modifiers
-                for (Function<ItemBuilder, ItemBuilder> itemModifier : mechanic.getItemModifiers())
-                    item = itemModifier.apply(item);
+                if (factory != null) {
+                    ConfigurationSection mechanicSection = mechanicsSection.getConfigurationSection(mechanicID);
+                    if (mechanicSection == null)
+                        continue;
+                    Mechanic mechanic = factory.parse(mechanicSection);
+                    if (mechanic == null)
+                        continue;
+                    // Apply item modifiers
+                    for (Function<ItemBuilder, ItemBuilder> itemModifier : mechanic.getItemModifiers())
+                        item = itemModifier.apply(item);
+                }
             }
-        }
 
         if (oraxenMeta.hasPackInfos()) {
             Integer customModelData;
@@ -425,7 +501,8 @@ public class ItemParser {
                 if (!Settings.DISABLE_AUTOMATIC_MODEL_DATA.toBool())
                     Optional.ofNullable(section.getConfigurationSection("Pack"))
                             .ifPresent(c -> c.set("custom_model_data", customModelData));
-            } else customModelData = null;
+            } else
+                customModelData = null;
 
             if (customModelData != null) {
                 item.setCustomModelData(customModelData);
@@ -435,7 +512,8 @@ public class ItemParser {
     }
 
     private ConfigurationSection mergeWithTemplateSection() {
-        if (section == null || templateItem == null || templateItem.section == null) return section;
+        if (section == null || templateItem == null || templateItem.section == null)
+            return section;
 
         ConfigurationSection merged = new YamlConfiguration().createSection(section.getName());
         OraxenYaml.copyConfigurationSection(templateItem.section, merged);

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -353,9 +353,6 @@ public class ItemParser {
         item.setToolComponent(toolComponent);
     }
 
-    private void parseConsumableComponent(ItemBuilder item, @NotNull ConfigurationSection consumableSection) {
-    }
-
     private void parseEquippableComponent(ItemBuilder item, ConfigurationSection equippableSection) {
         EquippableComponent equippableComponent = new ItemStack(type).getItemMeta().getEquippable();
 
@@ -411,7 +408,6 @@ public class ItemParser {
         }
 
         if (section.contains("PotionEffects")) {
-            @SuppressWarnings("unchecked") // because this sections must always return a List<LinkedHashMap<String, ?>>
             List<LinkedHashMap<String, Object>> potionEffects = (List<LinkedHashMap<String, Object>>) section
                     .getList("PotionEffects");
             if (potionEffects == null)
@@ -439,7 +435,7 @@ public class ItemParser {
                     final Object persistentDataType = PersistentDataType.class
                             .getDeclaredField((String) attributeJson.get("type")).get(null);
                     item.addCustomTag(new NamespacedKey(keyContent[0], keyContent[1]),
-                            (PersistentDataType) persistentDataType,
+                            (PersistentDataType<Object, Object>) persistentDataType,
                             attributeJson.get("value"));
                 }
             } catch (IllegalAccessException | NoSuchFieldException e) {
@@ -448,7 +444,6 @@ public class ItemParser {
         }
 
         if (section.contains("AttributeModifiers")) {
-            @SuppressWarnings("unchecked") // because this sections must always return a List<LinkedHashMap<String, ?>>
             List<LinkedHashMap<String, Object>> attributes = (List<LinkedHashMap<String, Object>>) section
                     .getList("AttributeModifiers");
             if (attributes != null)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxBlock.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxBlock.java
@@ -19,20 +19,26 @@ public class JukeboxBlock {
     private final String permission;
     private final double volume;
     private final double pitch;
+    public final String active_stage;
 
     public JukeboxBlock(MechanicFactory factory, ConfigurationSection section) {
         this.factory = factory;
         this.volume = section.getDouble("volume", 1);
         this.pitch = section.getDouble("pitch", 1);
         this.permission = section.getString("permission");
+        this.active_stage = section.getString("active_stage");
     }
 
     public String getPlayingSong(Entity baseEntity) {
         ItemStack disc = baseEntity.getPersistentDataContainer().get(MUSIC_DISC_KEY, DataType.ITEM_STACK);
-        if (disc == null) return null;
+        if (disc == null)
+            return null;
         MusicDiscMechanic mechanic = (MusicDiscMechanic) factory.getMechanic(OraxenItems.getIdByItem(disc));
         return (mechanic != null && !mechanic.hasNoSong()) ? mechanic.getSong()
-                : disc.getType().isRecord() ? disc.getType().toString().toLowerCase(Locale.ROOT).replace("music_disc_", "minecraft:music_disc.") : null;
+                : disc.getType().isRecord()
+                        ? disc.getType().toString().toLowerCase(Locale.ROOT).replace("music_disc_",
+                                "minecraft:music_disc.")
+                        : null;
     }
 
     public String getPermission() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
@@ -104,8 +104,11 @@ public class JukeboxListener implements Listener {
         insertedDisc.setAmount(1);
         if (player != null && player.getGameMode() != GameMode.CREATIVE)
             disc.setAmount(disc.getAmount() - insertedDisc.getAmount());
+        Key songKey = getSongFromDisc(insertedDisc);
         pdc.set(MUSIC_DISC_KEY, DataType.ITEM_STACK, insertedDisc);
-        baseEntity.getWorld().playSound(loc, jukebox.getPlayingSong(baseEntity), SoundCategory.RECORDS,
+        String soundId = OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey);
+
+        baseEntity.getWorld().playSound(loc, soundId, SoundCategory.RECORDS,
                 jukebox.getVolume(), jukebox.getPitch());
 
         if (jukebox.active_stage != null) {
@@ -155,7 +158,7 @@ public class JukeboxListener implements Listener {
     @Nullable
     private Key getSongFromDisc(ItemStack disc) {
         if (VersionUtil.atOrAbove("1.21") && disc.hasItemMeta() && disc.getItemMeta().hasJukeboxPlayable()) {
-            return disc.getItemMeta().getJukeboxPlayable().getSongKey().key();
+            return disc.getItemMeta().getJukeboxPlayable().getSong().key();
         } else {
             return Key.key("minecraft",
                     "music_disc." + disc.getType().toString().toLowerCase(Locale.ROOT).split("music_disc_")[1]);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
@@ -88,24 +88,19 @@ public class JukeboxListener implements Listener {
         FurnitureMechanic furnitureMechanic = OraxenFurniture.getFurnitureMechanic(baseEntity);
         Location loc = BlockHelpers.toCenterLocation(baseEntity.getLocation());
 
-        Logs.logWarning("alpha");
         if (furnitureMechanic == null || !furnitureMechanic.isJukebox())
             return false;
 
         if (!ItemUtils.isMusicDisc(disc))
             return false;
 
-        Logs.logWarning("beta");
-
         if (pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK))
             return false;
 
-        Logs.logWarning("gamma");
         JukeboxBlock jukebox = furnitureMechanic.getJukebox();
         if (!jukebox.hasPermission(player))
             return false;
 
-        Logs.logWarning("delta");
         ItemStack insertedDisc = disc.clone();
         insertedDisc.setAmount(1);
         if (player != null && player.getGameMode() != GameMode.CREATIVE)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
@@ -12,7 +12,6 @@ import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.ItemUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
@@ -108,6 +107,11 @@ public class JukeboxListener implements Listener {
         pdc.set(MUSIC_DISC_KEY, DataType.ITEM_STACK, insertedDisc);
         baseEntity.getWorld().playSound(loc, jukebox.getPlayingSong(baseEntity), SoundCategory.RECORDS,
                 jukebox.getVolume(), jukebox.getPitch());
+
+        if (jukebox.active_stage != null) {
+            FurnitureMechanic.setFurnitureItem(baseEntity, OraxenItems.getItemById(jukebox.active_stage).build());
+        }
+
         return true;
     }
 
@@ -137,6 +141,13 @@ public class JukeboxListener implements Listener {
                             Sound.sound(songKey, Sound.Source.RECORD, jukebox.getVolume(), jukebox.getPitch()));
                 });
         baseEntity.getWorld().dropItemNaturally(loc, item);
+
+        // if the active stage was not null we need to reset it because it changed
+        if (jukebox.active_stage != null) {
+            FurnitureMechanic.setFurnitureItem(baseEntity,
+                    OraxenItems.getItemById(furnitureMechanic.getItemID()).build());
+        }
+
         pdc.remove(MUSIC_DISC_KEY);
         return true;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
@@ -12,6 +12,7 @@ import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.ItemUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
@@ -40,10 +41,13 @@ public class JukeboxListener implements Listener {
         Player player = event.getPlayer();
         ItemStack itemStack = player.getInventory().getItemInMainHand();
 
-        if (event.getHand() != EquipmentSlot.HAND) return;
+        if (event.getHand() != EquipmentSlot.HAND)
+            return;
 
         boolean played = insertAndPlayDisc(baseEntity, itemStack, player);
-        if (!played) return;
+
+        if (!played)
+            return;
         player.swingMainHand();
 
         String displayName = null;
@@ -58,7 +62,8 @@ public class JukeboxListener implements Listener {
         }
 
         if (displayName != null) {
-            Component message = AdventureUtils.MINI_MESSAGE.deserialize(Message.MECHANICS_JUKEBOX_NOW_PLAYING.toString(), AdventureUtils.tagResolver("disc", displayName));
+            Component message = AdventureUtils.MINI_MESSAGE.deserialize(
+                    Message.MECHANICS_JUKEBOX_NOW_PLAYING.toString(), AdventureUtils.tagResolver("disc", displayName));
             OraxenPlugin.get().getAudience().player(player).sendActionBar(message);
         }
 
@@ -67,7 +72,8 @@ public class JukeboxListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEjectDisc(OraxenFurnitureInteractEvent event) {
-        if (!ejectAndStopDisc(event.getBaseEntity(), event.getPlayer())) return;
+        if (!ejectAndStopDisc(event.getBaseEntity(), event.getPlayer()))
+            return;
         event.getPlayer().swingMainHand();
         event.setCancelled(true);
     }
@@ -82,16 +88,31 @@ public class JukeboxListener implements Listener {
         FurnitureMechanic furnitureMechanic = OraxenFurniture.getFurnitureMechanic(baseEntity);
         Location loc = BlockHelpers.toCenterLocation(baseEntity.getLocation());
 
-        if (furnitureMechanic == null || !furnitureMechanic.isJukebox()) return false;
-        if (pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK) || !ItemUtils.isMusicDisc(disc)) return false;
+        Logs.logWarning("alpha");
+        if (furnitureMechanic == null || !furnitureMechanic.isJukebox())
+            return false;
+
+        if (!ItemUtils.isMusicDisc(disc))
+            return false;
+
+        Logs.logWarning("beta");
+
+        if (pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK))
+            return false;
+
+        Logs.logWarning("gamma");
         JukeboxBlock jukebox = furnitureMechanic.getJukebox();
-        if (!jukebox.hasPermission(player)) return false;
+        if (!jukebox.hasPermission(player))
+            return false;
+
+        Logs.logWarning("delta");
         ItemStack insertedDisc = disc.clone();
         insertedDisc.setAmount(1);
         if (player != null && player.getGameMode() != GameMode.CREATIVE)
             disc.setAmount(disc.getAmount() - insertedDisc.getAmount());
         pdc.set(MUSIC_DISC_KEY, DataType.ITEM_STACK, insertedDisc);
-        baseEntity.getWorld().playSound(loc, jukebox.getPlayingSong(baseEntity), SoundCategory.RECORDS, jukebox.getVolume(), jukebox.getPitch());
+        baseEntity.getWorld().playSound(loc, jukebox.getPlayingSong(baseEntity), SoundCategory.RECORDS,
+                jukebox.getVolume(), jukebox.getPitch());
         return true;
     }
 
@@ -101,19 +122,24 @@ public class JukeboxListener implements Listener {
         FurnitureMechanic furnitureMechanic = OraxenFurniture.getFurnitureMechanic(baseEntity);
         Location loc = BlockHelpers.toCenterLocation(baseEntity.getLocation());
 
-        if (furnitureMechanic == null || !furnitureMechanic.isJukebox()) return false;
-        if (!pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK) || !ItemUtils.isMusicDisc(item)) return false;
+        if (furnitureMechanic == null || !furnitureMechanic.isJukebox())
+            return false;
+        if (!pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK) || !ItemUtils.isMusicDisc(item))
+            return false;
 
         JukeboxBlock jukebox = furnitureMechanic.getJukebox();
-        if (!jukebox.hasPermission(player)) return false;
+        if (!jukebox.hasPermission(player))
+            return false;
 
         baseEntity.getWorld().getNearbyEntities(loc, 32, 32, 32).stream()
                 .filter(entity -> entity instanceof Player)
                 .map(entity -> (Player) entity)
                 .forEach(p -> {
                     Key songKey = getSongFromDisc(item);
-                    if (songKey == null) return;
-                    OraxenPlugin.get().getAudience().player(p).stopSound(Sound.sound(songKey, Sound.Source.RECORD, jukebox.getVolume(), jukebox.getPitch()));
+                    if (songKey == null)
+                        return;
+                    OraxenPlugin.get().getAudience().player(p).stopSound(
+                            Sound.sound(songKey, Sound.Source.RECORD, jukebox.getVolume(), jukebox.getPitch()));
                 });
         baseEntity.getWorld().dropItemNaturally(loc, item);
         pdc.remove(MUSIC_DISC_KEY);
@@ -122,12 +148,11 @@ public class JukeboxListener implements Listener {
 
     @Nullable
     private Key getSongFromDisc(ItemStack disc) {
-        if (VersionUtil.atOrAbove("1.21")) {
-            return disc.hasItemMeta() && disc.getItemMeta().hasJukeboxPlayable()
-                    ? disc.getItemMeta().getJukeboxPlayable().getSongKey().key()
-                    : null;
+        if (VersionUtil.atOrAbove("1.21") && disc.hasItemMeta() && disc.getItemMeta().hasJukeboxPlayable()) {
+            return disc.getItemMeta().getJukeboxPlayable().getSongKey().key();
         } else {
-            return Key.key("minecraft", "music_disc." + disc.getType().toString().toLowerCase(Locale.ROOT).split("music_disc_")[1]);
+            return Key.key("minecraft",
+                    "music_disc." + disc.getType().toString().toLowerCase(Locale.ROOT).split("music_disc_")[1]);
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/OraxenDatapack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/OraxenDatapack.java
@@ -1,0 +1,90 @@
+package io.th0rgal.oraxen.pack.generation;
+
+import io.th0rgal.oraxen.utils.VirtualFile;
+
+import org.apache.commons.io.FileUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.packs.DataPack;
+
+import com.google.gson.JsonObject;
+
+import net.kyori.adventure.key.Key;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public abstract class OraxenDatapack {
+    protected static final World defaultWorld = Bukkit.getWorlds().get(0);
+    protected final File datapackFolder;
+    protected final JsonObject datapackMeta = new JsonObject();
+    protected final boolean isFirstInstall;
+    protected final boolean datapackEnabled;
+
+    protected OraxenDatapack(String name, String description, int packFormat) {
+        this.datapackFolder = defaultWorld.getWorldFolder().toPath()
+                .resolve("datapacks/" + name).toFile();
+
+        JsonObject data = new JsonObject();
+        data.addProperty("description", description);
+        data.addProperty("pack_format", packFormat);
+        datapackMeta.add("pack", data);
+
+        this.isFirstInstall = isFirstInstall();
+        this.datapackEnabled = isDatapackEnabled();
+    }
+
+    protected void writeMCMeta() {
+        try {
+            File packMeta = datapackFolder.toPath().resolve("pack.mcmeta").toFile();
+            packMeta.createNewFile();
+            FileUtils.writeStringToFile(packMeta, datapackMeta.toString(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void clearOldDataPack() {
+        try {
+            FileUtils.deleteDirectory(datapackFolder);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected abstract Key getDatapackKey();
+
+    public abstract void generateAssets(List<VirtualFile> output);
+
+    protected boolean isFirstInstall() {
+        return Bukkit.getDataPackManager().getDataPacks().stream()
+                .filter(d -> d.getKey() != null)
+                .noneMatch(d -> getDatapackKey().equals(Key.key(d.getKey().toString())));
+    }
+
+    protected boolean isDatapackEnabled() {
+        for (DataPack dataPack : Bukkit.getDataPackManager().getEnabledDataPacks(defaultWorld)) {
+            if (dataPack.getKey() == null)
+                continue;
+            if (dataPack.getKey().equals(getDatapackKey()))
+                return true;
+        }
+        for (DataPack dataPack : Bukkit.getDataPackManager().getDisabledDataPacks(defaultWorld)) {
+            if (dataPack.getKey() == null)
+                continue;
+            if (dataPack.getKey().equals(getDatapackKey()))
+                return true;
+        }
+        return false;
+    }
+
+    public boolean isEnabled() {
+        return datapackEnabled;
+    }
+
+    public boolean isFirstTime() {
+        return isFirstInstall;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/OraxenDatapack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/OraxenDatapack.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.pack.generation;
 
 import io.th0rgal.oraxen.utils.VirtualFile;
+import io.th0rgal.oraxen.utils.VersionUtil;
 
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
@@ -22,6 +23,7 @@ public abstract class OraxenDatapack {
     protected final JsonObject datapackMeta = new JsonObject();
     protected final boolean isFirstInstall;
     protected final boolean datapackEnabled;
+    protected final String name;
 
     protected OraxenDatapack(String name, String description, int packFormat) {
         this.datapackFolder = defaultWorld.getWorldFolder().toPath()
@@ -32,6 +34,7 @@ public abstract class OraxenDatapack {
         data.addProperty("pack_format", packFormat);
         datapackMeta.add("pack", data);
 
+        this.name = name;
         this.isFirstInstall = isFirstInstall();
         this.datapackEnabled = isDatapackEnabled();
     }
@@ -78,6 +81,15 @@ public abstract class OraxenDatapack {
                 return true;
         }
         return false;
+    }
+
+    protected void enableDatapack(boolean enabled) {
+        if (VersionUtil.isPaperServer()) {
+            Bukkit.getDatapackManager().getPacks().stream()
+                    .filter(d -> d.getName() == this.name)
+                    .findFirst()
+                    .ifPresent(d -> d.setEnabled(enabled));
+        }
     }
 
     public boolean isEnabled() {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -622,16 +622,18 @@ public class ResourcePack {
 
     private void handleCustomArmor(List<VirtualFile> output) {
         CustomArmorType customArmorType = CustomArmorType.getSetting();
-        // Clear out old datapacks before generating new ones, in case type changed or
-        // otherwise
-        TrimArmorDatapack.clearOldDataPacks();
 
         switch (customArmorType) {
             case COMPONENT -> componentArmorModels.generatePackFiles(output);
-            case TRIMS -> trimArmorDatapack.generateTrimAssets(output);
+            case TRIMS -> {
+                if (trimArmorDatapack == null)
+                    trimArmorDatapack = new TrimArmorDatapack();
+                trimArmorDatapack.clearOldDataPack();
+                trimArmorDatapack.generateAssets(output);
+            }
             case SHADER -> {
                 if (Settings.CUSTOM_ARMOR_SHADER_GENERATE_CUSTOM_TEXTURES.toBool()
-                        && shaderArmorTextures.hasCustomArmors())
+                        && shaderArmorTextures.hasCustomArmors()) {
                     try {
                         String armorPath = "assets/minecraft/textures/models/armor";
                         output.add(
@@ -644,12 +646,17 @@ public class ResourcePack {
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
+                }
             }
+            default -> {
+            } // Handle NONE
         }
+
         if (VersionUtil.isPaperServer()) {
             Bukkit.getDatapackManager().getPacks().stream()
-                    .filter(d -> d.getName().equals(TrimArmorDatapack.datapackKey.value()))
-                    .findFirst().ifPresent(d -> d.setEnabled(CustomArmorType.getSetting() == CustomArmorType.TRIMS));
+                    .filter(d -> d.getName().equals(TrimArmorDatapack.DATAPACK_KEY.value()))
+                    .findFirst()
+                    .ifPresent(d -> d.setEnabled(CustomArmorType.getSetting() == CustomArmorType.TRIMS));
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -15,6 +15,7 @@ import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.OraxenMeta;
 import io.th0rgal.oraxen.pack.upload.UploadManager;
 import io.th0rgal.oraxen.sound.CustomSound;
+import io.th0rgal.oraxen.sound.JukeboxDatapack;
 import io.th0rgal.oraxen.sound.SoundManager;
 import io.th0rgal.oraxen.utils.*;
 import io.th0rgal.oraxen.utils.customarmor.ComponentArmorModels;
@@ -48,6 +49,7 @@ public class ResourcePack {
     private ComponentArmorModels componentArmorModels;
     private static final File packFolder = new File(OraxenPlugin.get().getDataFolder(), "pack");
     private final File pack = new File(packFolder, packFolder.getName() + ".zip");
+    private JukeboxDatapack jukeboxDatapack;
 
     public ResourcePack() {
         // we use maps to avoid duplicate
@@ -657,6 +659,12 @@ public class ResourcePack {
                     .filter(d -> d.getName().equals(TrimArmorDatapack.DATAPACK_KEY.value()))
                     .findFirst()
                     .ifPresent(d -> d.setEnabled(CustomArmorType.getSetting() == CustomArmorType.TRIMS));
+        }
+
+        // Handle jukebox datapack
+        if (jukeboxDatapack != null) {
+            jukeboxDatapack.clearOldDataPack();
+            jukeboxDatapack.generateAssets(output);
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
@@ -161,12 +161,16 @@ public class CustomSound {
 
         JsonObject songJson = new JsonObject();
 
+        // For custom sounds, we must use the full sound event definition
         JsonObject soundEvent = new JsonObject();
-        soundEvent.addProperty("id", "oraxen:" + name);
+        soundEvent.addProperty("sound_id", "minecraft:" + name);
+        // Optionally add range if needed
+        // soundEvent.addProperty("range", 16);
         songJson.add("sound_event", soundEvent);
 
+        // Add jukebox-specific properties
         JsonObject description = new JsonObject();
-        description.addProperty("text", subtitle != null ? subtitle : "Music Disc");
+        description.addProperty("text", AdventureUtils.LEGACY_SERIALIZER.serialize(getDescription()));
         songJson.add("description", description);
 
         songJson.addProperty("length_in_seconds", getLengthInSeconds());

--- a/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
@@ -2,15 +2,16 @@ package io.th0rgal.oraxen.sound;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.SoundCategory;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 public class CustomSound {
 
@@ -21,20 +22,52 @@ public class CustomSound {
     private final List<String> sounds = new ArrayList<>();
     private final boolean stream;
 
-    public CustomSound(@NotNull String name, @NotNull List<String> sounds, SoundCategory category, boolean replace,
-            String subtitle, boolean stream) {
+    // Jukebox data as an Optional record
+    private final Optional<JukeboxData> jukeboxData;
+
+    private record JukeboxData(
+            Component description,
+            int lengthInSeconds,
+            int comparatorOutput) {
+    }
+
+    public CustomSound(@NotNull String name, @NotNull ConfigurationSection config) {
         this.name = name;
-        List<String> temp = new ArrayList<>();
-        for (String sound : sounds) {
-            if (sound == null)
-                continue;
-            temp.add(sound.replace(".ogg", ""));
+
+        // Parse sounds list
+        List<String> soundsList = config.getStringList("sounds");
+        if (soundsList.isEmpty() && config.contains("sound")) {
+            soundsList = Collections.singletonList(config.getString("sound"));
         }
-        this.sounds.addAll(temp);
-        this.category = category == null ? SoundCategory.MASTER : category;
-        this.replace = replace;
-        this.subtitle = subtitle;
-        this.stream = stream;
+
+        // Process sounds, removing .ogg extension
+        for (String sound : soundsList) {
+            if (sound != null) {
+                sounds.add(sound.replace(".ogg", ""));
+            }
+        }
+
+        // Parse category
+        String categoryStr = config.getString("category");
+        this.category = categoryStr != null ? SoundCategory.valueOf(categoryStr.toUpperCase(Locale.ROOT))
+                : SoundCategory.MASTER;
+
+        this.subtitle = config.getString("subtitle");
+        this.replace = config.getBoolean("replace", false);
+        this.stream = config.getBoolean("stream", false);
+
+        // Initialize jukebox properties
+        ConfigurationSection jukeboxSection = config.getConfigurationSection("jukebox_song");
+        if (jukeboxSection != null) {
+            String descriptionText = jukeboxSection.getString("description",
+                    subtitle != null ? subtitle : "<white>Music Disc</white>");
+            this.jukeboxData = Optional.of(new JukeboxData(
+                    AdventureUtils.MINI_MESSAGE.deserialize(descriptionText),
+                    jukeboxSection.getInt("length_in_seconds", 120),
+                    jukeboxSection.getInt("comparator_output", 15)));
+        } else {
+            this.jukeboxData = Optional.empty();
+        }
     }
 
     public void play(@NotNull Player player, @NotNull Location location) {
@@ -82,6 +115,24 @@ public class CustomSound {
         return stream;
     }
 
+    public boolean isJukeboxSound() {
+        return jukeboxData.isPresent();
+    }
+
+    public int getLengthInSeconds() {
+        return jukeboxData.map(data -> data.lengthInSeconds).orElse(120);
+    }
+
+    public int getComparatorOutput() {
+        return jukeboxData.map(data -> data.comparatorOutput).orElse(15);
+    }
+
+    public Component getDescription() {
+        return jukeboxData
+                .map(data -> data.description)
+                .orElse(AdventureUtils.MINI_MESSAGE.deserialize("<white>Music Disc</white>"));
+    }
+
     public JsonObject toJson() {
         final JsonObject output = new JsonObject();
         if (category != null)
@@ -103,4 +154,24 @@ public class CustomSound {
         return output;
     }
 
+    public JsonObject toJukeboxJson() {
+        if (jukeboxData.isEmpty()) {
+            return new JsonObject();
+        }
+
+        JsonObject songJson = new JsonObject();
+
+        JsonObject soundEvent = new JsonObject();
+        soundEvent.addProperty("id", "oraxen:" + name);
+        songJson.add("sound_event", soundEvent);
+
+        JsonObject description = new JsonObject();
+        description.addProperty("text", subtitle != null ? subtitle : "Music Disc");
+        songJson.add("description", description);
+
+        songJson.addProperty("length_in_seconds", getLengthInSeconds());
+        songJson.addProperty("comparator_output", getComparatorOutput());
+
+        return songJson;
+    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
@@ -154,6 +154,10 @@ public class CustomSound {
         return output;
     }
 
+    public String getSoundId() {
+        return "minecraft:" + name;
+    }
+
     public JsonObject toJukeboxJson() {
         if (jukeboxData.isEmpty()) {
             return new JsonObject();
@@ -163,7 +167,7 @@ public class CustomSound {
 
         // For custom sounds, we must use the full sound event definition
         JsonObject soundEvent = new JsonObject();
-        soundEvent.addProperty("sound_id", "minecraft:" + name);
+        soundEvent.addProperty("sound_id", getSoundId());
         // Optionally add range if needed
         // soundEvent.addProperty("range", 16);
         songJson.add("sound_event", soundEvent);

--- a/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
@@ -19,18 +19,22 @@ public class CustomSound {
     private final String subtitle;
     private final boolean replace;
     private final List<String> sounds = new ArrayList<>();
+    private final boolean stream;
 
-    public CustomSound(@NotNull String name, @NotNull List<String> sounds, SoundCategory category, boolean replace, String subtitle) {
+    public CustomSound(@NotNull String name, @NotNull List<String> sounds, SoundCategory category, boolean replace,
+            String subtitle, boolean stream) {
         this.name = name;
         List<String> temp = new ArrayList<>();
         for (String sound : sounds) {
-            if (sound == null) continue;
+            if (sound == null)
+                continue;
             temp.add(sound.replace(".ogg", ""));
         }
         this.sounds.addAll(temp);
         this.category = category == null ? SoundCategory.MASTER : category;
         this.replace = replace;
         this.subtitle = subtitle;
+        this.stream = stream;
     }
 
     public void play(@NotNull Player player, @NotNull Location location) {
@@ -41,7 +45,8 @@ public class CustomSound {
         play(player, location, category, volume, pitch);
     }
 
-    public void play(@NotNull Player player, @NotNull Location location, @NotNull SoundCategory category, float volume, float pitch) {
+    public void play(@NotNull Player player, @NotNull Location location, @NotNull SoundCategory category, float volume,
+            float pitch) {
         player.playSound(location, name, category, volume, pitch);
     }
 
@@ -73,16 +78,27 @@ public class CustomSound {
         return new ArrayList<>(sounds);
     }
 
+    public boolean isStream() {
+        return stream;
+    }
+
     public JsonObject toJson() {
         final JsonObject output = new JsonObject();
-        if (category != null) output.addProperty("category", category.toString().toLowerCase(Locale.ROOT));
-        if (replace) output.addProperty("replace", true);
-        if (subtitle != null) output.addProperty("subtitle", subtitle);
+        if (category != null)
+            output.addProperty("category", category.toString().toLowerCase(Locale.ROOT));
+        if (replace)
+            output.addProperty("replace", true);
+        if (subtitle != null)
+            output.addProperty("subtitle", subtitle);
+        if (stream)
+            output.addProperty("stream", true);
         final JsonArray sounds = new JsonArray();
-        if (this.sounds.isEmpty()) sounds.getAsJsonArray();
-        else for (String sound : this.sounds) {
-            sounds.add(sound);
-        }
+        if (this.sounds.isEmpty())
+            sounds.getAsJsonArray();
+        else
+            for (String sound : this.sounds) {
+                sounds.add(sound);
+            }
         output.add("sounds", sounds);
         return output;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/sound/JukeboxDatapack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/JukeboxDatapack.java
@@ -1,0 +1,54 @@
+package io.th0rgal.oraxen.sound;
+
+import io.th0rgal.oraxen.pack.generation.OraxenDatapack;
+import io.th0rgal.oraxen.utils.VirtualFile;
+import net.kyori.adventure.key.Key;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+public class JukeboxDatapack extends OraxenDatapack {
+    public static final Key DATAPACK_KEY = Key.key("minecraft:file/oraxen_jukebox");
+    private final Collection<CustomSound> jukeboxSounds;
+
+    public JukeboxDatapack(Collection<CustomSound> jukeboxSounds) {
+        super("oraxen_jukebox",
+                "Datapack for Oraxen's Custom Jukebox Songs",
+                18); // Pack format for 1.20.4
+        this.jukeboxSounds = jukeboxSounds;
+    }
+
+    @Override
+    protected Key getDatapackKey() {
+        return DATAPACK_KEY;
+    }
+
+    @Override
+    public void generateAssets(List<VirtualFile> output) {
+        if (jukeboxSounds.isEmpty())
+            return;
+
+        datapackFolder.toPath().resolve("data/oraxen/jukebox_song").toFile().mkdirs();
+        writeMCMeta();
+        writeJukeboxSongs();
+    }
+
+    private void writeJukeboxSongs() {
+        for (CustomSound sound : jukeboxSounds) {
+            File songFile = datapackFolder.toPath()
+                    .resolve("data/oraxen/jukebox_song/" + sound.getName() + ".json")
+                    .toFile();
+
+            try {
+                songFile.createNewFile();
+                FileUtils.writeStringToFile(songFile, sound.toJukeboxJson().toString(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/sound/JukeboxDatapack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/JukeboxDatapack.java
@@ -2,12 +2,18 @@ package io.th0rgal.oraxen.sound;
 
 import io.th0rgal.oraxen.pack.generation.OraxenDatapack;
 import io.th0rgal.oraxen.utils.VirtualFile;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import io.th0rgal.oraxen.config.Message;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.bukkit.Bukkit;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
@@ -29,12 +35,20 @@ public class JukeboxDatapack extends OraxenDatapack {
 
     @Override
     public void generateAssets(List<VirtualFile> output) {
-        if (jukeboxSounds.isEmpty())
+        if (jukeboxSounds.isEmpty()) {
             return;
+        }
 
         datapackFolder.toPath().resolve("data/oraxen/jukebox_song").toFile().mkdirs();
         writeMCMeta();
         writeJukeboxSongs();
+
+        if (isFirstInstall || !datapackEnabled) {
+            Message.DATAPACK_GENERATED.send(Bukkit.getConsoleSender(),
+                    TagResolver.resolver(Placeholder.parsed("datapack_name", "Jukebox")));
+        }
+
+        enableDatapack(true);
     }
 
     private void writeJukeboxSongs() {

--- a/core/src/main/java/io/th0rgal/oraxen/sound/JukeboxDatapack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/JukeboxDatapack.java
@@ -2,7 +2,6 @@ package io.th0rgal.oraxen.sound;
 
 import io.th0rgal.oraxen.pack.generation.OraxenDatapack;
 import io.th0rgal.oraxen.utils.VirtualFile;
-import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;

--- a/core/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
@@ -22,18 +22,25 @@ public class SoundManager {
         final Collection<CustomSound> output = new ArrayList<>();
         for (String soundName : section.getKeys(true)) {
             ConfigurationSection sound = section.getConfigurationSection(soundName);
-            if (sound == null) continue;
+            if (sound == null)
+                continue;
             SoundCategory category = null;
             if (sound.isString("category")) {
                 try {
-                    category = (Objects.requireNonNullElse(SoundCategory.valueOf(sound.getString("category").toUpperCase(Locale.ROOT)), SoundCategory.MASTER));
+                    category = (Objects.requireNonNullElse(
+                            SoundCategory.valueOf(sound.getString("category").toUpperCase(Locale.ROOT)),
+                            SoundCategory.MASTER));
                 } catch (IllegalArgumentException ignored) {
                 }
             }
             List<String> sounds = sound.getStringList("sounds").isEmpty()
-                    ? Collections.singletonList(sound.getString("sound")) : sound.getStringList("sounds");
+                    ? Collections.singletonList(sound.getString("sound"))
+                    : sound.getStringList("sounds");
 
-            output.add(new CustomSound(soundName, sounds, category, sound.getBoolean("replace"), sound.getString("subtitle")));
+            output.add(new CustomSound(soundName, sounds, category, sound.getBoolean("replace"),
+                    sound.getString("subtitle"),
+                    // by default, stream is false
+                    sound.getBoolean("stream", false)));
         }
         return output;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
@@ -1,7 +1,10 @@
 package io.th0rgal.oraxen.sound;
 
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
+
+import net.kyori.adventure.key.Key;
 
 import java.util.*;
 
@@ -9,10 +12,12 @@ public class SoundManager {
 
     private final boolean autoGenerate;
     private final Collection<CustomSound> customSounds;
+    private final Map<Key, String> songKeys;
 
     public SoundManager(YamlConfiguration soundConfig) {
         this.autoGenerate = soundConfig.getBoolean("settings.automatically_generate");
         this.customSounds = new ArrayList<>();
+        this.songKeys = new HashMap<>();
 
         if (autoGenerate) {
             ConfigurationSection soundsSection = soundConfig.getConfigurationSection("sounds");
@@ -20,11 +25,20 @@ public class SoundManager {
                 for (String soundName : soundsSection.getKeys(false)) {
                     ConfigurationSection soundSection = soundsSection.getConfigurationSection(soundName);
                     if (soundSection != null) {
-                        customSounds.add(new CustomSound(soundName, soundSection));
+                        CustomSound sound = new CustomSound(soundName, soundSection);
+                        if (sound.isJukeboxSound()) {
+                            songKeys.put(NamespacedKey.fromString("oraxen:" + sound.getName()), sound.getSoundId());
+
+                        }
+                        customSounds.add(sound);
                     }
                 }
             }
         }
+    }
+
+    public String songKeyToSoundId(Key key) {
+        return songKeys.getOrDefault(key, key.toString());
     }
 
     public Collection<CustomSound> getCustomSounds() {

--- a/core/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/SoundManager.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.sound;
 
-import org.bukkit.SoundCategory;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 
@@ -12,41 +11,30 @@ public class SoundManager {
     private final Collection<CustomSound> customSounds;
 
     public SoundManager(YamlConfiguration soundConfig) {
-        autoGenerate = soundConfig.getBoolean("settings.automatically_generate");
-        customSounds = autoGenerate
-                ? parseCustomSounds(Objects.requireNonNull(soundConfig.getConfigurationSection("sounds")))
-                : new ArrayList<>();
-    }
+        this.autoGenerate = soundConfig.getBoolean("settings.automatically_generate");
+        this.customSounds = new ArrayList<>();
 
-    public Collection<CustomSound> parseCustomSounds(ConfigurationSection section) {
-        final Collection<CustomSound> output = new ArrayList<>();
-        for (String soundName : section.getKeys(true)) {
-            ConfigurationSection sound = section.getConfigurationSection(soundName);
-            if (sound == null)
-                continue;
-            SoundCategory category = null;
-            if (sound.isString("category")) {
-                try {
-                    category = (Objects.requireNonNullElse(
-                            SoundCategory.valueOf(sound.getString("category").toUpperCase(Locale.ROOT)),
-                            SoundCategory.MASTER));
-                } catch (IllegalArgumentException ignored) {
+        if (autoGenerate) {
+            ConfigurationSection soundsSection = soundConfig.getConfigurationSection("sounds");
+            if (soundsSection != null) {
+                for (String soundName : soundsSection.getKeys(false)) {
+                    ConfigurationSection soundSection = soundsSection.getConfigurationSection(soundName);
+                    if (soundSection != null) {
+                        customSounds.add(new CustomSound(soundName, soundSection));
+                    }
                 }
             }
-            List<String> sounds = sound.getStringList("sounds").isEmpty()
-                    ? Collections.singletonList(sound.getString("sound"))
-                    : sound.getStringList("sounds");
-
-            output.add(new CustomSound(soundName, sounds, category, sound.getBoolean("replace"),
-                    sound.getString("subtitle"),
-                    // by default, stream is false
-                    sound.getBoolean("stream", false)));
         }
-        return output;
     }
 
     public Collection<CustomSound> getCustomSounds() {
         return new ArrayList<>(customSounds);
+    }
+
+    public Collection<CustomSound> getJukeboxSounds() {
+        return customSounds.stream()
+                .filter(CustomSound::isJukeboxSound)
+                .toList();
     }
 
     public boolean isAutoGenerate() {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
@@ -1,6 +1,8 @@
 package io.th0rgal.oraxen.utils;
 
 import io.th0rgal.oraxen.utils.drops.Drop;
+import io.th0rgal.oraxen.utils.logs.Logs;
+
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.Tag;
@@ -43,7 +45,8 @@ public class ItemUtils {
      */
     public static void editItemMeta(ItemStack itemStack, Consumer<ItemMeta> function) {
         ItemMeta meta = itemStack.getItemMeta();
-        if (meta == null) return;
+        if (meta == null)
+            return;
         function.accept(meta);
         itemStack.setItemMeta(meta);
     }
@@ -60,22 +63,27 @@ public class ItemUtils {
     public static void damageItem(Player player, Drop drop, ItemStack itemStack) {
 
         // If all are null this is not something Oraxen should handle
-        // If the block/furniture has no drop, it returns Drop.emptyDrop() which is handled by the caller
-        if (drop == null) return;
+        // If the block/furniture has no drop, it returns Drop.emptyDrop() which is
+        // handled by the caller
+        if (drop == null)
+            return;
 
         int damage;
         boolean isToolEnough = drop.isToolEnough(itemStack);
         damage = isToolEnough ? 1 : 2;
-        // If the item is not a tool, it will not be damaged, example flint&steel should not be damaged
+        // If the item is not a tool, it will not be damaged, example flint&steel should
+        // not be damaged
         damage = isTool(itemStack) ? damage : 0;
 
-        if (damage == 0) return;
+        if (damage == 0)
+            return;
         if (VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.19"))
             player.damageItemStack(itemStack, damage);
         else {
             int finalDamage = damage;
             editItemMeta(itemStack, meta -> {
-                if (meta instanceof Damageable damageable && EventUtils.callEvent(new PlayerItemDamageEvent(player, itemStack, finalDamage))) {
+                if (meta instanceof Damageable damageable
+                        && EventUtils.callEvent(new PlayerItemDamageEvent(player, itemStack, finalDamage))) {
                     damageable.setDamage(damageable.getDamage() + 1);
                 }
             });
@@ -89,40 +97,50 @@ public class ItemUtils {
     public static boolean isTool(@NotNull Material material) {
         if (VersionUtil.atOrAbove("1.19.4") && !VersionUtil.atOrAbove("1.20.5"))
             return Tag.ITEMS_TOOLS.isTagged(material);
-        else return material.toString().endsWith("_AXE")
-                || material.toString().endsWith("_PICKAXE")
-                || material.toString().endsWith("_SHOVEL")
-                || material.toString().endsWith("_HOE")
-                || material.toString().endsWith("_SWORD")
-                || material == Material.TRIDENT;
+        else
+            return material.toString().endsWith("_AXE")
+                    || material.toString().endsWith("_PICKAXE")
+                    || material.toString().endsWith("_SHOVEL")
+                    || material.toString().endsWith("_HOE")
+                    || material.toString().endsWith("_SWORD")
+                    || material == Material.TRIDENT;
     }
 
     public static boolean isSkull(Material material) {
         return switch (material) {
-            case PLAYER_HEAD, PLAYER_WALL_HEAD, SKELETON_SKULL, SKELETON_WALL_SKULL, WITHER_SKELETON_SKULL, WITHER_SKELETON_WALL_SKULL, ZOMBIE_HEAD, ZOMBIE_WALL_HEAD, CREEPER_HEAD, CREEPER_WALL_HEAD, DRAGON_HEAD, DRAGON_WALL_HEAD, PIGLIN_HEAD, PIGLIN_WALL_HEAD ->
-                    true;
+            case PLAYER_HEAD, PLAYER_WALL_HEAD, SKELETON_SKULL, SKELETON_WALL_SKULL, WITHER_SKELETON_SKULL,
+                    WITHER_SKELETON_WALL_SKULL, ZOMBIE_HEAD, ZOMBIE_WALL_HEAD, CREEPER_HEAD, CREEPER_WALL_HEAD,
+                    DRAGON_HEAD, DRAGON_WALL_HEAD, PIGLIN_HEAD, PIGLIN_WALL_HEAD ->
+                true;
             default -> false;
         };
     }
 
     public static boolean hasInventoryParent(Material material) {
-        return Tag.WALLS.isTagged(material) || Tag.FENCES.isTagged(material) || Tag.BUTTONS.isTagged(material) || material == Material.PISTON || material == Material.STICKY_PISTON || (VersionUtil.atOrAbove("1.20") && material == Material.CHISELED_BOOKSHELF) || material == Material.BROWN_MUSHROOM_BLOCK || material == Material.RED_MUSHROOM_BLOCK || material == Material.MUSHROOM_STEM;
+        return Tag.WALLS.isTagged(material) || Tag.FENCES.isTagged(material) || Tag.BUTTONS.isTagged(material)
+                || material == Material.PISTON || material == Material.STICKY_PISTON
+                || (VersionUtil.atOrAbove("1.20") && material == Material.CHISELED_BOOKSHELF)
+                || material == Material.BROWN_MUSHROOM_BLOCK || material == Material.RED_MUSHROOM_BLOCK
+                || material == Material.MUSHROOM_STEM;
     }
 
     public static boolean isMusicDisc(ItemStack itemStack) {
-        if (itemStack == null) return false;
-        if (VersionUtil.atOrAbove("1.21")) {
-            return itemStack.hasItemMeta() && itemStack.getItemMeta().hasJukeboxPlayable();
-        } else {
-            return itemStack.getType().name().startsWith("MUSIC_DISC");
+        if (itemStack == null)
+            return false;
+        // native disks don't seem to have jukebox playable set to true
+        if (VersionUtil.atOrAbove("1.21") && itemStack.hasItemMeta() && itemStack.getItemMeta().hasJukeboxPlayable()) {
+            return true;
         }
+        return itemStack.getType().name().startsWith("MUSIC_DISC");
     }
 
     @Nullable
     public static ItemStack getUsingConvertsTo(ItemMeta itemMeta) {
-        if (!VersionUtil.atOrAbove("1.21") || itemMeta == null) return null;
+        if (!VersionUtil.atOrAbove("1.21") || itemMeta == null)
+            return null;
 
-        if (VersionUtil.atOrAbove("1.21.2")) return itemMeta.hasUseRemainder() ? itemMeta.getUseRemainder() : null;
+        if (VersionUtil.atOrAbove("1.21.2"))
+            return itemMeta.hasUseRemainder() ? itemMeta.getUseRemainder() : null;
         try {
             return (ItemStack) FoodComponent.class.getMethod("getUsingConvertsTo").invoke(itemMeta.getFood());
         } catch (Exception e) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/TrimArmorDatapack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/TrimArmorDatapack.java
@@ -7,11 +7,14 @@ import com.google.gson.JsonParser;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.pack.generation.OraxenDatapack;
 import io.th0rgal.oraxen.utils.VirtualFile;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -53,16 +56,14 @@ public class TrimArmorDatapack extends OraxenDatapack {
         writeTrimAtlas(output, armorPrefixes);
         copyArmorLayerTextures(output);
 
-        if (isFirstInstall) {
-            Logs.logError("Oraxen's Custom-Armor datapack could not be found...");
-            Logs.logWarning("The first time CustomArmor.armor_type is set to TRIMS in settings.yml");
-            Logs.logWarning("you need to restart your server so that the DataPack is enabled...");
-            Logs.logWarning("Custom-Armor will not work, please restart your server once!", true);
-        } else if (!datapackEnabled) {
-            Logs.logError("Oraxen's Custom-Armor datapack is not enabled...");
-            Logs.logWarning("Custom-Armor will not work, please restart your server!", true);
-        } else
+        if (isFirstInstall || !datapackEnabled) {
+            Message.DATAPACK_GENERATED.send(Bukkit.getConsoleSender(),
+                    TagResolver.resolver(Placeholder.parsed("datapack_name", "Custom-Armor")));
+        } else {
             checkOraxenArmorItems();
+        }
+
+        enableDatapack(CustomArmorType.getSetting() == CustomArmorType.TRIMS);
     }
 
     private void writeVanillaTrimPattern() {

--- a/core/src/main/resources/items/furniture.yml
+++ b/core/src/main/resources/items/furniture.yml
@@ -3,7 +3,7 @@ table:
   material: PAPER
   Mechanics:
     furniture:
-      type: DISPLAY_ENTITY # Valid types are DISPLAY_ENTITY, GLOW_DISPLAY_ENTITY & DISPLAY_ENTITY if server is 1.19.4>
+      type: ITEM_FRAME # Valid types are ITEM_FRAME, GLOW_ITEM_FRAME & DISPLAY_ENTITY if server is 1.19.4>
       limited_placing:
         roof: false
         floor: true
@@ -102,7 +102,7 @@ shelf:
   material: PAPER
   Mechanics:
     furniture:
-      type: DISPLAY_ENTITY
+      type: ITEM_FRAME
       limited_placing:
         roof: false
         floor: false
@@ -119,3 +119,26 @@ shelf:
   Pack:
     generate_model: false
     model: default/shelf
+
+turntable:
+  displayname: "<gray>Turntable"
+  material: PAPER
+  Mechanics:
+    furniture:
+      type: DISPLAY_ENTITY
+      limited_placing:
+        roof: false
+        floor: true
+        wall: false
+      barrier: true
+      light: 5
+      drop:
+        silktouch: false
+        loots:
+          - { oraxen_item: table, probability: 1.0 }
+      jukebox:
+        volume: 1.0
+        pitch: 1.0
+  Pack:
+    generate_model: false
+    model: default/turntable

--- a/core/src/main/resources/items/furniture.yml
+++ b/core/src/main/resources/items/furniture.yml
@@ -135,10 +135,18 @@ turntable:
       drop:
         silktouch: false
         loots:
-          - { oraxen_item: table, probability: 1.0 }
+          - { oraxen_item: turtable, probability: 1.0 }
       jukebox:
+        active_stage: "turtable_active_stage"
         volume: 1.0
         pitch: 1.0
   Pack:
     generate_model: false
     model: default/turntable
+
+turtable_active_stage:
+  material: PAPER
+  excludeFromInventory: true
+  Pack:
+    generate_model: false
+    model: default/weed/stage0

--- a/core/src/main/resources/items/furniture.yml
+++ b/core/src/main/resources/items/furniture.yml
@@ -3,7 +3,7 @@ table:
   material: PAPER
   Mechanics:
     furniture:
-      type: ITEM_FRAME # Valid types are ITEM_FRAME, GLOW_ITEM_FRAME & DISPLAY_ENTITY if server is 1.19.4>
+      type: DISPLAY_ENTITY # Valid types are DISPLAY_ENTITY, GLOW_DISPLAY_ENTITY & DISPLAY_ENTITY if server is 1.19.4>
       limited_placing:
         roof: false
         floor: true
@@ -102,7 +102,7 @@ shelf:
   material: PAPER
   Mechanics:
     furniture:
-      type: ITEM_FRAME
+      type: DISPLAY_ENTITY
       limited_placing:
         roof: false
         floor: false

--- a/core/src/main/resources/items/furniture.yml
+++ b/core/src/main/resources/items/furniture.yml
@@ -135,18 +135,23 @@ turntable:
       drop:
         silktouch: false
         loots:
-          - { oraxen_item: turtable, probability: 1.0 }
+          - { oraxen_item: turntable, probability: 1.0 }
+      display_entity_properties:
+        scale:
+          x: 0.75
+          y: 0.75
+          z: 0.75
       jukebox:
         active_stage: "turtable_active_stage"
         volume: 1.0
         pitch: 1.0
   Pack:
     generate_model: false
-    model: default/turntable
+    model: default/turntable_closed
 
 turtable_active_stage:
   material: PAPER
   excludeFromInventory: true
   Pack:
     generate_model: false
-    model: default/weed/stage0
+    model: default/turntable_opened

--- a/core/src/main/resources/items/items.yml
+++ b/core/src/main/resources/items/items.yml
@@ -158,7 +158,7 @@ welcome_disk:
     max_stack_size: 1
     jukebox_playable:
       show_in_tooltip: true
-      song_key: "minecraft:welcome"
+      song_key: "oraxen:welcome"
   Pack:
     generate_model: true
     parent_model: "item/handheld"

--- a/core/src/main/resources/items/items.yml
+++ b/core/src/main/resources/items/items.yml
@@ -150,3 +150,17 @@ fire:
   Pack:
     generate_model: false
     model: block/fire_floor0 # so we use the already existing fire model
+
+welcome_disk:
+  displayname: "<gradient:#9055FF:#13E2DA>Welcome Disk"
+  material: PAPER
+  Components:
+    max_stack_size: 1
+    jukebox_playable:
+      show_in_tooltip: true
+      song_key: "minecraft:welcome"
+  Pack:
+    generate_model: true
+    parent_model: "item/handheld"
+    textures:
+      - default/welcome_disk.png

--- a/core/src/main/resources/languages/czech.yml
+++ b/core/src/main/resources/languages/czech.yml
@@ -9,7 +9,7 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>Resourcepack nenahrán"
   pack_uploaded: "<prefix><#55ffa4>Resourcepack nahrán na url <url> za <delay> ms"
   pack_regenerated: "<prefix><#55ffa4>Resourcepack úspěšně regenerován"
-  updating_config: "<prefix><#facc43>Konfigurační možnost \"<option>\" nenalezena, přidávám!"
+  updating_config: '<prefix><#facc43>Konfigurační možnost "<option>" nenalezena, přidávám!'
   removing_config: Configuration option \"<option>\" has been marked for removal, removing it!"
   configs_validation_failed: "<prefix><#fa4943>Validace konfigurace selhala, plugin automaticky vypnut!"
   repaired_items: "<prefix><#55ffa4><amount> předmět(ů) bylo úspěšně opraveno!"
@@ -17,14 +17,15 @@ general:
   cannot_be_repaired_invalid: "<prefix><#fa4943>Musíte držet v ruce vhodný předmět!"
   updated_items: "<prefix><#55ffa4><amount> předmět(ů) bylo úspěšně aktualizováno pro <player>!"
   zip_browse_error: "<prefix><#fa4943>Nastala chyba při procházení zipu"
-  bad_recipe: "<prefix><#fa4943>Recept \"<recipe>\" není validní, ujistěte se, že všechny ingredience existují v konfigu"
-  item_not_found: "<prefix><#fa4943>Předmět \"<item>\" nenalezen"
-  plugin_hooks: "<prefix><#55ffa4>Plugin \"<plugin>\" detekován, zapínám hooky"
-  plugin_unhooks: "<prefix><#55ffa4>Odhookuji plugin \"<plugin>\""
+  bad_recipe: '<prefix><#fa4943>Recept "<recipe>" není validní, ujistěte se, že všechny ingredience existují v konfigu'
+  item_not_found: '<prefix><#fa4943>Předmět "<item>" nenalezen'
+  plugin_hooks: '<prefix><#55ffa4>Plugin "<plugin>" detekován, zapínám hooky'
+  plugin_unhooks: '<prefix><#55ffa4>Odhookuji plugin "<plugin>"'
   not_enough_exp: "<prefix><#fa4943>Na tohle potřebuješ více zkušeností"
   not_enough_space: "<prefix><#fa4943>Potřebuješ více místa pro položení tohoto nábytku"
   exit_menu: "<gradient:#FA7CBB:#F14658>Odejít"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  datapack_generated: "<prefix><#55ffa4>Datapack byl úspěšně vygenerován"
 
 logs:
   loaded: "<prefix><#55ffa4>Úspěšně načten na <os>"
@@ -34,31 +35,31 @@ logs:
 
 command:
   help: "<prefix><#b8bbc2>Dostupné příkazy
-        \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> reloadne plugin
-        \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> ukáže oraxen předměty v inventáři
-        \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> odešle oraxen pack
-        \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> opraví jeden nebo všechny tvé předměty
-        \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> givne oraxen předmět
-        \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> ukáže recepty
-        \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> otevře stavitele receptů
-        \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> uloží recept"
+    \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> reloadne plugin
+    \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> ukáže oraxen předměty v inventáři
+    \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> odešle oraxen pack
+    \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> opraví jeden nebo všechny tvé předměty
+    \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> givne oraxen předmět
+    \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> ukáže recepty
+    \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> otevře stavitele receptů
+    \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> uloží recept"
   join: "
-        <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> Resource Pack </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
+    <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> Resource Pack </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
 
-        <gray><bold>Abys viděl nové předměty, musíš mít speciální resourcepack (ale neboj, můžeš používat i vlastní ve stejnou chvíli).</bold>
+    <gray><bold>Abys viděl nové předměty, musíš mít speciální resourcepack (ale neboj, můžeš používat i vlastní ve stejnou chvíli).</bold>
 
-        <dark_gray>»<gray> Abyste jej nahráli přímo ze hry, <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ nahrání resourcepacku ze hry může způsobit lagy\"><red><bold>KLIK ZDE</bold></hover></click>
+    <dark_gray>»<gray> Abyste jej nahráli přímo ze hry, <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ nahrání resourcepacku ze hry může způsobit lagy\"><red><bold>KLIK ZDE</bold></hover></click>
 
-        <dark_gray>»<gray> Pro stažení z internetu, <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ instalujte jej z Nastavení/Balíčky modifikací ve hře\"><green><bold>KLIK ZDE</bold></hover></click>
-        "
+    <dark_gray>»<gray> Pro stažení z internetu, <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ instalujte jej z Nastavení/Balíčky modifikací ve hře\"><green><bold>KLIK ZDE</bold></hover></click>
+    "
 
   recipe:
     no_builder: "<prefix><#fa4943>Nejdřív vytvoř prosím recept!"
@@ -87,5 +88,5 @@ command:
 
 mechanics:
   not_enough_exp: "<prefix><#fa4943>Pro tohle potřebuješ více zkušeností"
-  backpack_stacked: "<prefix><#fa4943>Cannot open stacked backpack"
+  backpack_stacked: "<prefix><#fa4943>Nelze otevřít naskládaný batoh"
   jukebox_now_playing: "<dark_purple>Nyní se přehrává <disc>"

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -9,18 +9,18 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>Resourcepack not uploaded"
   pack_uploaded: "<prefix><#55ffa4>Resourcepack uploaded to <url> in <delay> ms"
   pack_regenerated: "<prefix><#55ffa4>Resourcepack successfully regenerated"
-  updating_config: "<prefix><#facc43>Configuration option \"<option>\" not found, adding it!"
-  removing_config: "<prefix><#facc43>Configuration option \"<option>\" has been marked for removal, removing it!"
+  updating_config: '<prefix><#facc43>Configuration option "<option>" not found, adding it!'
+  removing_config: '<prefix><#facc43>Configuration option "<option>" has been marked for removal, removing it!'
   configs_validation_failed: "<prefix><#fa4943>Configurations validation failed, plugin automatically disabled!"
   repaired_items: "<prefix><#55ffa4><amount> item(s) were successfully repaired!"
   cannot_be_repaired: "<prefix><#fa4943>This item cannot be repaired!"
   cannot_be_repaired_invalid: "<prefix><#fa4943>You need to hold a valid Item in your hand!"
   updated_items: "<prefix><#55ffa4><amount> item(s) were successfully updated for <player>!"
   zip_browse_error: "<prefix><#fa4943>An error occured browsing the zip"
-  bad_recipe: "<prefix><#fa4943>The recipe \"<recipe>\" is invalid, please ensure all its ingredients exist in your config"
-  item_not_found: "<prefix><#fa4943>Item \"<item>\" not found"
-  plugin_hooks: "<prefix><#55ffa4>Plugin \"<plugin>\" detected, enabling hooks"
-  plugin_unhooks: "<prefix><#55ffa4>Unhooking plugin \"<plugin>\""
+  bad_recipe: '<prefix><#fa4943>The recipe "<recipe>" is invalid, please ensure all its ingredients exist in your config'
+  item_not_found: '<prefix><#fa4943>Item "<item>" not found'
+  plugin_hooks: '<prefix><#55ffa4>Plugin "<plugin>" detected, enabling hooks'
+  plugin_unhooks: '<prefix><#55ffa4>Unhooking plugin "<plugin>"'
   not_enough_exp: "<prefix><#fa4943>You need more experience to do this"
   not_enough_space: "<prefix><#fa4943>You need more space to place this furniture"
   exit_menu: "<gradient:#FA7CBB:#F14658>Exit"
@@ -31,31 +31,26 @@ logs:
   unloaded: "<prefix><#55ffa4>Successfully unloaded"
   no_armor_item: "<prefix><#fa4943>No item matching <name> found. Unable to use <armor_layer_file>"
   duplicate_armor_color: "<prefix><#fa4943><first_armor_prefix> armor set uses the same color as <second_armor_prefix> with a different texture"
-  datapack_not_found: "<prefix><#fa4943>Oraxen's <datapack_name> datapack could not be found..."
-  datapack_first_install: "<prefix><#facc43>The first time <setting_path> is set to <setting_value> in settings.yml"
-  datapack_restart_required: "<prefix><#facc43>you need to restart your server so that the DataPack is enabled..."
-  datapack_not_working: "<prefix><#facc43><feature_name> will not work, please restart your server once!"
-  datapack_not_enabled: "<prefix><#fa4943>Oraxen's <datapack_name> datapack is not enabled..."
   datapack_generated: "<prefix><#facc43>Generated <datapack_name> datapack. A server restart is required for this feature to work."
 
 command:
   help: "<prefix><#b8bbc2>Available commands
-        \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> reload the plugin
-        \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> show oraxen items in inventory
-        \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> send oraxen pack
-        \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> repair one or all your items
-        \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> give an oraxen item
-        \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> show recipes
-        \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> open recipes builder
-        \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> save recipe"
+    \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> reload the plugin
+    \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> show oraxen items in inventory
+    \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> send oraxen pack
+    \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> repair one or all your items
+    \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> give an oraxen item
+    \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> show recipes
+    \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> open recipes builder
+    \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> save recipe"
 
   join: |-
     <dark_gray><st>                           </st><dark_gray>{<aqua><bold>Resource Pack</bold><dark_gray>}<dark_gray><st>                        </st>

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -31,6 +31,12 @@ logs:
   unloaded: "<prefix><#55ffa4>Successfully unloaded"
   no_armor_item: "<prefix><#fa4943>No item matching <name> found. Unable to use <armor_layer_file>"
   duplicate_armor_color: "<prefix><#fa4943><first_armor_prefix> armor set uses the same color as <second_armor_prefix> with a different texture"
+  datapack_not_found: "<prefix><#fa4943>Oraxen's <datapack_name> datapack could not be found..."
+  datapack_first_install: "<prefix><#facc43>The first time <setting_path> is set to <setting_value> in settings.yml"
+  datapack_restart_required: "<prefix><#facc43>you need to restart your server so that the DataPack is enabled..."
+  datapack_not_working: "<prefix><#facc43><feature_name> will not work, please restart your server once!"
+  datapack_not_enabled: "<prefix><#fa4943>Oraxen's <datapack_name> datapack is not enabled..."
+  datapack_generated: "<prefix><#facc43>Generated <datapack_name> datapack. A server restart is required for this feature to work."
 
 command:
   help: "<prefix><#b8bbc2>Available commands

--- a/core/src/main/resources/languages/french.yml
+++ b/core/src/main/resources/languages/french.yml
@@ -9,22 +9,23 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>Le pack de ressources n'a pas été téléversé"
   pack_uploaded: "<prefix><#55ffa4>Pack de ressources téléversé à l'url <url> en <delay> ms"
   pack_regenerated: "<prefix><#55ffa4>Pack de ressources régénéré avec succès"
-  updating_config: "<prefix><#facc43>Option de configuration \"<option>\" introuvable, ajout en cours !"
-  removing_config: "<prefix><#facc43>Option de configuration \"<option>\" a été marquée pour suppression, la supprimer !"
+  updating_config: '<prefix><#facc43>Option de configuration "<option>" introuvable, ajout en cours !'
+  removing_config: '<prefix><#facc43>Option de configuration "<option>" a été marquée pour suppression, la supprimer !'
   configs_validation_failed: "<prefix><#fa4943>Échec de la validation des configurations, plugin automatiquement désactivé !"
   repaired_items: "<prefix><#55ffa4><amount> item(s) ont été réparés avec succès !"
   cannot_be_repaired: "<prefix><#fa4943>Cet item ne peut pas être réparé !"
   cannot_be_repaired_invalid: "<prefix><#fa4943>Vous devez tenir un item valide dans votre main !"
   updated_items: "<prefix><#55ffa4><amount> item(s) ont été mis à jour pour <player>!"
   zip_browse_error: "<prefix><#fa4943>Une erreur s'est produite en parcourant le zip"
-  bad_recipe: "<prefix><#fa4943>La recette \"<recipe>\" n'est pas valide, veuillez vous assurer que tous ses ingrédients existent dans votre config"
-  item_not_found: "<prefix><#fa4943>Item \"<item>\" introuvable"
-  plugin_hooks: "<prefix><#55ffa4>Plugin \"<plugin>\" détecté, activation des hooks"
-  plugin_unhooks: "<prefix><#55ffa4>Unhooking plugin \"<plugin>\""
+  bad_recipe: '<prefix><#fa4943>La recette "<recipe>" n''est pas valide, veuillez vous assurer que tous ses ingrédients existent dans votre config'
+  item_not_found: '<prefix><#fa4943>Item "<item>" introuvable'
+  plugin_hooks: '<prefix><#55ffa4>Plugin "<plugin>" détecté, activation des hooks'
+  plugin_unhooks: '<prefix><#55ffa4>Unhooking plugin "<plugin>"'
   not_enough_exp: "<prefix><#fa4943>Vous avez besoin de plus d'expérience pour faire ceci"
   not_enough_space: "<prefix><#fa4943>Vous avez besoin de plus de place pour placer cet équipement"
   exit_menu: "<gradient:#FA7CBB:#F14658>Quitter"
   no_emojis: "<prefix><#fa4943>Aucun émoji trouvé"
+  datapack_generated: "<prefix><#55ffa4>Le datapack a été généré avec succès"
 
 logs:
   loaded: "<prefix><#55ffa4>Chargé avec succès sur <os>"
@@ -34,31 +35,31 @@ logs:
 
 command:
   help: "<prefix><#b8bbc2>Commandes disponibles
-        \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> recharge le plugin
-        \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> affiche les item oraxen dans un inventaire
-        \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> envoie le pack Oraxen
-        \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> répare un ou tous vos item(s)
-        \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> donne un item Oraxen
-        \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> montre les recettes
-        \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> ouvre le créateur de recette
-        \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> sauvegarde une recette"
+    \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> recharge le plugin
+    \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> affiche les item oraxen dans un inventaire
+    \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> envoie le pack Oraxen
+    \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> répare un ou tous vos item(s)
+    \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> donne un item Oraxen
+    \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> montre les recettes
+    \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> ouvre le créateur de recette
+    \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> sauvegarde une recette"
   join: "
-        <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> Resource Pack </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
+    <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> Resource Pack </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
 
-        <gray><bold>Pour voir les nouveaux items, vous devez utiliser un pack de ressources spécial (mais ne vous inquiétez pas, cela ne vous empêche pas d'utiliser le vôtre en même temps).</bold>
+    <gray><bold>Pour voir les nouveaux items, vous devez utiliser un pack de ressources spécial (mais ne vous inquiétez pas, cela ne vous empêche pas d'utiliser le vôtre en même temps).</bold>
 
-        <dark_gray>»<gray> Pour essayer de le charger directement depuis le jeu, <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ charger le pack de ressources depuis le jeu peut provoquer des lags\"><red><bold>CLIQUER ICI</bold></hover></click>
+    <dark_gray>»<gray> Pour essayer de le charger directement depuis le jeu, <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ charger le pack de ressources depuis le jeu peut provoquer des lags\"><red><bold>CLIQUER ICI</bold></hover></click>
 
-        <dark_gray>»<gray> Pour le télécharger depuis internet, <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ installez-le depuis Options/Pack de ressources dans votre jeu\"><green><bold>CLIQUER ICI</bold></hover></click>
-        "
+    <dark_gray>»<gray> Pour le télécharger depuis internet, <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ installez-le depuis Options/Pack de ressources dans votre jeu\"><green><bold>CLIQUER ICI</bold></hover></click>
+    "
 
   recipe:
     no_builder: "<prefix><#fa4943>Veuillez d'abord créer une recette !"
@@ -77,10 +78,10 @@ command:
     wrong_color: "<prefix><#fa4943>Couleur non reconnue, essayez une couleur hexadécimale comme #FFFFFF !"
     failed: "<prefix><#fa4943>Cet item ne peut pas changer de couleur !"
 
-  hud: #If someone could translate this, I would be very happy!
-    no_hud: "<prefix><#fa4943>Il n'y pas d'ATH pour l'id '<hud_id>'!"
-    toggle_on: "<prefix><#55ffa4>L'ATH '<hud_id>' a été basculé sur activé!"
-    toggle_off: "<prefix><#fa4943>L'ATH '<hud_id>' a été basculé sur désactivé!"
+  hud:
+    no_hud: "<prefix><#fa4943>Il n'y a pas d'ATH nommé '<hud_id>'!"
+    toggle_on: "<prefix><#55ffa4>ATH '<hud_id>' activé!"
+    toggle_off: "<prefix><#fa4943>ATH '<hud_id>' désactivé!"
 
   debug.toggle: "<prefix><#55ffa4>Mode de débogage basculé sur <#43fa8c><state><#55ffa4>!"
   version: "<prefix><#55ffa4>Version d'Oraxen: <#43fa8c><version><#55ffa4>!"

--- a/core/src/main/resources/languages/german.yml
+++ b/core/src/main/resources/languages/german.yml
@@ -25,6 +25,7 @@ general:
   not_enough_space: "<prefix><#fa4943>Sie brauchen mehr Platz, um diese Möbel zu platzieren"
   exit_menu: "<gradient:#FA7CBB:#F14658>Beenden"
   no_emojis: "<prefix><#fa4943>Keine Emojis gefunden"
+  datapack_generated: "<prefix><#55ffa4>Datapack wurde erfolgreich generiert"
 
 logs:
   loaded: "<prefix><#55ffa4>Erfolgreich geladen auf <os>"
@@ -74,13 +75,13 @@ command:
     wrong_color: "<prefix><#fa4943>Farbe nicht erkannt, versuchen Sie eine hexadezimale Farbe wie #FFFFFF!"
     failed: "<prefix><#fa4943>Sie können die Farbe dieses Artikels nicht ändern!"
 
-  hud: #If someone could translate this, I would be very happy!
-    no_hud: "<prefix><#fa4943>There is no HUD by the name '<hud_id>'!"
-    toggle_on: "<prefix><#55ffa4>Toggled '<hud_id>' on!"
-    toggle_off: "<prefix><#fa4943>Toggled '<hud_id>' off!"
+  hud:
+    no_hud: "<prefix><#fa4943>Es gibt kein HUD mit dem Namen '<hud_id>'!"
+    toggle_on: "<prefix><#55ffa4>HUD '<hud_id>' aktiviert!"
+    toggle_off: "<prefix><#fa4943>HUD '<hud_id>' deaktiviert!"
 
-  debug.toggle: "<prefix><#55ffa4>Debug mode is now <#43fa8c><state><#55ffa4>!"
-  version: "<prefix><#55ffa4>Oraxen version: <#43fa8c><version><#55ffa4>!"
+  debug.toggle: "<prefix><#55ffa4>Debug-Modus ist jetzt <#43fa8c><state><#55ffa4>!"
+  version: "<prefix><#55ffa4>Oraxen Version: <#43fa8c><version><#55ffa4>!"
 
 mechanics:
   not_enough_exp: "<prefix><#fa4943>Sie brauchen mehr Erfahrung, um dies zu tun"

--- a/core/src/main/resources/languages/jpn_JP.yml
+++ b/core/src/main/resources/languages/jpn_JP.yml
@@ -25,6 +25,7 @@ general:
   not_enough_space: "<prefix><#fa4943>この家具を置くためのスペースが足りません"
   exit_menu: "<gradient:#FA7CBB:#F14658>終了"
   no_emojis: "<prefix><#fa4943>絵文字が見つかりません"
+  datapack_generated: "<prefix><#55ffa4>データパックが正常に生成されました"
 
 logs:
   loaded: "<prefix><#55ffa4><os>で正常に読み込まれました"

--- a/core/src/main/resources/languages/korean.yml
+++ b/core/src/main/resources/languages/korean.yml
@@ -9,22 +9,23 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>리소스 팩이 업로드되지 않았습니다"
   pack_uploaded: "<prefix><#55ffa4>리소스 팩이 <delay>ms 내에 <url>에 업로드되었습니다"
   pack_regenerated: "<prefix><#55ffa4>리소스 팩이 성공적으로 재생성되었습니다"
-  updating_config: "<prefix><#facc43>구성 옵션 \"<option>\"을(를) 찾을 수 없습니다. 옵션을 추가합니다!"
-  removing_config: "<prefix><#facc43>구성 옵션 \"<option>\"이(가) 제거 대기 상태로 표시되어 삭제됩니다!"
+  updating_config: '<prefix><#facc43>구성 옵션 "<option>"을(를) 찾을 수 없습니다. 옵션을 추가합니다!'
+  removing_config: '<prefix><#facc43>구성 옵션 "<option>"이(가) 제거 ��기 상태로 표시되어 삭제됩니다!'
   configs_validation_failed: "<prefix><#fa4943>구성 유효성 검사에 실패했습니다. 플러그인이 자동으로 비활성화되었습니다!"
   repaired_items: "<prefix><#55ffa4><amount>개의 아이템이 성공적으로 수리되었습니다!"
   cannot_be_repaired: "<prefix><#fa4943>이 아이템은 수리할 수 없습니다!"
   cannot_be_repaired_invalid: "<prefix><#fa4943>손에 유효한 아이템을 들고 있어야 합니다!"
   updated_items: "<prefix><#55ffa4><amount>개의 아이템이 <player>님을 위해 성공적으로 업데이트되었습니다!"
   zip_browse_error: "<prefix><#fa4943>ZIP을 브라우징 하는 중 오류가 발생했습니다"
-  bad_recipe: "<prefix><#fa4943>레시피 \"<recipe>\"가 유효하지 않습니다. 모든 재료가 구성에 존재하는지 확인하세요"
-  item_not_found: "<prefix><#fa4943>아이템 \"<item>\"을(를) 찾을 수 없습니다"
-  plugin_hooks: "<prefix><#55ffa4>플러그인 \"<plugin>\"이 감지되었습니다. 후크를 활성화합니다"
-  plugin_unhooks: "<prefix><#55ffa4>플러그인 \"<plugin>\"의 후크를 비활성화합니다"
+  bad_recipe: '<prefix><#fa4943>레시피 "<recipe>"가 유효하지 않습니다. 모든 재료가 구성에 존재하는지 확인하세요'
+  item_not_found: '<prefix><#fa4943>아이템 "<item>"을(를) 찾을 수 없습니다'
+  plugin_hooks: '<prefix><#55ffa4>플러그인 "<plugin>"이 감지되었습니다. 후크를 활성화합니다'
+  plugin_unhooks: '<prefix><#55ffa4>플러그인 "<plugin>"의 후크를 비활성화합니다'
   not_enough_exp: "<prefix><#fa4943>이 작업을 수행하기에는 더 많은 경험치가 필요합니다"
   not_enough_space: "<prefix><#fa4943>가구를 놓을 공간이 부족합니다"
   exit_menu: "<gradient:#FA7CBB:#F14658>나가기"
   no_emojis: "<prefix><#fa4943>이모지를 찾을 수 없습니다"
+  datapack_generated: "<prefix><#55ffa4>데이터팩이 성공적으로 생성되었습니다"
 
 logs:
   loaded: "<prefix><#55ffa4>성공적으로 <os>에 로드되었습니다"
@@ -34,22 +35,22 @@ logs:
 
 command:
   help: "<prefix><#b8bbc2>사용 가능한 명령어
-        \n<hover:show_text:\"<gray>리로드 명령어\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>리로드 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 플러그인을 리로드합니다
-        \n<hover:show_text:\"<gray>인벤토리 명령어\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>인벤토리</click></hover>  <#6f737d>»<#b8bbc2> 인벤토리에 있는 Oraxen 아이템을 표시합니다
-        \n<hover:show_text:\"<gray>팩 명령어\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>팩 <#fa8943>유형 <#43c9fa>대상</click></hover>  <#6f737d>»<#b8bbc2> Oraxen 팩을 보냅니다
-        \n<hover:show_text:\"<gray>수리 명령어\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>수리 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 당신의 아이템 중 하나 또는 모두를 수리합니다
-        \n<hover:show_text:\"<gray>아이템 지급 명령어\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>지급 <#43c9fa>대상 <#fa4362>아이템 <#43fa8c>수량</click></hover>  <#6f737d>»<#b8bbc2> Oraxen 아이템을 지급합니다
-        \n<hover:show_text:\"<gray>레시피 표시 명령어\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>레시피 표시 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 레시피를 표시합니다
-        \n<hover:show_text:\"<gray>레시피 제작 명령어\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>레시피 빌더 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 레시피 빌더를 엽니다
-        \n<hover:show_text:\"<gray>레시피 저장 명령어\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>레시피 저장 <#faf443>이름</click></hover>  <#6f737d>»<#b8bbc2> 레시피를 저장합니다"
+    \n<hover:show_text:\"<gray>리로드 명령어\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>리로드 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 플러그인을 리로드합니다
+    \n<hover:show_text:\"<gray>인벤토리 명령어\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>인벤토리</click></hover>  <#6f737d>»<#b8bbc2> 인벤토리에 있는 Oraxen 아이템을 표시합니다
+    \n<hover:show_text:\"<gray>팩 명령어\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>팩 <#fa8943>유형 <#43c9fa>대상</click></hover>  <#6f737d>»<#b8bbc2> Oraxen 팩을 보냅니다
+    \n<hover:show_text:\"<gray>수리 명령어\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>수리 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 당신의 아이템 중 하나 또는 모두를 수리합니다
+    \n<hover:show_text:\"<gray>아이템 지급 명령어\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>지급 <#43c9fa>대상 <#fa4362>아이템 <#43fa8c>수량</click></hover>  <#6f737d>»<#b8bbc2> Oraxen 아이템을 지급합니다
+    \n<hover:show_text:\"<gray>레시피 표시 명령어\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>레시피 표시 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 레시피를 표시합니다
+    \n<hover:show_text:\"<gray>레시피 제작 명령어\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>레시피 빌더 <#fa8943>유형</click></hover>  <#6f737d>»<#b8bbc2> 레시피 빌더를 엽니다
+    \n<hover:show_text:\"<gray>레시피 저장 명령어\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>레시피 저장 <#faf443>이름</click></hover>  <#6f737d>»<#b8bbc2> 레시피를 저장합니다"
 
   join: |-
     <dark_gray><st>                           </st><dark_gray>{<aqua><bold>리소스 팩</bold><dark_gray>}<dark_gray><st>                        </st>

--- a/core/src/main/resources/languages/ru-RU.yml
+++ b/core/src/main/resources/languages/ru-RU.yml
@@ -9,22 +9,23 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>Ресурспак не выгружен"
   pack_uploaded: "<prefix><#55ffa4>Ресурспак выгружен на <url> за <delay> мс"
   pack_regenerated: "<prefix><#55ffa4>Ресурспак успешно перегенерирован"
-  updating_config: "<prefix><#facc43>Опция конфигурации \"<option>\" не найдена, добавляется!"
-  removing_config: "<prefix><#facc43>Опция конфигурации \"<option>\" помечена для удаления, удаляется!"
+  updating_config: '<prefix><#facc43>Опция конфигурации "<option>" не найдена, добавляется!'
+  removing_config: '<prefix><#facc43>Опция конфигурации "<option>" помечена для удаления, удаляется!'
   configs_validation_failed: "<prefix><#fa4943>Проверка конфигураций не удалась, плагин автоматически отключён!"
   repaired_items: "<prefix><#55ffa4><amount> предмет(ов) успешно отремонтировано!"
   cannot_be_repaired: "<prefix><#fa4943>Этот предмет не может быть отремонтирован!"
   cannot_be_repaired_invalid: "<prefix><#fa4943>Вам нужно держать предмет в руке!"
   updated_items: "<prefix><#55ffa4><amount> предмет(ов) успешно обновлено для <player>!"
   zip_browse_error: "<prefix><#fa4943>Произошла ошибка при просмотре zip"
-  bad_recipe: "<prefix><#fa4943>Рецепт \"<recipe>\" недействителен, убедитесь, что все его ингредиенты существуют в вашей конфигурации"
-  item_not_found: "<prefix><#fa4943>Предмет \"<item>\" не найден"
-  plugin_hooks: "<prefix><#55ffa4>Обнаружен плагин \"<plugin>\", включение интеграции"
-  plugin_unhooks: "<prefix><#55ffa4>Отключение интеграции для плагина \"<plugin>\""
+  bad_recipe: '<prefix><#fa4943>Рецепт "<recipe>" недействителен, убедитесь, что все его ингредиенты существуют в вашей конфигурации'
+  item_not_found: '<prefix><#fa4943>Предмет "<item>" не найден'
+  plugin_hooks: '<prefix><#55ffa4>Обнаружен плагин "<plugin>", включение интеграции'
+  plugin_unhooks: '<prefix><#55ffa4>Отключение интеграции для плагина "<plugin>"'
   not_enough_exp: "<prefix><#fa4943>Вам нужно больше очков опыта, чтобы сделать это"
   not_enough_space: "<prefix><#fa4943>Вам нужно больше места, чтобы разместить эту декорацию"
   exit_menu: "<gradient:#FA7CBB:#F14658>Выход"
   no_emojis: "<prefix><#fa4943>Эмодзи не найдены"
+  datapack_generated: "<prefix><#55ffa4>Датапак успешно сгенерирован"
 
 logs:
   loaded: "<prefix><#55ffa4>Успешно загружено на <os>"
@@ -34,22 +35,22 @@ logs:
 
 command:
   help: "<prefix><#b8bbc2>Доступные команды
-        \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>reload <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> перезагрузить плагин
-        \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> показать предметы oraxen в инвентаре
-        \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>pack <#fa8943>тип <#43c9fa>цель</click></hover>  <#6f737d>»<#b8bbc2> отправить ресурспак игроку
-        \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>repair <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> отремонтировать один или все ваши предметы
-        \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>give <#43c9fa>цель <#fa4362>предмет <#43fa8c>количество</click></hover>  <#6f737d>»<#b8bbc2> получить предмет oraxen
-        \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>recipes show <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> показать рецепты
-        \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>recipes builder <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> открыть конструктор рецептов
-        \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>recipes save <#faf443>имя</click></hover>  <#6f737d>»<#b8bbc2> сохранить рецепт"
+    \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>reload <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> перезагрузить плагин
+    \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> показать предметы oraxen в инвентаре
+    \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>pack <#fa8943>тип <#43c9fa>цель</click></hover>  <#6f737d>»<#b8bbc2> отправить ресурспак игроку
+    \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>repair <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> отремонтировать один или все ваши предметы
+    \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>give <#43c9fa>цель <#fa4362>предмет <#43fa8c>количество</click></hover>  <#6f737d>»<#b8bbc2> получить предмет oraxen
+    \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>recipes show <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> показать рецепты
+    \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>recipes builder <#fa8943>тип</click></hover>  <#6f737d>»<#b8bbc2> открыть конструктор рецептов
+    \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>recipes save <#faf443>имя</click></hover>  <#6f737d>»<#b8bbc2> сохранить рецепт"
 
   join: |-
     <dark_gray><st>                             </st><dark_gray>{<aqua><bold>Ресурспак</bold><dark_gray>}<dark_gray><st>                          </st>

--- a/core/src/main/resources/languages/zh-CN.yml
+++ b/core/src/main/resources/languages/zh-CN.yml
@@ -9,7 +9,7 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>材质包上传失败"
   pack_uploaded: "<prefix><#55ffa4>材质包上传至 <url> 用时 <delay> 毫秒"
   pack_regenerated: "<prefix><#55ffa4>材质包重新生成成功"
-  updating_config: "<prefix><#facc43>未找到配置选项 \"<option>\"， 添加中！"
+  updating_config: '<prefix><#facc43>未找到配置选项 "<option>"， 添加中！'
   removing_config: Configuration option \"<option>\" has been marked for removal, removing it!"
   configs_validation_failed: "<prefix><#fa4943>配置文件验证失败，插件将自动禁用！"
   repaired_items: "<prefix><#55ffa4><amount> 个物品已成功修复！"
@@ -17,14 +17,15 @@ general:
   cannot_be_repaired_invalid: "<prefix><#fa4943>你需要在你的手中持有一个有效的物品！"
   updated_items: "<prefix><#55ffa4>已为 <player> 成功更新 <amount> 个物品！"
   zip_browse_error: "<prefix><#fa4943>浏览压缩文件时发生了一个错误"
-  bad_recipe: "<prefix><#fa4943>配方 \"<recipe>\" 无效，请确保配方配置文件无误"
-  item_not_found: "<prefix><#fa4943>无法找到 \"<item>\""
-  plugin_hooks: "<prefix><#55ffa4>找到 \"<plugin>\" 插件, 贴贴中"
-  plugin_unhooks: "<prefix><#55ffa4>让 \"<plugin>\" 爬"
+  bad_recipe: '<prefix><#fa4943>配方 "<recipe>" 无效，请确保配方配置文件无误'
+  item_not_found: '<prefix><#fa4943>无法找到 "<item>"'
+  plugin_hooks: '<prefix><#55ffa4>找到 "<plugin>" 插件, 贴贴中'
+  plugin_unhooks: '<prefix><#55ffa4>让 "<plugin>" 爬'
   not_enough_exp: "<prefix><#fa4943>经验值好像不够欸"
   not_enough_space: "<prefix><#fa4943>你需要更多的空间来放置这个家具"
   exit_menu: "<gradient:#FA7CBB:#F14658>退出"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  datapack_generated: "<prefix><#55ffa4>数据包生成成功"
 
 logs:
   loaded: "<prefix><#55ffa4>已成功在 <os> 载入"
@@ -34,31 +35,31 @@ logs:
 
 command:
   help: "<prefix><#b8bbc2>可用指令
-        \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 重载此插件
-        \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> 在背包中显示 oraxen 物品
-        \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> 发送材质包
-        \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 修复一个或所有你的物品
-        \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> 给一个 oraxen 物品
-        \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 显示配方
-        \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 打开配方生成器
-        \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> 保存配方"
+    \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 重载此插件
+    \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> 在背包中显示 oraxen 物品
+    \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> 发送材质包
+    \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 修复一个或所有你的物品
+    \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> 给一个 oraxen 物品
+    \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 显示配方
+    \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 打开配方生成器
+    \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> 保存配方"
   join: "
-        <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> 材质包 </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
+    <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> 材质包 </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
 
-        <gray><bold>要看到新的物品，你需要使用一个特殊的材质包包 (不用担心，你依然可以使用自己的材质包)。</bold>
+    <gray><bold>要看到新的物品，你需要使用一个特殊的材质包包 (不用担心，你依然可以使用自己的材质包)。</bold>
 
-        <dark_gray>»<gray> 如果你想直接在游戏内载入它， <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ 加载材质包可能会造成卡顿\"><red><bold>点击这里</bold></hover></click>
+    <dark_gray>»<gray> 如果你想直接在游戏内载入它， <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ 加载材质包可能会造成卡顿\"><red><bold>点击这里</bold></hover></click>
 
-        <dark_gray>»<gray> 如果想从网上下载， <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ 自行从游戏载入此材质包\"><green><bold>点击这里</bold></hover></click>
-        "
+    <dark_gray>»<gray> 如果想从网上下载， <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ 自行从游戏载入此材质包\"><green><bold>点击这里</bold></hover></click>
+    "
 
   recipe:
     no_builder: "<prefix><#fa4943>请先创建一个配方！"
@@ -77,7 +78,7 @@ command:
     wrong_color: "<prefix><#fa4943>颜色无法识别，请尝试使用十六进制的颜色，如 #FFFFFF!"
     failed: "<prefix><#fa4943>你无法改变此物品的颜色！"
 
-  hud: #If someone could translate this, I would be very happy! 
+  hud: #If someone could translate this, I would be very happy!
     no_hud: "<prefix><#fa4943>没有一个名字叫 '<hud_id>' 的HUD!"
     toggle_on: "<prefix><#55ffa4>切换 '<hud_id>' 开启!"
     toggle_off: "<prefix><#fa4943>切换 '<hud_id>' 关闭!"

--- a/core/src/main/resources/languages/zh-TW.yml
+++ b/core/src/main/resources/languages/zh-TW.yml
@@ -9,7 +9,7 @@ general:
   pack_not_uploaded: "<prefix><#fa4943>材質包上傳失敗"
   pack_uploaded: "<prefix><#55ffa4>材質包上傳至 <url> 用時 <delay> 毫秒"
   pack_regenerated: "<prefix><#55ffa4>材質包重新生成成功"
-  updating_config: "<prefix><#facc43>未找到配置選項 \"<option>\"， 新增中！"
+  updating_config: '<prefix><#facc43>未找到配置選項 "<option>"， 新增中！'
   removing_config: Configuration option \"<option>\" has been marked for removal, removing it!"
   configs_validation_failed: "<prefix><#fa4943>配置檔案驗證失敗，外掛將自動禁用！"
   repaired_items: "<prefix><#55ffa4><amount> 個物品已成功修復！"
@@ -17,14 +17,15 @@ general:
   cannot_be_repaired_invalid: "<prefix><#fa4943>你需要在你的手中持有一個有效的物品！"
   updated_items: "<prefix><#55ffa4>已為 <player> 成功更新 <amount> 個物品！"
   zip_browse_error: "<prefix><#fa4943>瀏覽壓縮檔案時發生了一個錯誤"
-  bad_recipe: "<prefix><#fa4943>配方 \"<recipe>\" 無效，請確保配方配置檔案無誤"
-  item_not_found: "<prefix><#fa4943>無法找到 \"<item>\""
-  plugin_hooks: "<prefix><#55ffa4>找到 \"<plugin>\" 外掛, 貼貼中"
-  plugin_unhooks: "<prefix><#55ffa4>讓 \"<plugin>\" 爬"
+  bad_recipe: '<prefix><#fa4943>配方 "<recipe>" 無效，請確保配方配置檔案無誤'
+  item_not_found: '<prefix><#fa4943>無法找到 "<item>"'
+  plugin_hooks: '<prefix><#55ffa4>找到 "<plugin>" 外掛, 貼貼中'
+  plugin_unhooks: '<prefix><#55ffa4>讓 "<plugin>" 爬'
   not_enough_exp: "<prefix><#fa4943>經驗值好像不夠欸"
   not_enough_space: "<prefix><#fa4943>你需要更多的空間來放置這個傢俱"
   exit_menu: "<gradient:#FA7CBB:#F14658>退出"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  datapack_generated: "<prefix><#55ffa4>資料包生成成功"
 
 logs:
   loaded: "<prefix><#55ffa4>已成功在 <os> 載入"
@@ -34,31 +35,31 @@ logs:
 
 command:
   help: "<prefix><#b8bbc2>可用指令
-        \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
-          <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 過載此外掛
-        \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
-          <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> 在揹包中顯示 oraxen 物品
-        \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
-          <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> 傳送材質包
-        \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
-          <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 修復一個或所有你的物品
-        \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
-          <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> 給一個 oraxen 物品
-        \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
-          <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 顯示配方
-        \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
-          <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 開啟配方生成器
-        \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
-          <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> 儲存配方"
+    \n<hover:show_text:\"<gray>fill reload command\"><click:SUGGEST_COMMAND:/oraxen reload ><#6f737d>/o
+    <#b8bbc2>reload <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 過載此外掛
+    \n<hover:show_text:\"<gray>fill inv command\"><click:SUGGEST_COMMAND:/oraxen inv><#6f737d>/o
+    <#b8bbc2>inventory</click></hover>  <#6f737d>»<#b8bbc2> 在揹包中顯示 oraxen 物品
+    \n<hover:show_text:\"<gray>fill pack command\"><click:SUGGEST_COMMAND:/oraxen pack ><#6f737d>/o
+    <#b8bbc2>pack <#fa8943>type <#43c9fa>target</click></hover>  <#6f737d>»<#b8bbc2> 傳送材質包
+    \n<hover:show_text:\"<gray>fill repair command\"><click:SUGGEST_COMMAND:/oraxen repair ><#6f737d>/o
+    <#b8bbc2>repair <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 修復一個或所有你的物品
+    \n<hover:show_text:\"<gray>fill give command\"><click:SUGGEST_COMMAND:/oraxen give ><#6f737d>/o
+    <#b8bbc2>give <#43c9fa>target <#fa4362>item <#43fa8c>amount</click></hover>  <#6f737d>»<#b8bbc2> 給一個 oraxen 物品
+    \n<hover:show_text:\"<gray>fill recipes show command\"><click:SUGGEST_COMMAND:/oraxen recipes show ><#6f737d>/o
+    <#b8bbc2>recipes show <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 顯示配方
+    \n<hover:show_text:\"<gray>fill recipes builder command\"><click:SUGGEST_COMMAND:/oraxen recipes builder ><#6f737d>/o
+    <#b8bbc2>recipes builder <#fa8943>type</click></hover>  <#6f737d>»<#b8bbc2> 開啟配方生成器
+    \n<hover:show_text:\"<gray>fill recipes save command\"><click:SUGGEST_COMMAND:/oraxen recipes save ><#6f737d>/o
+    <#b8bbc2>recipes save <#faf443>name</click></hover>  <#6f737d>»<#b8bbc2> 儲存配方"
   join: "
-        <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> 材質包 </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
+    <dark_gray><strikethrough>                           </strikethrough><dark_gray>{<aqua><bold> 材質包 </bold><dark_gray>}<dark_gray><strikethrough>                        </strikethrough>
 
-        <gray><bold>要看到新的物品，你需要使用一個特殊的材質包包 (不用擔心，你依然可以使用自己的材質包)。</bold>
+    <gray><bold>要看到新的物品，你需要使用一個特殊的材質包包 (不用擔心，你依然可以使用自己的材質包)。</bold>
 
-        <dark_gray>»<gray> 如果你想直接在遊戲內載入它， <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ 載入材質包可能會造成卡頓\"><red><bold>點選這裡</bold></hover></click>
+    <dark_gray>»<gray> 如果你想直接在遊戲內載入它， <click:run_command:/oraxen pack send @p><hover:show_text:\"<red>/!\\ 載入材質包可能會造成卡頓\"><red><bold>點選這裡</bold></hover></click>
 
-        <dark_gray>»<gray> 如果想從網上下載， <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ 自行從遊戲載入此材質包\"><green><bold>點選這裡</bold></hover></click>
-        "
+    <dark_gray>»<gray> 如果想從網上下載， <click:open_url:<pack_url>><hover:show_text:\"<green>/!\\ 自行從遊戲載入此材質包\"><green><bold>點選這裡</bold></hover></click>
+    "
 
   recipe:
     no_builder: "<prefix><#fa4943>請先建立一個配方！"
@@ -77,15 +78,15 @@ command:
     wrong_color: "<prefix><#fa4943>顏色無法識別，請嘗試使用十六進位制的顏色，如 #FFFFFF!"
     failed: "<prefix><#fa4943>你無法改變此物品的顏色！"
 
-  hud: #If someone could translate this, I would be very happy!
-    no_hud: "<prefix><#fa4943>There is no HUD by the name '<hud_id>'!"
-    toggle_on: "<prefix><#55ffa4>Toggled '<hud_id>' on!"
-    toggle_off: "<prefix><#fa4943>Toggled '<hud_id>' off!"
+  hud:
+    no_hud: "<prefix><#fa4943>沒有名為 '<hud_id>' 的HUD!"
+    toggle_on: "<prefix><#55ffa4>已開啟 '<hud_id>' HUD!"
+    toggle_off: "<prefix><#fa4943>已關閉 '<hud_id>' HUD!"
 
-  debug.toggle: "<prefix><#55ffa4>Debug mode is now <#43fa8c><state><#55ffa4>!"
-  version: "<prefix><#55ffa4>Oraxen version: <#43fa8c><version><#55ffa4>!"
+  debug.toggle: "<prefix><#55ffa4>除錯模式現在為 <#43fa8c><state><#55ffa4>!"
+  version: "<prefix><#55ffa4>Oraxen 版本: <#43fa8c><version><#55ffa4>!"
 
 mechanics:
   not_enough_exp: "<prefix><#fa4943>你需要更多經驗欸"
-  backpack_stacked: "<prefix><#fa4943>Cannot open stacked backpack"
-  jukebox_now_playing: "<dark_purple>Now Playing <disc>"
+  backpack_stacked: "<prefix><#fa4943>無法打開堆疊的背包"
+  jukebox_now_playing: "<dark_purple>正在播放 <disc>"

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -1,7 +1,7 @@
 debug: false
 Plugin:
-  keep_this_up_to_date: true #Oraxen will delete old settings
-  language: "english"
+  keep_this_up_to_date: true # Oraxen will delete old settings
+  language: "english" # Valid options are "czech", "english", "french", "german",  "jpn_JP", "korean", "ru-RU", "zh-CN", "zh-TW"
   commands:
     repair:
       oraxen_durability_only: false # will not repair vanilla items if set to true
@@ -26,7 +26,18 @@ WorldEdit: # Please note these are both experimental still and should be used wi
 ConfigsTools:
   # list of model data numbers the automatic system will skip
   # List can take ranges like 1-4 as well as normal singular numbers
-  skipped_model_data_numbers: []
+  skipped_model_data_numbers:
+    [
+      "czech",
+      "english",
+      "french",
+      "german",
+      "korean",
+      "ru-RU",
+      "zh-CN",
+      "zh-TW",
+      "JPN_JP",
+    ]
   disable_automatic_model_data: false
   disable_automatic_glyph_code: false
   enable_configs_updater: true

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -26,18 +26,7 @@ WorldEdit: # Please note these are both experimental still and should be used wi
 ConfigsTools:
   # list of model data numbers the automatic system will skip
   # List can take ranges like 1-4 as well as normal singular numbers
-  skipped_model_data_numbers:
-    [
-      "czech",
-      "english",
-      "french",
-      "german",
-      "korean",
-      "ru-RU",
-      "zh-CN",
-      "zh-TW",
-      "JPN_JP",
-    ]
+  skipped_model_data_numbers: []
   disable_automatic_model_data: false
   disable_automatic_glyph_code: false
   enable_configs_updater: true

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -143,7 +143,7 @@ Pack:
         sound:
           # Disabled by default, just switch to enabled to send
           # the below sound whenever someone joins
-          enabled: false
+          enabled: true
           type: minecraft:welcome
           volume: 1.0
           pitch: 1.0

--- a/core/src/main/resources/sound.yml
+++ b/core/src/main/resources/sound.yml
@@ -9,9 +9,15 @@ settings:
 # The above are just empty and side-effect of generating the json file.
 sounds:
   welcome:
-    category: record
+    category: records
     sound: welcome.ogg # extension is not mandatory
     stream: true
+    subtitle: "Welcome Song"
+    # This section will automatically generate a datapack
+    jukebox_song:
+      description: "<gold>Welcome <yellow>Song</yellow></gold>"
+      length_in_seconds: 180
+      comparator_output: 12
   block.wood.step: # Required for custom sounds
     replace: true
   block.wood.place:

--- a/core/src/main/resources/sound.yml
+++ b/core/src/main/resources/sound.yml
@@ -11,6 +11,7 @@ sounds:
   welcome:
     category: record
     sound: welcome.ogg # extension is not mandatory
+    stream: true
   block.wood.step: # Required for custom sounds
     replace: true
   block.wood.place:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pluginVersion=1.184.1
+pluginVersion=1.185.0
 idofrontVersion=0.21.12


### PR DESCRIPTION
This update improves the Jukebox feature, focusing on sounds and making use of new components to add more flexibility and functionality.

## What's New
- **Custom Disks and Music**: You can now create your own disks with your own music, and Oraxen will handle the datapack generation automatically. This makes it easier to add custom content without extra hassle.
- **Reworked Furniture Integration**: It's now possible to create furniture that works like a jukebox in 1.21.3, using custom disks or regular ones, but with your own design. These can even have custom models when the disk is running.
- **Updated Default Config**: The default config has been updated to show off these new features. A new **turntable** ("tourne disque") has been added, which opens itself and starts spinning the disk when you insert one, adding a nice visual touch.

### Related Issues
- Closes https://github.com/oraxen/oraxen/issues/1584
- Closes https://github.com/oraxen/oraxen/issues/1586

This update improves the jukebox experience and makes it easier to customize sounds and visuals. Feel free to test it out and share any feedback!
