### PR TITLE
1.189.0

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -671,12 +671,12 @@ public class ItemBuilder {
     }
 
     public ItemBuilder addAttributeModifiers(final Attribute attribute, final AttributeModifier attributeModifier) {
-        if (!hasAttributeModifiers) {
-            hasAttributeModifiers = true;
-            attributeModifiers = HashMultimap.create();
-        }
         if (attribute != null && attributeModifier != null) {
+            if (attributeModifiers == null) {
+                attributeModifiers = HashMultimap.create();
+            }
             attributeModifiers.put(attribute, attributeModifier);
+            hasAttributeModifiers = true;
         }
         return this;
     }
@@ -830,8 +830,9 @@ public class ItemBuilder {
             }
         }
 
-        if (hasAttributeModifiers)
+        if (hasAttributeModifiers && attributeModifiers != null) {
             itemMeta.setAttributeModifiers(attributeModifiers);
+        }
 
         itemMeta.setCustomModelData(customModelData);
 

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemBuilder.java
@@ -661,8 +661,8 @@ public class ItemBuilder {
 
     public ItemBuilder addItemFlags(final ItemFlag... itemFlags) {
         if (this.itemFlags == null)
-            this.itemFlags = new HashSet<>();
-        this.itemFlags.addAll(Arrays.asList(itemFlags));
+            this.itemFlags = EnumSet.noneOf(ItemFlag.class); // Use EnumSet for better performance
+        Collections.addAll(this.itemFlags, itemFlags);
         return this;
     }
 
@@ -675,14 +675,20 @@ public class ItemBuilder {
             hasAttributeModifiers = true;
             attributeModifiers = HashMultimap.create();
         }
-        attributeModifiers.put(attribute, attributeModifier);
+        if (attribute != null && attributeModifier != null) {
+            attributeModifiers.put(attribute, attributeModifier);
+        }
         return this;
     }
 
     public ItemBuilder addAllAttributeModifiers(final Multimap<Attribute, AttributeModifier> attributeModifiers) {
-        if (!hasAttributeModifiers)
+        if (!hasAttributeModifiers) {
             hasAttributeModifiers = true;
-        this.attributeModifiers.putAll(attributeModifiers);
+            this.attributeModifiers = HashMultimap.create();
+        }
+        if (attributeModifiers != null) {
+            this.attributeModifiers.putAll(attributeModifiers);
+        }
         return this;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -190,18 +190,12 @@ public class ItemParser {
     }
 
     private void handleLegacyComponents(ItemBuilder item, ConfigurationSection components) {
-        if (components.contains("max_stack_size"))
-            item.setMaxStackSize(Math.clamp(components.getInt("max_stack_size"), 1, 99));
 
-        if (components.contains("enchantment_glint_override"))
-            item.setEnchantmentGlindOverride(components.getBoolean("enchantment_glint_override"));
         if (components.contains("durability")) {
             item.setDamagedOnBlockBreak(components.getBoolean("durability.damage_block_break"));
             item.setDamagedOnEntityHit(components.getBoolean("durability.damage_entity_hit"));
             item.setDurability(Math.max(components.getInt("durability.value"), components.getInt("durability", 1)));
         }
-        if (components.contains("rarity"))
-            item.setRarity(ItemRarity.valueOf(components.getString("rarity")));
         if (components.contains("fire_resistant"))
             item.setFireResistant(components.getBoolean("fire_resistant"));
         if (components.contains("hide_tooltip"))
@@ -241,28 +235,18 @@ public class ItemParser {
 
         Optional.ofNullable(components.getConfigurationSection("use_remainder"))
                 .ifPresent(useRemainder -> parseUseRemainderComponent(item, useRemainder));
-        Optional.ofNullable(components.getString("damage_resistant")).map(NamespacedKey::fromString)
-                .ifPresent(damageResistantKey -> item.setDamageResistant(
-                        Bukkit.getTag(DamageTypeTags.REGISTRY_DAMAGE_TYPES, damageResistantKey, DamageType.class)));
 
         Optional.ofNullable(components.getString("tooltip_style")).map(NamespacedKey::fromString)
                 .ifPresent(item::setTooltipStyle);
         Optional.ofNullable(components.getString("item_model")).map(NamespacedKey::fromString)
                 .ifPresent(item::setItemModel);
-        if (components.contains("enchantable"))
-            item.setEnchantable(components.getInt("enchantable"));
-        if (components.contains("glider"))
-            item.setGlider(components.getBoolean("glider"));
-
         Optional.ofNullable(components.getConfigurationSection("consumable"))
                 .ifPresent(consumableSection -> NMSHandlers.getHandler().consumableComponent(item, consumableSection));
     }
 
     private boolean isLegacyComponent(String key) {
-        return key.equals("max_stack_size") ||
-                key.equals("enchantment_glint_override") ||
+        return 
                 key.equals("durability") ||
-                key.equals("rarity") ||
                 key.equals("fire_resistant") ||
                 key.equals("hide_tooltip") ||
                 key.equals("food") ||
@@ -271,11 +255,8 @@ public class ItemParser {
                 key.equals("equippable") ||
                 key.equals("use_cooldown") ||
                 key.equals("use_remainder") ||
-                key.equals("damage_resistant") ||
                 key.equals("tooltip_style") ||
                 key.equals("item_model") ||
-                key.equals("enchantable") ||
-                key.equals("glider") ||
                 key.equals("consumable");
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -474,18 +474,29 @@ public class ItemParser {
             }
         }
 
-        if (section.contains("AttributeModifiers")) {
-            List<LinkedHashMap<String, Object>> attributes = (List<LinkedHashMap<String, Object>>) section
-                    .getList("AttributeModifiers");
-            if (attributes != null)
-                for (LinkedHashMap<String, Object> attributeJson : attributes) {
+        List<Map<String, Object>> attributes = (List<Map<String, Object>>) section.getList("AttributeModifiers");
+        if (attributes != null) {
+            for (Map<String, Object> attributeJson : attributes) {
+                try {
                     attributeJson.putIfAbsent("uuid", UUID.randomUUID().toString());
                     attributeJson.putIfAbsent("name", "oraxen:modifier");
                     attributeJson.putIfAbsent("key", "oraxen:modifier");
+
                     AttributeModifier attributeModifier = AttributeModifier.deserialize(attributeJson);
                     Attribute attribute = AttributeWrapper.fromString((String) attributeJson.get("attribute"));
-                    item.addAttributeModifiers(attribute, attributeModifier);
+
+                    if (attribute != null) {
+                        item.addAttributeModifiers(attribute, attributeModifier);
+                    } else {
+                        Logs.logWarning("Attribute not found for key: " + attributeJson.get("attribute") + " in item: " + section.getName());
+                    }
+                } catch (Exception e) {
+                    Logs.logWarning("Error parsing AttributeModifiers in " + section.getName());
+                    if (Settings.DEBUG.toBool()) {
+                        e.printStackTrace();
+                    }
                 }
+            }
         }
 
         if (section.contains("Enchantments")) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -10,6 +10,8 @@ import java.util.*;
 
 public class VersionUtil {
     private static final Map<NMSVersion, Map<Integer, MinecraftVersion>> versionMap = new HashMap<>();
+    private static final boolean IS_PAPER;
+    private static final boolean IS_FOLIA;
 
     public enum NMSVersion {
         v1_21_R3,
@@ -32,6 +34,8 @@ public class VersionUtil {
     }
 
     static {
+        IS_PAPER = hasClass("com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent");
+        IS_FOLIA = hasClass("io.papermc.paper.threadedregions.RegionizedServer");
         versionMap.put(NMSVersion.v1_21_R3,
                 Map.of(19, new MinecraftVersion("1.21.4")));
         versionMap.put(NMSVersion.v1_21_R2,
@@ -70,24 +74,11 @@ public class VersionUtil {
      * @throws IllegalArgumentException if server is null
      */
     public static boolean isPaperServer() {
-        Server server = Bukkit.getServer();
-        Validate.notNull(server, "Server cannot be null");
-        if (server.getName().equalsIgnoreCase("Paper"))
-            return true;
-
-        try {
-            Class.forName("com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+        return IS_PAPER;
     }
 
     public static boolean isFoliaServer() {
-        Server server = Bukkit.getServer();
-        Validate.notNull(server, "Server cannot be null");
-
-        return server.getName().equalsIgnoreCase("Folia");
+        return IS_FOLIA;
     }
 
     public static boolean isSupportedVersion(@NotNull NMSVersion serverVersion,
@@ -153,5 +144,14 @@ public class VersionUtil {
     public static boolean isValidCompiler() {
         List<String> split = Arrays.stream(manifest.split(":|\n")).map(String::trim).toList();
         return Set.of("sivert", "thomas").contains(split.get(split.indexOf("Built-By") + 1).toLowerCase(Locale.ROOT));
+    }
+
+    private static boolean hasClass(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException var2) {
+            return false;
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/wrappers/AttributeWrapper.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/wrappers/AttributeWrapper.java
@@ -11,10 +11,42 @@ import java.util.Locale;
 
 public class AttributeWrapper {
 
+    public static final Attribute ARMOR = VersionUtil.atOrAbove("1.21.2") ? Attribute.ARMOR : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.armor"));
+    public static final Attribute ARMOR_TOUGHNESS = VersionUtil.atOrAbove("1.21.2") ? Attribute.ARMOR_TOUGHNESS : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.armor_toughness"));
+    public static final Attribute ATTACK_DAMAGE = VersionUtil.atOrAbove("1.21.2") ? Attribute.ATTACK_DAMAGE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.attack_damage"));
+    public static final Attribute ATTACK_KNOCKBACK = VersionUtil.atOrAbove("1.21.2") ? Attribute.ATTACK_KNOCKBACK : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.attack_knockback"));
+    public static final Attribute ATTACK_SPEED = VersionUtil.atOrAbove("1.21.2") ? Attribute.ATTACK_SPEED : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.attack_speed"));
+    public static final Attribute BLOCK_BREAK_SPEED = VersionUtil.atOrAbove("1.21.2") ? Attribute.BLOCK_BREAK_SPEED : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.block_break_speed"));
+    public static final Attribute BLOCK_INTERACTION_RANGE = VersionUtil.atOrAbove("1.21.2") ? Attribute.BLOCK_INTERACTION_RANGE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.block_interaction_range"));
+    public static final Attribute BURNING_TIME = VersionUtil.atOrAbove("1.21.2") ? Attribute.BURNING_TIME : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.burning_time"));
+    public static final Attribute ENTITY_INTERACTION_RANGE = VersionUtil.atOrAbove("1.21.2") ? Attribute.ENTITY_INTERACTION_RANGE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.entity_interaction_range"));
+    public static final Attribute EXPLOSION_KNOCKBACK_RESISTANCE = VersionUtil.atOrAbove("1.21.2") ? Attribute.EXPLOSION_KNOCKBACK_RESISTANCE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.explosion_knockback_resistance"));
+    public static final Attribute FALL_DAMAGE_MULTIPLIER = VersionUtil.atOrAbove("1.21.2") ? Attribute.FALL_DAMAGE_MULTIPLIER : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.fall_damage_multiplier"));
+    public static final Attribute FLYING_SPEED = VersionUtil.atOrAbove("1.21.2") ? Attribute.FLYING_SPEED : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.flying_speed"));
+    public static final Attribute FOLLOW_RANGE = VersionUtil.atOrAbove("1.21.2") ? Attribute.FOLLOW_RANGE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.follow_range"));
+    public static final Attribute GRAVITY = VersionUtil.atOrAbove("1.21.2") ? Attribute.GRAVITY : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.gravity"));
+    public static final Attribute JUMP_STRENGTH = VersionUtil.atOrAbove("1.21.2") ? Attribute.JUMP_STRENGTH : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.jump_strength"));
+    public static final Attribute KNOCKBACK_RESISTANCE = VersionUtil.atOrAbove("1.21.2") ? Attribute.KNOCKBACK_RESISTANCE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.knockback_resistance"));
+    public static final Attribute LUCK = VersionUtil.atOrAbove("1.21.2") ? Attribute.LUCK : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.luck"));
+    public static final Attribute MAX_ABSORPTION = VersionUtil.atOrAbove("1.21.2") ? Attribute.MAX_ABSORPTION : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.max_absorption"));
     public static final Attribute MAX_HEALTH = VersionUtil.atOrAbove("1.21.2") ? Attribute.MAX_HEALTH : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.max_health"));
+    public static final Attribute MINING_EFFICIENCY = VersionUtil.atOrAbove("1.21.2") ? Attribute.MINING_EFFICIENCY : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.mining_efficiency"));
+    public static final Attribute MOVEMENT_EFFICIENCY = VersionUtil.atOrAbove("1.21.2") ? Attribute.MOVEMENT_EFFICIENCY : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.movement_efficiency"));
+    public static final Attribute MOVEMENT_SPEED = VersionUtil.atOrAbove("1.21.2") ? Attribute.MOVEMENT_SPEED : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.movement_speed"));
+    public static final Attribute OXYGEN_BONUS = VersionUtil.atOrAbove("1.21.2") ? Attribute.OXYGEN_BONUS : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.oxygen_bonus"));
+    public static final Attribute SAFE_FALL_DISTANCE = VersionUtil.atOrAbove("1.21.2") ? Attribute.SAFE_FALL_DISTANCE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.safe_fall_distance"));
+    public static final Attribute SCALE = VersionUtil.atOrAbove("1.21.2") ? Attribute.SCALE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.scale"));
+    public static final Attribute SNEAKING_SPEED = VersionUtil.atOrAbove("1.21.2") ? Attribute.SNEAKING_SPEED : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.sneaking_speed"));
+    public static final Attribute SPAWN_REINFORCEMENTS = VersionUtil.atOrAbove("1.21.2") ? Attribute.SPAWN_REINFORCEMENTS : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.spawn_reinforcements"));
+    public static final Attribute STEP_HEIGHT = VersionUtil.atOrAbove("1.21.2") ? Attribute.STEP_HEIGHT : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.step_height"));
+    public static final Attribute SUBMERGED_MINING_SPEED = VersionUtil.atOrAbove("1.21.2") ? Attribute.SUBMERGED_MINING_SPEED : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.submerged_mining_speed"));
+    public static final Attribute SWEEPING_DAMAGE_RATIO = VersionUtil.atOrAbove("1.21.2") ? Attribute.SWEEPING_DAMAGE_RATIO : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.sweeping_damage_ratio"));
+    public static final Attribute TEMPT_RANGE = VersionUtil.atOrAbove("1.21.2") ? Attribute.TEMPT_RANGE : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic.tempt_range"));
 
     @Nullable
     public static Attribute fromString(@NotNull String attribute) {
-        return Registry.ATTRIBUTE.get(NamespacedKey.fromString(attribute.toLowerCase(Locale.ENGLISH)));
+        String attributeName = attribute.replace("GENERIC_", "").toLowerCase(Locale.ENGLISH);
+
+        return VersionUtil.atOrAbove("1.21.2") ? Registry.ATTRIBUTE.get(NamespacedKey.fromString(attributeName)) : Registry.ATTRIBUTE.get(NamespacedKey.fromString("generic." + attributeName));
     }
 }

--- a/core/src/main/resources/items/armors.yml
+++ b/core/src/main/resources/items/armors.yml
@@ -23,10 +23,10 @@ emerald_helmet:
     # - attribute: Get the list here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html
     # - operations: 0 for ADD_NUMBER, 1 for ADD_SCALAR, 2 for MULTIPLY_SCALAR_1;
     # - slot: HAND, OFF_HAND, FEET, LEGS, CHEST or HEAD
-    - { attribute: GENERIC_MAX_HEALTH, amount: 2, operation: 0, slot: HEAD }
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: MAX_HEALTH, amount: 2, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: HEAD }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: HEAD,
@@ -51,10 +51,10 @@ emerald_chestplate:
       slot: CHEST
       model: oraxen:emerald
   AttributeModifiers:
-    - { attribute: GENERIC_MAX_HEALTH, amount: 3, operation: 0, slot: CHEST }
-    - { attribute: GENERIC_ARMOR, amount: 8, operation: 0, slot: CHEST }
+    - { attribute: MAX_HEALTH, amount: 3, operation: 0, slot: CHEST }
+    - { attribute: ARMOR, amount: 8, operation: 0, slot: CHEST }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: CHEST,
@@ -79,10 +79,10 @@ emerald_leggings:
       slot: LEGS
       model: oraxen:emerald
   AttributeModifiers:
-    - { attribute: GENERIC_MAX_HEALTH, amount: 3, operation: 0, slot: LEGS }
-    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0, slot: LEGS }
+    - { attribute: MAX_HEALTH, amount: 3, operation: 0, slot: LEGS }
+    - { attribute: ARMOR, amount: 6, operation: 0, slot: LEGS }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: LEGS,
@@ -107,10 +107,10 @@ emerald_boots:
       slot: FEET
       model: oraxen:emerald
   AttributeModifiers:
-    - { attribute: GENERIC_MAX_HEALTH, amount: 2, operation: 0, slot: FEET }
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: FEET }
+    - { attribute: MAX_HEALTH, amount: 2, operation: 0, slot: FEET }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: FEET }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: FEET,
@@ -135,7 +135,7 @@ obsidian_helmet:
       slot: HEAD
       model: oraxen:obsidian
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 2, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -157,7 +157,7 @@ obsidian_chestplate:
       slot: CHEST
       model: oraxen:obsidian
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0, slot: CHEST }
+    - { attribute: ARMOR, amount: 6, operation: 0, slot: CHEST }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -178,7 +178,7 @@ obsidian_leggings:
       slot: LEGS
       model: oraxen:obsidian
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 5, operation: 0, slot: LEGS }
+    - { attribute: ARMOR, amount: 5, operation: 0, slot: LEGS }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -199,7 +199,7 @@ obsidian_boots:
       slot: FEET
       model: oraxen:obsidian
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 2, operation: 0, slot: FEET }
+    - { attribute: ARMOR, amount: 2, operation: 0, slot: FEET }
   Pack:
     generate_model: true
     parent_model: "item/generated"
@@ -218,9 +218,9 @@ ruby_helmet:
       slot: HEAD
       model: oraxen:ruby
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: HEAD }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: HEAD,
@@ -243,9 +243,9 @@ ruby_chestplate:
       slot: CHEST
       model: oraxen:ruby
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 8, operation: 0, slot: CHEST }
+    - { attribute: ARMOR, amount: 8, operation: 0, slot: CHEST }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: CHEST,
@@ -268,9 +268,9 @@ ruby_leggings:
       slot: LEGS
       model: oraxen:ruby
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 6, operation: 0, slot: LEGS }
+    - { attribute: ARMOR, amount: 6, operation: 0, slot: LEGS }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: LEGS,
@@ -293,9 +293,9 @@ ruby_boots:
       slot: FEET
       model: oraxen:ruby
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: FEET }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: FEET }
     - {
-        attribute: GENERIC_ARMOR_TOUGHNESS,
+        attribute: ARMOR_TOUGHNESS,
         amount: 2,
         operation: 0,
         slot: FEET,

--- a/core/src/main/resources/items/hats.yml
+++ b/core/src/main/resources/items/hats.yml
@@ -11,8 +11,8 @@ anubis_head:
   lore:
     - "<#6f737d>» <#D5D6D8>NightVision when worn"
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: false
     model: default/anubis_head # .json extension is not mandatory
@@ -32,8 +32,8 @@ crown:
   displayname: "<gradient:#F06966:#FAD6A6>Crown"
   material: PAPER
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: false
     model: default/crown
@@ -45,8 +45,8 @@ pharaoh_head:
   displayname: "<gradient:#F06966:#FAD6A6>Pharaoh Head"
   material: PAPER
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: false
     model: default/pharaoh_head
@@ -58,8 +58,8 @@ witch_hat:
   displayname: "<gradient:#DF98FA:#9055FF>Witch Hat"
   material: PAPER
   AttributeModifiers:
-    - { attribute: GENERIC_ARMOR, amount: 3, operation: 0, slot: HEAD }
-    - { attribute: GENERIC_ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
+    - { attribute: ARMOR, amount: 3, operation: 0, slot: HEAD }
+    - { attribute: ARMOR_TOUGHNESS, amount: 2, operation: 0, slot: HEAD }
   Pack:
     generate_model: false
     model: default/witch_hat

--- a/core/src/main/resources/items/items.yml
+++ b/core/src/main/resources/items/items.yml
@@ -27,7 +27,7 @@ example_sword:
     # - generate one here: https://www.uuidgenerator.net/
     # - slot: HAND, OFF_HAND, FEET, LEGS, CHEST or HEAD
     - {
-        attribute: GENERIC_MOVEMENT_SPEED,
+        attribute: MOVEMENT_SPEED,
         amount: 0.1,
         operation: 0,
         slot: HAND,

--- a/core/src/main/resources/items/mystical.yml
+++ b/core/src/main/resources/items/mystical.yml
@@ -67,7 +67,7 @@ battle_axe:
   displayname: '<gradient:#F06966:#FAD6A6>Battle Axe'
   material: DIAMOND_AXE
   AttributeModifiers:
-    - attribute: GENERIC_ATTACK_DAMAGE
+    - attribute: ATTACK_DAMAGE
       amount: 7
       operation: 0
       slot: HAND

--- a/core/src/main/resources/items/weapons.yml
+++ b/core/src/main/resources/items/weapons.yml
@@ -10,9 +10,9 @@ storm_sword:
   material: DIAMOND_SWORD
   AttributeModifiers:
     # diamond sword has an attack damage of 7
-    - { attribute: GENERIC_ATTACK_DAMAGE, amount: 10, operation: 0, slot: HAND }
+    - { attribute: ATTACK_DAMAGE, amount: 10, operation: 0, slot: HAND }
     # it has two times more full-strength attacks per second than diamond sword
-    - { attribute: GENERIC_ATTACK_SPEED, amount: 3.2, operation: 0, slot: HAND }
+    - { attribute: ATTACK_SPEED, amount: 3.2, operation: 0, slot: HAND }
   lore:
     - "<#6f737d>» <#D5D6D8>Right click to strike lightning"
   Pack:
@@ -29,9 +29,9 @@ energy_crystal_sword:
   material: DIAMOND_SWORD
   AttributeModifiers:
     # diamond sword has an attack damage of 7
-    - { attribute: GENERIC_ATTACK_DAMAGE, amount: 10, operation: 0, slot: HAND }
+    - { attribute: ATTACK_DAMAGE, amount: 10, operation: 0, slot: HAND }
     # it has as much full-strength attacks per second than diamond sword
-    - { attribute: GENERIC_ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
+    - { attribute: ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
   Pack:
     generate_model: false
     model: default/energy_crystal_sword
@@ -43,9 +43,9 @@ glass_sword:
     - "<#6f737d>» <#D5D6D8>Fragile"
   AttributeModifiers:
     # diamond sword has an attack damage of 7
-    - { attribute: GENERIC_ATTACK_DAMAGE, amount: 10, operation: 0, slot: HAND }
+    - { attribute: ATTACK_DAMAGE, amount: 10, operation: 0, slot: HAND }
     # it has as 5 full-strength attacks per second
-    - { attribute: GENERIC_ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
+    - { attribute: ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
   Pack:
     generate_model: true
     parent_model: "item/handheld"
@@ -62,9 +62,9 @@ obsidian_sword:
     - "<#6f737d>» <#D5D6D8>Ludicrous durability"
   AttributeModifiers:
     # diamond sword has an attack damage of 7
-    - { attribute: GENERIC_ATTACK_DAMAGE, amount: 6, operation: 0, slot: HAND }
+    - { attribute: ATTACK_DAMAGE, amount: 6, operation: 0, slot: HAND }
     # it has as 5 full-strength attacks per second
-    - { attribute: GENERIC_ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
+    - { attribute: ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
   Pack:
     generate_model: true
     parent_model: "item/handheld"
@@ -81,9 +81,9 @@ blood_sword:
     - "<#6f737d>» <#D5D6D8>Steal the life of your enemies"
   AttributeModifiers:
     # diamond sword has an attack damage of 7
-    - { attribute: GENERIC_ATTACK_DAMAGE, amount: 8, operation: 0, slot: HAND }
+    - { attribute: ATTACK_DAMAGE, amount: 8, operation: 0, slot: HAND }
     # it has as much full-strength attacks per second than diamond sword
-    - { attribute: GENERIC_ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
+    - { attribute: ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
   Pack:
     generate_model: false
     model: default/blood_sword
@@ -118,9 +118,9 @@ katana:
   material: DIAMOND_SWORD
   AttributeModifiers:
     # diamond sword has an attack damage of 7
-    - { attribute: GENERIC_ATTACK_DAMAGE, amount: 5, operation: 0, slot: HAND }
+    - { attribute: ATTACK_DAMAGE, amount: 5, operation: 0, slot: HAND }
     # it has as 5 full-strength attacks per second
-    - { attribute: GENERIC_ATTACK_SPEED, amount: 5, operation: 0, slot: HAND }
+    - { attribute: ATTACK_SPEED, amount: 5, operation: 0, slot: HAND }
   Pack:
     generate_model: false
     model: default/katana
@@ -132,7 +132,7 @@ combat_bow:
   displayname: '<gradient:#F69D84:#FAD98D>Combat Bow'
   material: BOW
   AttributeModifiers:
-    - attribute: GENERIC_ATTACK_DAMAGE
+    - attribute: ATTACK_DAMAGE
       amount: 7
       operation: 0
       slot: HAND


### PR DESCRIPTION
- Improve performance of server software check (from @Euphillya)  
- Fix attribute modifiers  (from @KamillPlayZ )
- Refactor item handling to align with the data component format  
- Remove several legacy components:  
  - `max_stack_size`: Previously set a custom stack size (now managed by data components).  
  - `enchantment_glint_override`: Allowed overriding the enchantment glint effect (now handled via enchantment logic).  
  - `rarity`: Defined item rarity (redundant with in-game mechanics).  
  - `damage_resistant`: Set damage resistance (now configurable using tags).  
  - `enchantable`: Controlled enchantability (now handled natively).  
  - `glider`: Previously enabled gliding behavior (moved to a dedicated mechanic).  


to do in next pr:
- Follow conventions for equippable components
- Replace food components by a mechanic?
- Remove components that exist in gamepedia
- add more examples using components (and also saplings?)