### PR TITLE
Fix Music Disc stuff

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.*;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.storage.StorageMechanic.PERSONAL_STORAGE_KEY;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.storage.StorageMechanic.STORAGE_KEY;
-import static io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscListener.MUSIC_DISC_KEY;
+import static io.th0rgal.oraxen.utils.MusicDiscHelpers.MUSIC_DISC_KEY;
 
 public class OraxenFurniture {
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxBlock.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxBlock.java
@@ -1,17 +1,11 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox;
 
-import com.jeff_media.morepersistentdatatypes.DataType;
-import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
-import io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscMechanic;
+import io.th0rgal.oraxen.utils.MusicDiscHelpers;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.Locale;
-
-import static io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscListener.MUSIC_DISC_KEY;
 
 public class JukeboxBlock {
 
@@ -30,15 +24,8 @@ public class JukeboxBlock {
     }
 
     public String getPlayingSong(Entity baseEntity) {
-        ItemStack disc = baseEntity.getPersistentDataContainer().get(MUSIC_DISC_KEY, DataType.ITEM_STACK);
-        if (disc == null)
-            return null;
-        MusicDiscMechanic mechanic = (MusicDiscMechanic) factory.getMechanic(OraxenItems.getIdByItem(disc));
-        return (mechanic != null && !mechanic.hasNoSong()) ? mechanic.getSong()
-                : disc.getType().isRecord()
-                        ? disc.getType().toString().toLowerCase(Locale.ROOT).replace("music_disc_",
-                                "minecraft:music_disc.")
-                        : null;
+        ItemStack disc = MusicDiscHelpers.getMusicDisc(baseEntity.getPersistentDataContainer());
+        return MusicDiscHelpers.getSong(disc, factory);
     }
 
     public String getPermission() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
@@ -118,7 +118,7 @@ public class JukeboxListener implements Listener {
         JukeboxBlock jukebox = furnitureMechanic.getJukebox();
         if (!jukebox.hasPermission(player))
             return false;
-        var item = MusicDiscHelpers.stopJukeboxAt(baseEntity);
+        var item = MusicDiscHelpers.stopJukeboxAt(baseEntity, jukebox.getVolume(), jukebox.getPitch());
         if(item == null) return false;
         baseEntity.getWorld().dropItemNaturally(baseEntity.getLocation().toCenterLocation(), item);
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/jukebox/JukeboxListener.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox;
 
-import com.jeff_media.morepersistentdatatypes.DataType;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.api.OraxenItems;
@@ -11,16 +10,12 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import io.th0rgal.oraxen.utils.ItemUtils;
-import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.MusicDiscHelpers;
-import net.kyori.adventure.key.Key;
-import net.kyori.adventure.sound.Sound;
-import net.kyori.adventure.sound.SoundStop;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.SoundCategory;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -32,8 +27,6 @@ import org.bukkit.persistence.PersistentDataContainer;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
-
-import static io.th0rgal.oraxen.utils.MusicDiscHelpers.MUSIC_DISC_KEY;
 
 public class JukeboxListener implements Listener {
 
@@ -107,7 +100,7 @@ public class JukeboxListener implements Listener {
         insertedDisc.setAmount(1);
         if (player != null && player.getGameMode() != GameMode.CREATIVE)
             disc.setAmount(disc.getAmount() - insertedDisc.getAmount());
-        MusicDiscHelpers.setAndPlayMusicDisc(baseEntity, insertedDisc, SoundCategory.RECORDS, jukebox.getVolume(), jukebox.getPitch());
+        MusicDiscHelpers.setAndPlayMusicDisc(baseEntity, insertedDisc, jukebox.getVolume(), jukebox.getPitch());
 
         if (jukebox.active_stage != null) {
             FurnitureMechanic.setFurnitureItem(baseEntity, OraxenItems.getItemById(jukebox.active_stage).build());
@@ -118,38 +111,22 @@ public class JukeboxListener implements Listener {
 
     private boolean ejectAndStopDisc(Entity baseEntity, @Nullable Player player) {
         PersistentDataContainer pdc = baseEntity.getPersistentDataContainer();
-        ItemStack item = pdc.get(MUSIC_DISC_KEY, DataType.ITEM_STACK);
         FurnitureMechanic furnitureMechanic = OraxenFurniture.getFurnitureMechanic(baseEntity);
-        Location loc = BlockHelpers.toCenterLocation(baseEntity.getLocation());
 
         if (furnitureMechanic == null || !furnitureMechanic.isJukebox())
             return false;
-        if (!pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK) || !ItemUtils.isMusicDisc(item))
-            return false;
-
         JukeboxBlock jukebox = furnitureMechanic.getJukebox();
         if (!jukebox.hasPermission(player))
             return false;
-
-        baseEntity.getWorld().getNearbyEntities(loc, 32, 32, 32).stream()
-            .filter(entity -> entity instanceof Player)
-            .map(entity -> (Player) entity)
-            .forEach(p -> {
-                Key songKey = getSongFromDisc(item);
-                if (songKey == null)
-                    return;
-                OraxenPlugin.get().getAudience().player(p).stopSound(
-                    SoundStop.namedOnSource(songKey, Sound.Source.RECORD));
-            });
-        baseEntity.getWorld().dropItemNaturally(loc, item);
+        var item = MusicDiscHelpers.stopJukeboxAt(baseEntity);
+        if(item == null) return false;
+        baseEntity.getWorld().dropItemNaturally(baseEntity.getLocation().toCenterLocation(), item);
 
         // if the active stage was not null we need to reset it because it changed
         if (jukebox.active_stage != null) {
             FurnitureMechanic.setFurnitureItem(baseEntity,
                 OraxenItems.getItemById(furnitureMechanic.getItemID()).build());
         }
-
-        pdc.remove(MUSIC_DISC_KEY);
         return true;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -1,7 +1,7 @@
 package io.th0rgal.oraxen.nms;
 
 import io.th0rgal.oraxen.items.ItemBuilder;
-import org.bukkit.World;
+import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -44,7 +44,9 @@ public interface NMSHandler {
     @Nullable
     BlockData correctBlockStates(Player player, EquipmentSlot slot, ItemStack itemStack);
 
-    /** Removes mineable/axe tag from noteblocks for custom blocks */
+    /**
+     * Removes mineable/axe tag from noteblocks for custom blocks
+     */
     void customBlockDefaultTools(Player player);
 
     default void foodComponent(ItemBuilder itemBuilder, ConfigurationSection foodSection) {
@@ -63,19 +65,25 @@ public interface NMSHandler {
 
     }
 
+    default boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+        return false;
+    }
+
+    default void stopJukeBox(Location location) {
+    }
     /**
      * Keys that are used by vanilla Minecraft and should therefore be skipped
      * Some are accessed through API methods, others are just used internally
      */
     Set<String> vanillaKeys = Set.of("PublicBukkitValues", "display", "CustomModelData", "Damage", "AttributeModifiers",
-            "Unbreakable", "CanDestroy", "slot", "count", "HideFlags", "CanPlaceOn", "Enchantments",
-            "StoredEnchantments",
-            "RepairCost", "CustomPotionEffects", "Potion", "CustomPotionColor", "Trim", "EntityTag",
-            "pages", "filtered_pages", "filtered_title", "resolved", "generation", "author", "title",
-            "BucketVariantTag", "Items", "LodestoneTracked", "LodestoneDimension", "LodestonePos",
-            "ChargedProjectiles", "Charged", "DebugProperty", "Fireworks", "Explosion", "Flight",
-            "map", "map_scale_direction", "map_to_lock", "Decorations", "SkullOwner", "Effects", "BlockEntityTag",
-            "BlockStateTag");
+        "Unbreakable", "CanDestroy", "slot", "count", "HideFlags", "CanPlaceOn", "Enchantments",
+        "StoredEnchantments",
+        "RepairCost", "CustomPotionEffects", "Potion", "CustomPotionColor", "Trim", "EntityTag",
+        "pages", "filtered_pages", "filtered_title", "resolved", "generation", "author", "title",
+        "BucketVariantTag", "Items", "LodestoneTracked", "LodestoneDimension", "LodestonePos",
+        "ChargedProjectiles", "Charged", "DebugProperty", "Fireworks", "Explosion", "Flight",
+        "map", "map_scale_direction", "map_to_lock", "Decorations", "SkullOwner", "Effects", "BlockEntityTag",
+        "BlockStateTag");
 
     default boolean getSupported() {
         return false;
@@ -83,7 +91,7 @@ public interface NMSHandler {
 
     /**
      * Sets a component on an item using the DataComponents registry
-     * 
+     *
      * @param item         The ItemBuilder to modify
      * @param componentKey The component key (e.g. "food", "tool", etc.)
      * @param component    The component data
@@ -145,6 +153,15 @@ public interface NMSHandler {
         @Override
         public boolean setComponent(ItemBuilder item, String componentKey, Object component) {
             return false;
+        }
+
+        @Override
+        public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+            return false;
+        }
+
+        @Override
+        public void stopJukeBox(Location location) {
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -65,8 +65,10 @@ public interface NMSHandler {
 
     }
 
-    default boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+    default boolean supportsJukeboxPlaying() {
         return false;
+    }
+    default void playJukeBoxSong(Location location, ItemStack itemStack) {
     }
 
     default void stopJukeBox(Location location) {
@@ -153,15 +155,6 @@ public interface NMSHandler {
         @Override
         public boolean setComponent(ItemBuilder item, String componentKey, Object component) {
             return false;
-        }
-
-        @Override
-        public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
-            return false;
-        }
-
-        @Override
-        public void stopJukeBox(Location location) {
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandlers.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
@@ -15,13 +16,13 @@ public class NMSHandlers {
     private static NMSHandler handler;
     private static String version;
 
-    @Nullable
+    @NotNull
     public static NMSHandler getHandler() {
         if (handler != null)
             return handler;
         else {
             setup();
-            if (handler == null && Settings.DEBUG.toBool()) {
+            if (handler instanceof NMSHandler.EmptyNMSHandler && Settings.DEBUG.toBool()) {
                 Logs.logError("Failed to setup NMS handler for server version: " + Bukkit.getVersion());
                 Logs.logError("Supported versions: " + java.util.Arrays.toString(SUPPORTED_VERSION));
                 Logs.logError("Current server implements Paper: " + VersionUtil.isPaperServer());
@@ -58,6 +59,9 @@ public class NMSHandlers {
                 if (Settings.DEBUG.toBool())
                     e.printStackTrace();
             }
+        }
+        if(handler == null) {
+            handler = new NMSHandler.EmptyNMSHandler();
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/BlockHelpers.java
@@ -184,6 +184,14 @@ public class BlockHelpers {
         };
     }
 
+    public static BlockState getState(Block block) {
+        if(VersionUtil.isPaperServer()) {
+            return block.getState(false);
+        } else {
+            return block.getState();
+        }
+    }
+
     public enum BlockCorrection {
         NMS, LEGACY;
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ItemUtils.java
@@ -1,7 +1,6 @@
 package io.th0rgal.oraxen.utils;
 
 import io.th0rgal.oraxen.utils.drops.Drop;
-import io.th0rgal.oraxen.utils.logs.Logs;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -125,13 +124,17 @@ public class ItemUtils {
     }
 
     public static boolean isMusicDisc(ItemStack itemStack) {
-        if (itemStack == null)
-            return false;
+        if (isInvalidItem(itemStack)) return false;
         // native disks don't seem to have jukebox playable set to true
         if (VersionUtil.atOrAbove("1.21") && itemStack.hasItemMeta() && itemStack.getItemMeta().hasJukeboxPlayable()) {
             return true;
+        } else {
+            return itemStack.getType().isRecord();
         }
-        return itemStack.getType().name().startsWith("MUSIC_DISC");
+    }
+
+    public static boolean isInvalidItem(ItemStack itemStack) {
+        return itemStack == null || itemStack.getType().isAir() || itemStack.getAmount() == 0;
     }
 
     @Nullable

--- a/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
@@ -1,0 +1,94 @@
+package io.th0rgal.oraxen.utils;
+
+import com.jeff_media.morepersistentdatatypes.DataType;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.mechanics.Mechanic;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscMechanic;
+import net.kyori.adventure.key.Key;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.SoundCategory;
+import org.bukkit.block.Block;
+import org.bukkit.block.Jukebox;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+
+public class MusicDiscHelpers {
+    public static final NamespacedKey MUSIC_DISC_KEY = new NamespacedKey(OraxenPlugin.get(), "music_disc");
+
+    public static boolean hasMusicDisc(PersistentDataContainer pdc) {
+        return pdc.has(MUSIC_DISC_KEY, DataType.ITEM_STACK);
+    }
+
+    public static ItemStack getMusicDisc(PersistentDataContainer pdc) {
+        try {
+            return pdc.get(MUSIC_DISC_KEY, DataType.ITEM_STACK);
+        } catch (Exception e) {
+            // music disc is saved as an older format, that is no longer supported.
+            // TODO: maybe try recovering from the old format
+            // possible causes item was saved on paper pre 1.21.5 and now its 1.21.5 or later
+            // or it was saved on spigot and now loaded on paper.
+            return null;
+        }
+    }
+
+    public static void setAndPlayMusicDisc(Entity entity, ItemStack record, SoundCategory soundCategory, float volume, float pitch) {
+        var pdc = entity.getPersistentDataContainer();
+        var song = MusicDiscHelpers.getSong(record);
+        if (song == null) return;
+        Key songKey = Key.key(song);
+        String soundId = OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey);
+
+        entity.getWorld().playSound(entity, soundId, soundCategory, volume, pitch);
+        pdc.set(MUSIC_DISC_KEY, DataType.ITEM_STACK, record);
+    }
+
+    public static boolean isVanillaJukeboxWithVanillaDisc(Block block) {
+        if (!block.getType().equals(Material.JUKEBOX)) return false;
+        var blockState = BlockHelpers.getState(block);
+        if (blockState instanceof Jukebox jukebox) {
+            return ItemUtils.isMusicDisc(jukebox.getRecord());
+        }
+        return false;
+    }
+
+    @Nullable
+    public static String getSong(ItemStack record, MechanicFactory factory) {
+        if (ItemUtils.isInvalidItem(record)) return null;
+
+        var song = getSong(record);
+        if (song != null) return song;
+
+        String itemID = OraxenItems.getIdByItem(record);
+        Mechanic mechanic = factory.getMechanic(itemID);
+        if (mechanic instanceof MusicDiscMechanic musicDiscMechanic && !musicDiscMechanic.hasNoSong()) {
+            return musicDiscMechanic.getSong();
+        }
+        return null;
+    }
+
+    /**
+     * Gets the vanilla song from the ItemStack
+     *
+     * @param record the record who could hold a song
+     * @return the song from the playable component or record
+     */
+    @Nullable
+    public static String getSong(ItemStack record) {
+        if (ItemUtils.isInvalidItem(record)) return null;
+        // native disks don't seem to have jukebox playable set to true
+        if (VersionUtil.atOrAbove("1.21") && record.hasItemMeta() && record.getItemMeta().hasJukeboxPlayable()) {
+            return record.getItemMeta().getJukeboxPlayable().getSongKey().toString();
+        } else if (record.getType().isRecord()) {
+            return record.getType().toString().toLowerCase(Locale.ROOT)
+                .replaceFirst("music_disc_", "minecraft:music_disc.");
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
@@ -45,8 +45,8 @@ public class MusicDiscHelpers {
 
     public static void setAndPlayMusicDisc(Entity entity, ItemStack record, float volume, float pitch) {
         var pdc = entity.getPersistentDataContainer();
-        if (ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F && NMSHandlers.getHandler().playJukeBoxSong(entity.getLocation(), record)) {
-            // running via the playJukeBoxSong
+        if (ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F) {
+            NMSHandlers.getHandler().playJukeBoxSong(entity.getLocation(), record);
         } else {
             var song = MusicDiscHelpers.getSong(record);
             if (song == null) return;
@@ -58,23 +58,23 @@ public class MusicDiscHelpers {
         pdc.set(MUSIC_DISC_KEY, DataType.ITEM_STACK, record);
     }
 
-    public static ItemStack stopJukeboxAt(Entity entity) {
+    public static ItemStack stopJukeboxAt(Entity entity, float volume, float pitch) {
         var pdc = entity.getPersistentDataContainer();
         ItemStack record = getMusicDisc(pdc);
         if(record == null) return null;
         pdc.remove(MUSIC_DISC_KEY);
-        if(ItemUtils.isMusicDisc(record)) {
+        if(ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F) {
             NMSHandlers.getHandler().stopJukeBox(entity.getLocation());
-        }
-        var song = MusicDiscHelpers.getSong(record);
-        if (song == null) return record;
-        Key songKey = Key.key(song);
-        Key soundId = Key.key(OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey));
+        } else {
+            var song = MusicDiscHelpers.getSong(record);
+            if (song == null) return record;
+            Key songKey = Key.key(song);
+            Key soundId = Key.key(OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey));
 
-        entity.getWorld().getNearbyEntities(entity.getLocation(), 64, 64, 64, e -> e instanceof Player)
-            .stream().map(Player.class::cast)
-            .forEach(player -> player.stopSound(SoundStop.namedOnSource(soundId, Sound.Source.RECORD)));
-        pdc.remove(MUSIC_DISC_KEY);
+            entity.getWorld().getNearbyEntities(entity.getLocation(), 64, 64, 64, e -> e instanceof Player)
+                .stream().map(Player.class::cast)
+                .forEach(player -> player.stopSound(SoundStop.namedOnSource(soundId, Sound.Source.RECORD)));
+        }
         return record;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
@@ -45,7 +45,7 @@ public class MusicDiscHelpers {
 
     public static void setAndPlayMusicDisc(Entity entity, ItemStack record, float volume, float pitch) {
         var pdc = entity.getPersistentDataContainer();
-        if (ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F) {
+        if (ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F && NMSHandlers.getHandler().supportsJukeboxPlaying()) {
             NMSHandlers.getHandler().playJukeBoxSong(entity.getLocation(), record);
         } else {
             var song = MusicDiscHelpers.getSong(record);
@@ -63,7 +63,7 @@ public class MusicDiscHelpers {
         ItemStack record = getMusicDisc(pdc);
         if(record == null) return null;
         pdc.remove(MUSIC_DISC_KEY);
-        if(ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F) {
+        if(ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F && NMSHandlers.getHandler().supportsJukeboxPlaying()) {
             NMSHandlers.getHandler().stopJukeBox(entity.getLocation());
         } else {
             var song = MusicDiscHelpers.getSong(record);

--- a/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/MusicDiscHelpers.java
@@ -6,18 +6,22 @@ import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscMechanic;
+import io.th0rgal.oraxen.nms.NMSHandlers;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.sound.SoundStop;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.SoundCategory;
 import org.bukkit.block.Block;
 import org.bukkit.block.Jukebox;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
+import java.util.logging.Level;
 
 public class MusicDiscHelpers {
     public static final NamespacedKey MUSIC_DISC_KEY = new NamespacedKey(OraxenPlugin.get(), "music_disc");
@@ -34,19 +38,44 @@ public class MusicDiscHelpers {
             // TODO: maybe try recovering from the old format
             // possible causes item was saved on paper pre 1.21.5 and now its 1.21.5 or later
             // or it was saved on spigot and now loaded on paper.
+            OraxenPlugin.get().getLogger().log(Level.SEVERE, "Failed to read Music disc from pdc! " + pdc.toString(), e);
             return null;
         }
     }
 
-    public static void setAndPlayMusicDisc(Entity entity, ItemStack record, SoundCategory soundCategory, float volume, float pitch) {
+    public static void setAndPlayMusicDisc(Entity entity, ItemStack record, float volume, float pitch) {
         var pdc = entity.getPersistentDataContainer();
-        var song = MusicDiscHelpers.getSong(record);
-        if (song == null) return;
-        Key songKey = Key.key(song);
-        String soundId = OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey);
+        if (ItemUtils.isMusicDisc(record) && volume == 1F && pitch == 1F && NMSHandlers.getHandler().playJukeBoxSong(entity.getLocation(), record)) {
+            // running via the playJukeBoxSong
+        } else {
+            var song = MusicDiscHelpers.getSong(record);
+            if (song == null) return;
+            Key songKey = Key.key(song);
+            Key soundId = Key.key(OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey));
 
-        entity.getWorld().playSound(entity, soundId, soundCategory, volume, pitch);
+            entity.getWorld().playSound(Sound.sound(soundId, Sound.Source.RECORD, volume, pitch));
+        }
         pdc.set(MUSIC_DISC_KEY, DataType.ITEM_STACK, record);
+    }
+
+    public static ItemStack stopJukeboxAt(Entity entity) {
+        var pdc = entity.getPersistentDataContainer();
+        ItemStack record = getMusicDisc(pdc);
+        if(record == null) return null;
+        pdc.remove(MUSIC_DISC_KEY);
+        if(ItemUtils.isMusicDisc(record)) {
+            NMSHandlers.getHandler().stopJukeBox(entity.getLocation());
+        }
+        var song = MusicDiscHelpers.getSong(record);
+        if (song == null) return record;
+        Key songKey = Key.key(song);
+        Key soundId = Key.key(OraxenPlugin.get().getSoundManager().songKeyToSoundId(songKey));
+
+        entity.getWorld().getNearbyEntities(entity.getLocation(), 64, 64, 64, e -> e instanceof Player)
+            .stream().map(Player.class::cast)
+            .forEach(player -> player.stopSound(SoundStop.namedOnSource(soundId, Sound.Source.RECORD)));
+        pdc.remove(MUSIC_DISC_KEY);
+        return record;
     }
 
     public static boolean isVanillaJukeboxWithVanillaDisc(Block block) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.192.0
+pluginVersion=1.192.1

--- a/v1_21_R2/src/main/java/io/th0rgal/oraxen/nms/v1_21_R2/NMSHandler.java
+++ b/v1_21_R2/src/main/java/io/th0rgal/oraxen/nms/v1_21_R2/NMSHandler.java
@@ -27,6 +27,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -37,6 +38,7 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemUseAnimation;
+import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.item.component.Consumable;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.consume_effects.*;
@@ -45,9 +47,11 @@ import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.EnumUtils;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.SoundCategory;
 import org.bukkit.SoundGroup;
@@ -55,6 +59,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
@@ -85,23 +90,23 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (ChannelInitializeListenerHolder.hasListener(tagKey))
             return;
         ChannelInitializeListenerHolder.addListener(tagKey, (channel -> channel.pipeline().addBefore("packet_handler",
-                tagKey.asString(), new ChannelDuplexHandler() {
-                    Connection connection = (Connection) channel.pipeline().get("packet_handler");
-                    TagNetworkSerialization.NetworkPayload payload = createPayload();
+            tagKey.asString(), new ChannelDuplexHandler() {
+                Connection connection = (Connection) channel.pipeline().get("packet_handler");
+                TagNetworkSerialization.NetworkPayload payload = createPayload();
 
-                    @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                        if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
-                            Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = updateTagsPacket
-                                    .getTags();
-                            if (NoteBlockMechanicFactory.isEnabled()
-                                    && NoteBlockMechanicFactory.getInstance().removeMineableTag())
-                                tags.put(Registries.BLOCK, payload);
-                            msg = new ClientboundUpdateTagsPacket(tags);
-                        }
-                        ctx.write(msg, promise);
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                    if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
+                        Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = updateTagsPacket
+                            .getTags();
+                        if (NoteBlockMechanicFactory.isEnabled()
+                            && NoteBlockMechanicFactory.getInstance().removeMineableTag())
+                            tags.put(Registries.BLOCK, payload);
+                        msg = new ClientboundUpdateTagsPacket(tags);
                     }
-                })));
+                    ctx.write(msg, promise);
+                }
+            })));
     }
 
     @Override
@@ -168,7 +173,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         // Shulker-Boxes are DirectionalPlace based unlike other directional-blocks
         if (org.bukkit.Tag.SHULKER_BOXES.isTagged(itemStack.getType())) {
             placeContext = new DirectionalPlaceContext(serverPlayer.level(), hitResult.getBlockPos(),
-                    hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
+                hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
         }
 
         BlockPos pos = hitResult.getBlockPos();
@@ -185,15 +190,15 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             SoundGroup sound = block.getBlockData().getSoundGroup();
 
             world.playSound(
-                    BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
-                    SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
+                BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
+                SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
         }
 
         return world.getBlockAt(pos.getX(), pos.getY(), pos.getZ()).getBlockData();
     }
 
     public BlockHitResult getPlayerPOVHitResult(Level world, net.minecraft.world.entity.player.Player player,
-            ClipContext.Fluid fluidHandling) {
+                                                ClipContext.Fluid fluidHandling) {
         float f = player.getXRot();
         float g = player.getYRot();
         Vec3 vec3 = player.getEyePosition();
@@ -215,8 +220,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private TagNetworkSerialization.NetworkPayload createPayload() {
         Constructor<?> constructor = Arrays
-                .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
-                .orElse(null);
+            .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
+            .orElse(null);
         if (constructor == null)
             return null;
         constructor.setAccessible(true);
@@ -240,7 +245,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
      * .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
      * } else pair.getSecond().forEach(block ->
      * list.add(BuiltInRegistries.BLOCK.getId(block.value())));
-     * 
+     *
      * return Map.of(pair.getFirst().location(), list);
      * }).collect(HashMap::new, Map::putAll, Map::putAll);
      * }
@@ -253,25 +258,25 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     /**
      * Sets a component on an item using the DataComponents registry
-     * 
+     *
      * @param item         The ItemBuilder to modify
      * @param componentKey The component key (e.g. "food", "tool", etc.)
      * @param component    The component object or ConfigurationSection
      * @return true if the component was successfully set
      */
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public boolean setComponent(ItemBuilder item, String componentKey, Object component) {
         try {
             net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(new ItemStack(item.getType()));
             net.minecraft.resources.ResourceLocation componentLocation = net.minecraft.resources.ResourceLocation
-                    .tryParse("minecraft:" + componentKey.toLowerCase());
+                .tryParse("minecraft:" + componentKey.toLowerCase());
             if (componentLocation == null)
                 return false;
 
             net.minecraft.core.component.DataComponentType<?> componentType = net.minecraft.core.registries.BuiltInRegistries.DATA_COMPONENT_TYPE
-                    .getOptional(componentLocation)
-                    .orElse(null);
+                .getOptional(componentLocation)
+                .orElse(null);
             if (componentType == null)
                 return false;
 
@@ -295,7 +300,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                         }
                     } catch (Exception e) {
                         io.th0rgal.oraxen.utils.logs.Logs
-                                .logWarning("Failed to create default component for " + componentKey);
+                            .logWarning("Failed to create default component for " + componentKey);
                         return false;
                     }
                 }
@@ -303,7 +308,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                 // Apply NBT to component
                 try {
                     Method fromTag = defaultComponent.getClass().getMethod("fromTag",
-                            net.minecraft.nbt.CompoundTag.class);
+                        net.minecraft.nbt.CompoundTag.class);
                     fromTag.setAccessible(true);
                     Object parsedComponent = fromTag.invoke(defaultComponent, nbt);
 
@@ -316,7 +321,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                     return true;
                 } catch (Exception e) {
                     io.th0rgal.oraxen.utils.logs.Logs
-                            .logWarning("Failed to apply NBT data to component " + componentKey);
+                        .logWarning("Failed to apply NBT data to component " + componentKey);
                     if (io.th0rgal.oraxen.config.Settings.DEBUG.toBool())
                         e.printStackTrace();
                     return false;
@@ -407,16 +412,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         Consumable.Builder consumable = Consumable.builder();
         Consumable template = Optional.ofNullable(
                 CraftItemStack.asNMSCopy(new ItemStack(item.getType())).getComponents().get(DataComponents.CONSUMABLE))
-                .orElse(Consumable.builder().build());
+            .orElse(Consumable.builder().build());
 
         consumable.consumeSeconds((float) section.getDouble("consume_seconds", template.consumeSeconds()));
         consumable.animation(
-                Optional.ofNullable(EnumUtils.getEnum(ItemUseAnimation.class, section.getString("animation")))
-                        .orElse(template.animation()));
+            Optional.ofNullable(EnumUtils.getEnum(ItemUseAnimation.class, section.getString("animation")))
+                .orElse(template.animation()));
         consumable.hasConsumeParticles(section.getBoolean("consume_particles", template.hasConsumeParticles()));
         consumable.sound(Optional.ofNullable(section.getString("sound"))
-                .map(s -> Holder.direct(new SoundEvent(ResourceLocation.parse(s), Optional.empty())))
-                .orElse(template.sound()));
+            .map(s -> Holder.direct(new SoundEvent(ResourceLocation.parse(s), Optional.empty())))
+            .orElse(template.sound()));
 
         List<Map<?, ?>> effectsMap = section.getMapList("effects");
         if (effectsMap.isEmpty())
@@ -426,41 +431,41 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             for (Map<?, ?> effectSection : effectsMap) {
                 String type = Optional.ofNullable(effectSection.get("type")).map(Object::toString).orElse("");
                 if (type.equals("APPLY_EFFECTS")
-                        && effectSection.getOrDefault("effects", null) instanceof Map<?, ?> effects) {
+                    && effectSection.getOrDefault("effects", null) instanceof Map<?, ?> effects) {
                     for (Map.Entry<String, LinkedHashMap<String, Object>> effectMap : effects.entrySet().stream()
-                            .map(o -> (Map.Entry<String, LinkedHashMap<String, Object>>) o)
-                            .collect(Collectors.toSet())) {
+                        .map(o -> (Map.Entry<String, LinkedHashMap<String, Object>>) o)
+                        .collect(Collectors.toSet())) {
                         LinkedHashMap<String, Object> applyEffectSection = effectMap.getValue();
 
                         BuiltInRegistries.MOB_EFFECT.getOptional(ResourceLocation.parse(effectMap.getKey()))
-                                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
-                                .ifPresentOrElse(mobEffect -> {
-                                    int duration = Optional.ofNullable(applyEffectSection.get("duration"))
-                                            .map(s -> Integer.parseInt(s.toString())).orElse(1) * 20;
-                                    int amplifier = Optional.ofNullable(applyEffectSection.get("amplifier"))
-                                            .map(s -> Integer.parseInt(s.toString())).orElse(0);
-                                    boolean ambient = Optional.ofNullable(applyEffectSection.get("ambient"))
-                                            .map(s -> Boolean.parseBoolean(s.toString())).orElse(true);
-                                    boolean particles = Optional.ofNullable(applyEffectSection.get("show_particles"))
-                                            .map(s -> Boolean.parseBoolean(s.toString())).orElse(true);
-                                    boolean icon = Optional.ofNullable(applyEffectSection.get("show_icon"))
-                                            .map(s -> Boolean.parseBoolean(s.toString())).orElse(true);
-                                    float probability = Optional.ofNullable(applyEffectSection.get("amplifier"))
-                                            .map(s -> Float.parseFloat(s.toString())).orElse(0f);
-                                    MobEffectInstance instance = new MobEffectInstance(mobEffect, duration, amplifier,
-                                            ambient, particles, icon);
+                            .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+                            .ifPresentOrElse(mobEffect -> {
+                                int duration = Optional.ofNullable(applyEffectSection.get("duration"))
+                                    .map(s -> Integer.parseInt(s.toString())).orElse(1) * 20;
+                                int amplifier = Optional.ofNullable(applyEffectSection.get("amplifier"))
+                                    .map(s -> Integer.parseInt(s.toString())).orElse(0);
+                                boolean ambient = Optional.ofNullable(applyEffectSection.get("ambient"))
+                                    .map(s -> Boolean.parseBoolean(s.toString())).orElse(true);
+                                boolean particles = Optional.ofNullable(applyEffectSection.get("show_particles"))
+                                    .map(s -> Boolean.parseBoolean(s.toString())).orElse(true);
+                                boolean icon = Optional.ofNullable(applyEffectSection.get("show_icon"))
+                                    .map(s -> Boolean.parseBoolean(s.toString())).orElse(true);
+                                float probability = Optional.ofNullable(applyEffectSection.get("amplifier"))
+                                    .map(s -> Float.parseFloat(s.toString())).orElse(0f);
+                                MobEffectInstance instance = new MobEffectInstance(mobEffect, duration, amplifier,
+                                    ambient, particles, icon);
 
-                                    consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
-                                }, () -> Logs.logError(
-                                        "Invalid potion effect: " + effectMap.getKey() + ", in consumable-property!"));
+                                consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
+                            }, () -> Logs.logError(
+                                "Invalid potion effect: " + effectMap.getKey() + ", in consumable-property!"));
                     }
                 } else if (type.equals("REMOVE_EFFECTS")
-                        && effectSection.getOrDefault("effects", null) instanceof ArrayList<?> effects) {
+                    && effectSection.getOrDefault("effects", null) instanceof ArrayList<?> effects) {
                     List<Holder<MobEffect>> mobEffects = new ArrayList<>();
                     for (Object object : effects) {
                         BuiltInRegistries.MOB_EFFECT.getOptional(ResourceLocation.parse(String.valueOf(object)))
-                                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
-                                .ifPresent(mobEffects::add);
+                            .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+                            .ifPresent(mobEffects::add);
                     }
                     consumable.onConsume(new RemoveStatusEffectsConsumeEffect(HolderSet.direct(mobEffects)));
                 } else if (type.equals("CLEAR_ALL_EFFECTS")) {
@@ -471,12 +476,12 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                 } else if (type.equals("PLAY_SOUND")) {
                     try {
                         ResourceLocation soundKey = Optional.ofNullable(effectSection.get("sound"))
-                                .map(Objects::toString).map(ResourceLocation::parse)
-                                .orElse(template.sound().value().location());
+                            .map(Objects::toString).map(ResourceLocation::parse)
+                            .orElse(template.sound().value().location());
                         BuiltInRegistries.SOUND_EVENT.getOptional(soundKey)
-                                .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
-                                .map(PlaySoundConsumeEffect::new)
-                                .ifPresent(consumable::onConsume);
+                            .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
+                            .map(PlaySoundConsumeEffect::new)
+                            .ifPresent(consumable::onConsume);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -513,5 +518,22 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             e.printStackTrace();
         }
         return itemStack;
+    }
+
+    @Override
+    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+        Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
+        if (!optional.isPresent()) return false;
+        int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
+        level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
+        return true;
+    }
+
+    @Override
+    public void stopJukeBox(Location location) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        level.levelEvent(null, LevelEvent.SOUND_STOP_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), 0);
     }
 }

--- a/v1_21_R2/src/main/java/io/th0rgal/oraxen/nms/v1_21_R2/NMSHandler.java
+++ b/v1_21_R2/src/main/java/io/th0rgal/oraxen/nms/v1_21_R2/NMSHandler.java
@@ -521,14 +521,18 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     }
 
     @Override
-    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+    public boolean supportsJukeboxPlaying() {
+        return true;
+    }
+
+    @Override
+    public void playJukeBoxSong(Location location, ItemStack itemStack) {
         ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
         net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
         Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
-        if (!optional.isPresent()) return false;
+        if (!optional.isPresent()) return; // should never happen if the itemstack has the jukeboxPlayable component
         int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
         level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
-        return true;
     }
 
     @Override

--- a/v1_21_R3/src/main/java/io/th0rgal/oraxen/nms/v1_21_R3/NMSHandler.java
+++ b/v1_21_R3/src/main/java/io/th0rgal/oraxen/nms/v1_21_R3/NMSHandler.java
@@ -575,14 +575,18 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     }
 
     @Override
-    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+    public boolean supportsJukeboxPlaying() {
+        return true;
+    }
+
+    @Override
+    public void playJukeBoxSong(Location location, ItemStack itemStack) {
         ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
         net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
         Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
-        if (!optional.isPresent()) return false;
+        if (!optional.isPresent()) return; // should never happen if the itemstack has the jukeboxPlayable component
         int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
         level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
-        return true;
     }
 
     @Override

--- a/v1_21_R3/src/main/java/io/th0rgal/oraxen/nms/v1_21_R3/NMSHandler.java
+++ b/v1_21_R3/src/main/java/io/th0rgal/oraxen/nms/v1_21_R3/NMSHandler.java
@@ -27,6 +27,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -37,6 +38,7 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemUseAnimation;
+import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.item.component.Consumable;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.consume_effects.*;
@@ -45,9 +47,11 @@ import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.EnumUtils;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.SoundCategory;
 import org.bukkit.SoundGroup;
@@ -55,6 +59,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
@@ -84,23 +89,23 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (ChannelInitializeListenerHolder.hasListener(tagKey))
             return;
         ChannelInitializeListenerHolder.addListener(tagKey, (channel -> channel.pipeline().addBefore("packet_handler",
-                tagKey.asString(), new ChannelDuplexHandler() {
-                    Connection connection = (Connection) channel.pipeline().get("packet_handler");
-                    TagNetworkSerialization.NetworkPayload payload = createPayload();
+            tagKey.asString(), new ChannelDuplexHandler() {
+                Connection connection = (Connection) channel.pipeline().get("packet_handler");
+                TagNetworkSerialization.NetworkPayload payload = createPayload();
 
-                    @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                        if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
-                            Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = updateTagsPacket
-                                    .getTags();
-                            if (NoteBlockMechanicFactory.isEnabled()
-                                    && NoteBlockMechanicFactory.getInstance().removeMineableTag())
-                                tags.put(Registries.BLOCK, payload);
-                            msg = new ClientboundUpdateTagsPacket(tags);
-                        }
-                        ctx.write(msg, promise);
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                    if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
+                        Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = updateTagsPacket
+                            .getTags();
+                        if (NoteBlockMechanicFactory.isEnabled()
+                            && NoteBlockMechanicFactory.getInstance().removeMineableTag())
+                            tags.put(Registries.BLOCK, payload);
+                        msg = new ClientboundUpdateTagsPacket(tags);
                     }
-                })));
+                    ctx.write(msg, promise);
+                }
+            })));
     }
 
     @Override
@@ -167,7 +172,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         // Shulker-Boxes are DirectionalPlace based unlike other directional-blocks
         if (org.bukkit.Tag.SHULKER_BOXES.isTagged(itemStack.getType())) {
             placeContext = new DirectionalPlaceContext(serverPlayer.level(), hitResult.getBlockPos(),
-                    hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
+                hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
         }
 
         BlockPos pos = hitResult.getBlockPos();
@@ -184,15 +189,15 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             SoundGroup sound = block.getBlockData().getSoundGroup();
 
             world.playSound(
-                    BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
-                    SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
+                BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
+                SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
         }
 
         return world.getBlockAt(pos.getX(), pos.getY(), pos.getZ()).getBlockData();
     }
 
     public BlockHitResult getPlayerPOVHitResult(Level world, net.minecraft.world.entity.player.Player player,
-            ClipContext.Fluid fluidHandling) {
+                                                ClipContext.Fluid fluidHandling) {
         float f = player.getXRot();
         float g = player.getYRot();
         Vec3 vec3 = player.getEyePosition();
@@ -214,8 +219,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private TagNetworkSerialization.NetworkPayload createPayload() {
         Constructor<?> constructor = Arrays
-                .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
-                .orElse(null);
+            .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
+            .orElse(null);
         if (constructor == null)
             return null;
         constructor.setAccessible(true);
@@ -239,7 +244,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
      * .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
      * } else pair.getSecond().forEach(block ->
      * list.add(BuiltInRegistries.BLOCK.getId(block.value())));
-     * 
+     *
      * return Map.of(pair.getFirst().location(), list);
      * }).collect(HashMap::new, Map::putAll, Map::putAll);
      * }
@@ -252,25 +257,25 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     /**
      * Sets a component on an item using the DataComponents registry
-     * 
+     *
      * @param item         The ItemBuilder to modify
      * @param componentKey The component key (e.g. "food", "tool", etc.)
      * @param component    The component object
      * @return true if the component was successfully set
      */
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public boolean setComponent(ItemBuilder item, String componentKey, Object component) {
         try {
             net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(new ItemStack(item.getType()));
             net.minecraft.resources.ResourceLocation componentLocation = net.minecraft.resources.ResourceLocation
-                    .tryParse("minecraft:" + componentKey.toLowerCase());
+                .tryParse("minecraft:" + componentKey.toLowerCase());
             if (componentLocation == null)
                 return false;
 
             net.minecraft.core.component.DataComponentType<?> componentType = net.minecraft.core.registries.BuiltInRegistries.DATA_COMPONENT_TYPE
-                    .getOptional(componentLocation)
-                    .orElse(null);
+                .getOptional(componentLocation)
+                .orElse(null);
             if (componentType == null)
                 return false;
 
@@ -294,7 +299,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                         }
                     } catch (Exception e) {
                         io.th0rgal.oraxen.utils.logs.Logs
-                                .logWarning("Failed to create default component for " + componentKey);
+                            .logWarning("Failed to create default component for " + componentKey);
                         return false;
                     }
                 }
@@ -302,7 +307,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                 // Apply NBT to component
                 try {
                     Method fromTag = defaultComponent.getClass().getMethod("fromTag",
-                            net.minecraft.nbt.CompoundTag.class);
+                        net.minecraft.nbt.CompoundTag.class);
                     fromTag.setAccessible(true);
                     Object parsedComponent = fromTag.invoke(defaultComponent, nbt);
 
@@ -315,7 +320,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                     return true;
                 } catch (Exception e) {
                     io.th0rgal.oraxen.utils.logs.Logs
-                            .logWarning("Failed to apply NBT data to component " + componentKey);
+                        .logWarning("Failed to apply NBT data to component " + componentKey);
                     if (io.th0rgal.oraxen.config.Settings.DEBUG.toBool())
                         e.printStackTrace();
                     return false;
@@ -426,13 +431,13 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         Consumable.Builder consumable = Consumable.builder();
         Consumable template = Optional.ofNullable(CraftItemStack.asNMSCopy(new ItemStack(item.getType()))
                 .getComponents().get(DataComponents.CONSUMABLE))
-                .orElse(Consumable.builder().build());
+            .orElse(Consumable.builder().build());
 
         // Basic properties
         consumable.consumeSeconds((float) section.getDouble("consume_seconds", template.consumeSeconds()));
         consumable.animation(Optional.ofNullable(EnumUtils.getEnum(ItemUseAnimation.class,
                 section.getString("animation", "").toUpperCase()))
-                .orElse(template.animation()));
+            .orElse(template.animation()));
         consumable.hasConsumeParticles(section.getBoolean("has_consume_particles", template.hasConsumeParticles()));
 
         // Sound handling
@@ -451,8 +456,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         } else {
             for (Map<?, ?> effectSection : effectsMap) {
                 String type = Optional.ofNullable(effectSection.get("type"))
-                        .map(Object::toString)
-                        .orElse("");
+                    .map(Object::toString)
+                    .orElse("");
 
                 switch (type.toLowerCase()) {
                     case "apply_effects" -> handleApplyEffects(consumable, effectSection);
@@ -460,8 +465,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                     case "clear_all_effects" -> consumable.onConsume(new ClearAllStatusEffectsConsumeEffect());
                     case "teleport_randomly" -> {
                         float diameter = Optional.ofNullable(effectSection.get("diameter"))
-                                .map(d -> Float.parseFloat(d.toString()))
-                                .orElse(16f);
+                            .map(d -> Float.parseFloat(d.toString()))
+                            .orElse(16f);
                         consumable.onConsume(new TeleportRandomlyConsumeEffect(diameter));
                     }
                     case "play_sound" -> handlePlaySound(consumable, effectSection, template);
@@ -478,36 +483,36 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             return;
 
         float probability = Optional.ofNullable(effectSection.get("probability"))
-                .map(p -> Float.parseFloat(p.toString()))
-                .orElse(1.0f);
+            .map(p -> Float.parseFloat(p.toString()))
+            .orElse(1.0f);
 
         for (Map.Entry<?, ?> entry : effects.entrySet()) {
             String effectId = entry.getKey().toString();
             Map<String, Object> effectData = (Map<String, Object>) entry.getValue();
 
             BuiltInRegistries.MOB_EFFECT.getOptional(ResourceLocation.parse(effectId))
-                    .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
-                    .ifPresent(effect -> {
-                        int duration = Optional.ofNullable(effectData.get("duration"))
-                                .map(d -> Integer.parseInt(d.toString()) * 20)
-                                .orElse(20);
-                        int amplifier = Optional.ofNullable(effectData.get("amplifier"))
-                                .map(a -> Integer.parseInt(a.toString()))
-                                .orElse(0);
-                        boolean ambient = Optional.ofNullable(effectData.get("ambient"))
-                                .map(a -> Boolean.parseBoolean(a.toString()))
-                                .orElse(false);
-                        boolean particles = Optional.ofNullable(effectData.get("show_particles"))
-                                .map(p -> Boolean.parseBoolean(p.toString()))
-                                .orElse(true);
-                        boolean icon = Optional.ofNullable(effectData.get("show_icon"))
-                                .map(i -> Boolean.parseBoolean(i.toString()))
-                                .orElse(true);
+                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+                .ifPresent(effect -> {
+                    int duration = Optional.ofNullable(effectData.get("duration"))
+                        .map(d -> Integer.parseInt(d.toString()) * 20)
+                        .orElse(20);
+                    int amplifier = Optional.ofNullable(effectData.get("amplifier"))
+                        .map(a -> Integer.parseInt(a.toString()))
+                        .orElse(0);
+                    boolean ambient = Optional.ofNullable(effectData.get("ambient"))
+                        .map(a -> Boolean.parseBoolean(a.toString()))
+                        .orElse(false);
+                    boolean particles = Optional.ofNullable(effectData.get("show_particles"))
+                        .map(p -> Boolean.parseBoolean(p.toString()))
+                        .orElse(true);
+                    boolean icon = Optional.ofNullable(effectData.get("show_icon"))
+                        .map(i -> Boolean.parseBoolean(i.toString()))
+                        .orElse(true);
 
-                        MobEffectInstance instance = new MobEffectInstance(
-                                effect, duration, amplifier, ambient, particles, icon);
-                        consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
-                    });
+                    MobEffectInstance instance = new MobEffectInstance(
+                        effect, duration, amplifier, ambient, particles, icon);
+                    consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
+                });
         }
     }
 
@@ -516,13 +521,13 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             return;
 
         List<Holder<MobEffect>> mobEffects = effects.stream()
-                .map(Object::toString)
-                .map(ResourceLocation::parse)
-                .map(BuiltInRegistries.MOB_EFFECT::getOptional)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
-                .toList();
+            .map(Object::toString)
+            .map(ResourceLocation::parse)
+            .map(BuiltInRegistries.MOB_EFFECT::getOptional)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+            .toList();
 
         if (!mobEffects.isEmpty()) {
             consumable.onConsume(new RemoveStatusEffectsConsumeEffect(HolderSet.direct(mobEffects)));
@@ -531,14 +536,14 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private void handlePlaySound(Consumable.Builder consumable, Map<?, ?> effectSection, Consumable template) {
         ResourceLocation soundKey = Optional.ofNullable(effectSection.get("sound"))
-                .map(Object::toString)
-                .map(ResourceLocation::parse)
-                .orElse(template.sound().value().location());
+            .map(Object::toString)
+            .map(ResourceLocation::parse)
+            .orElse(template.sound().value().location());
 
         BuiltInRegistries.SOUND_EVENT.getOptional(soundKey)
-                .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
-                .map(PlaySoundConsumeEffect::new)
-                .ifPresent(consumable::onConsume);
+            .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
+            .map(PlaySoundConsumeEffect::new)
+            .ifPresent(consumable::onConsume);
     }
 
     @Override
@@ -567,5 +572,22 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             e.printStackTrace();
         }
         return itemStack;
+    }
+
+    @Override
+    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+        Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
+        if (!optional.isPresent()) return false;
+        int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
+        level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
+        return true;
+    }
+
+    @Override
+    public void stopJukeBox(Location location) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        level.levelEvent(null, LevelEvent.SOUND_STOP_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), 0);
     }
 }

--- a/v1_21_R4/src/main/java/io/th0rgal/oraxen/nms/v1_21_R4/NMSHandler.java
+++ b/v1_21_R4/src/main/java/io/th0rgal/oraxen/nms/v1_21_R4/NMSHandler.java
@@ -27,6 +27,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -37,6 +38,7 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemUseAnimation;
+import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.item.component.Consumable;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.consume_effects.*;
@@ -45,9 +47,11 @@ import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.EnumUtils;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.SoundCategory;
 import org.bukkit.SoundGroup;
@@ -55,6 +59,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
@@ -84,23 +89,23 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         if (ChannelInitializeListenerHolder.hasListener(tagKey))
             return;
         ChannelInitializeListenerHolder.addListener(tagKey, (channel -> channel.pipeline().addBefore("packet_handler",
-                tagKey.asString(), new ChannelDuplexHandler() {
-                    Connection connection = (Connection) channel.pipeline().get("packet_handler");
-                    TagNetworkSerialization.NetworkPayload payload = createPayload();
+            tagKey.asString(), new ChannelDuplexHandler() {
+                Connection connection = (Connection) channel.pipeline().get("packet_handler");
+                TagNetworkSerialization.NetworkPayload payload = createPayload();
 
-                    @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                        if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
-                            Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = updateTagsPacket
-                                    .getTags();
-                            if (NoteBlockMechanicFactory.isEnabled()
-                                    && NoteBlockMechanicFactory.getInstance().removeMineableTag())
-                                tags.put(Registries.BLOCK, payload);
-                            msg = new ClientboundUpdateTagsPacket(tags);
-                        }
-                        ctx.write(msg, promise);
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                    if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
+                        Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = updateTagsPacket
+                            .getTags();
+                        if (NoteBlockMechanicFactory.isEnabled()
+                            && NoteBlockMechanicFactory.getInstance().removeMineableTag())
+                            tags.put(Registries.BLOCK, payload);
+                        msg = new ClientboundUpdateTagsPacket(tags);
                     }
-                })));
+                    ctx.write(msg, promise);
+                }
+            })));
     }
 
     @Override
@@ -168,7 +173,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         // Shulker-Boxes are DirectionalPlace based unlike other directional-blocks
         if (org.bukkit.Tag.SHULKER_BOXES.isTagged(itemStack.getType())) {
             placeContext = new DirectionalPlaceContext(serverPlayer.level(), hitResult.getBlockPos(),
-                    hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
+                hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
         }
 
         BlockPos pos = hitResult.getBlockPos();
@@ -185,15 +190,15 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             SoundGroup sound = block.getBlockData().getSoundGroup();
 
             world.playSound(
-                    BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
-                    SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
+                BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
+                SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
         }
 
         return world.getBlockAt(pos.getX(), pos.getY(), pos.getZ()).getBlockData();
     }
 
     public BlockHitResult getPlayerPOVHitResult(Level world, net.minecraft.world.entity.player.Player player,
-            ClipContext.Fluid fluidHandling) {
+                                                ClipContext.Fluid fluidHandling) {
         float f = player.getXRot();
         float g = player.getYRot();
         Vec3 vec3 = player.getEyePosition();
@@ -215,8 +220,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private TagNetworkSerialization.NetworkPayload createPayload() {
         Constructor<?> constructor = Arrays
-                .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
-                .orElse(null);
+            .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
+            .orElse(null);
         if (constructor == null)
             return null;
         constructor.setAccessible(true);
@@ -240,7 +245,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
      * .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
      * } else pair.getSecond().forEach(block ->
      * list.add(BuiltInRegistries.BLOCK.getId(block.value())));
-     * 
+     *
      * return Map.of(pair.getFirst().location(), list);
      * }).collect(HashMap::new, Map::putAll, Map::putAll);
      * }
@@ -253,25 +258,25 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     /**
      * Sets a component on an item using the DataComponents registry
-     * 
+     *
      * @param item         The ItemBuilder to modify
      * @param componentKey The component key (e.g. "food", "tool", etc.)
      * @param component    The component object
      * @return true if the component was successfully set
      */
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public boolean setComponent(ItemBuilder item, String componentKey, Object component) {
         try {
             net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(new ItemStack(item.getType()));
             net.minecraft.resources.ResourceLocation componentLocation = net.minecraft.resources.ResourceLocation
-                    .tryParse("minecraft:" + componentKey.toLowerCase());
+                .tryParse("minecraft:" + componentKey.toLowerCase());
             if (componentLocation == null)
                 return false;
 
             net.minecraft.core.component.DataComponentType<?> componentType = net.minecraft.core.registries.BuiltInRegistries.DATA_COMPONENT_TYPE
-                    .getOptional(componentLocation)
-                    .orElse(null);
+                .getOptional(componentLocation)
+                .orElse(null);
             if (componentType == null)
                 return false;
 
@@ -295,7 +300,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                         }
                     } catch (Exception e) {
                         io.th0rgal.oraxen.utils.logs.Logs
-                                .logWarning("Failed to create default component for " + componentKey);
+                            .logWarning("Failed to create default component for " + componentKey);
                         return false;
                     }
                 }
@@ -303,7 +308,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                 // Apply NBT to component
                 try {
                     Method fromTag = defaultComponent.getClass().getMethod("fromTag",
-                            net.minecraft.nbt.CompoundTag.class);
+                        net.minecraft.nbt.CompoundTag.class);
                     fromTag.setAccessible(true);
                     Object parsedComponent = fromTag.invoke(defaultComponent, nbt);
 
@@ -316,7 +321,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                     return true;
                 } catch (Exception e) {
                     io.th0rgal.oraxen.utils.logs.Logs
-                            .logWarning("Failed to apply NBT data to component " + componentKey);
+                        .logWarning("Failed to apply NBT data to component " + componentKey);
                     if (io.th0rgal.oraxen.config.Settings.DEBUG.toBool())
                         e.printStackTrace();
                     return false;
@@ -427,13 +432,13 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         Consumable.Builder consumable = Consumable.builder();
         Consumable template = Optional.ofNullable(CraftItemStack.asNMSCopy(new ItemStack(item.getType()))
                 .getComponents().get(DataComponents.CONSUMABLE))
-                .orElse(Consumable.builder().build());
+            .orElse(Consumable.builder().build());
 
         // Basic properties
         consumable.consumeSeconds((float) section.getDouble("consume_seconds", template.consumeSeconds()));
         consumable.animation(Optional.ofNullable(EnumUtils.getEnum(ItemUseAnimation.class,
                 section.getString("animation", "").toUpperCase()))
-                .orElse(template.animation()));
+            .orElse(template.animation()));
         consumable.hasConsumeParticles(section.getBoolean("has_consume_particles", template.hasConsumeParticles()));
 
         // Sound handling
@@ -452,8 +457,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         } else {
             for (Map<?, ?> effectSection : effectsMap) {
                 String type = Optional.ofNullable(effectSection.get("type"))
-                        .map(Object::toString)
-                        .orElse("");
+                    .map(Object::toString)
+                    .orElse("");
 
                 switch (type.toLowerCase()) {
                     case "apply_effects" -> handleApplyEffects(consumable, effectSection);
@@ -461,8 +466,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                     case "clear_all_effects" -> consumable.onConsume(new ClearAllStatusEffectsConsumeEffect());
                     case "teleport_randomly" -> {
                         float diameter = Optional.ofNullable(effectSection.get("diameter"))
-                                .map(d -> Float.parseFloat(d.toString()))
-                                .orElse(16f);
+                            .map(d -> Float.parseFloat(d.toString()))
+                            .orElse(16f);
                         consumable.onConsume(new TeleportRandomlyConsumeEffect(diameter));
                     }
                     case "play_sound" -> handlePlaySound(consumable, effectSection, template);
@@ -479,36 +484,36 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             return;
 
         float probability = Optional.ofNullable(effectSection.get("probability"))
-                .map(p -> Float.parseFloat(p.toString()))
-                .orElse(1.0f);
+            .map(p -> Float.parseFloat(p.toString()))
+            .orElse(1.0f);
 
         for (Map.Entry<?, ?> entry : effects.entrySet()) {
             String effectId = entry.getKey().toString();
             Map<String, Object> effectData = (Map<String, Object>) entry.getValue();
 
             BuiltInRegistries.MOB_EFFECT.getOptional(ResourceLocation.parse(effectId))
-                    .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
-                    .ifPresent(effect -> {
-                        int duration = Optional.ofNullable(effectData.get("duration"))
-                                .map(d -> Integer.parseInt(d.toString()) * 20)
-                                .orElse(20);
-                        int amplifier = Optional.ofNullable(effectData.get("amplifier"))
-                                .map(a -> Integer.parseInt(a.toString()))
-                                .orElse(0);
-                        boolean ambient = Optional.ofNullable(effectData.get("ambient"))
-                                .map(a -> Boolean.parseBoolean(a.toString()))
-                                .orElse(false);
-                        boolean particles = Optional.ofNullable(effectData.get("show_particles"))
-                                .map(p -> Boolean.parseBoolean(p.toString()))
-                                .orElse(true);
-                        boolean icon = Optional.ofNullable(effectData.get("show_icon"))
-                                .map(i -> Boolean.parseBoolean(i.toString()))
-                                .orElse(true);
+                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+                .ifPresent(effect -> {
+                    int duration = Optional.ofNullable(effectData.get("duration"))
+                        .map(d -> Integer.parseInt(d.toString()) * 20)
+                        .orElse(20);
+                    int amplifier = Optional.ofNullable(effectData.get("amplifier"))
+                        .map(a -> Integer.parseInt(a.toString()))
+                        .orElse(0);
+                    boolean ambient = Optional.ofNullable(effectData.get("ambient"))
+                        .map(a -> Boolean.parseBoolean(a.toString()))
+                        .orElse(false);
+                    boolean particles = Optional.ofNullable(effectData.get("show_particles"))
+                        .map(p -> Boolean.parseBoolean(p.toString()))
+                        .orElse(true);
+                    boolean icon = Optional.ofNullable(effectData.get("show_icon"))
+                        .map(i -> Boolean.parseBoolean(i.toString()))
+                        .orElse(true);
 
-                        MobEffectInstance instance = new MobEffectInstance(
-                                effect, duration, amplifier, ambient, particles, icon);
-                        consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
-                    });
+                    MobEffectInstance instance = new MobEffectInstance(
+                        effect, duration, amplifier, ambient, particles, icon);
+                    consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
+                });
         }
     }
 
@@ -517,13 +522,13 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             return;
 
         List<Holder<MobEffect>> mobEffects = effects.stream()
-                .map(Object::toString)
-                .map(ResourceLocation::parse)
-                .map(BuiltInRegistries.MOB_EFFECT::getOptional)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
-                .toList();
+            .map(Object::toString)
+            .map(ResourceLocation::parse)
+            .map(BuiltInRegistries.MOB_EFFECT::getOptional)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+            .toList();
 
         if (!mobEffects.isEmpty()) {
             consumable.onConsume(new RemoveStatusEffectsConsumeEffect(HolderSet.direct(mobEffects)));
@@ -532,14 +537,14 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private void handlePlaySound(Consumable.Builder consumable, Map<?, ?> effectSection, Consumable template) {
         ResourceLocation soundKey = Optional.ofNullable(effectSection.get("sound"))
-                .map(Object::toString)
-                .map(ResourceLocation::parse)
-                .orElse(template.sound().value().location());
+            .map(Object::toString)
+            .map(ResourceLocation::parse)
+            .orElse(template.sound().value().location());
 
         BuiltInRegistries.SOUND_EVENT.getOptional(soundKey)
-                .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
-                .map(PlaySoundConsumeEffect::new)
-                .ifPresent(consumable::onConsume);
+            .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
+            .map(PlaySoundConsumeEffect::new)
+            .ifPresent(consumable::onConsume);
     }
 
     @Override
@@ -568,5 +573,22 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             e.printStackTrace();
         }
         return itemStack;
+    }
+
+    @Override
+    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+        Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
+        if (!optional.isPresent()) return false;
+        int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
+        level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
+        return true;
+    }
+
+    @Override
+    public void stopJukeBox(Location location) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        level.levelEvent(null, LevelEvent.SOUND_STOP_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), 0);
     }
 }

--- a/v1_21_R4/src/main/java/io/th0rgal/oraxen/nms/v1_21_R4/NMSHandler.java
+++ b/v1_21_R4/src/main/java/io/th0rgal/oraxen/nms/v1_21_R4/NMSHandler.java
@@ -576,14 +576,18 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     }
 
     @Override
-    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+    public boolean supportsJukeboxPlaying() {
+        return true;
+    }
+
+    @Override
+    public void playJukeBoxSong(Location location, ItemStack itemStack) {
         ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
         net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
         Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
-        if (!optional.isPresent()) return false;
+        if (!optional.isPresent()) return; // should never happen if the itemstack has the jukeboxPlayable component
         int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
         level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
-        return true;
     }
 
     @Override

--- a/v1_21_R5/src/main/java/io/th0rgal/oraxen/nms/v1_21_R5/NMSHandler.java
+++ b/v1_21_R5/src/main/java/io/th0rgal/oraxen/nms/v1_21_R5/NMSHandler.java
@@ -27,6 +27,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.tags.TagNetworkSerialization;
@@ -37,6 +38,7 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemUseAnimation;
+import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.item.component.Consumable;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.consume_effects.*;
@@ -45,9 +47,11 @@ import net.minecraft.world.item.context.DirectionalPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.EnumUtils;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.SoundCategory;
 import org.bukkit.SoundGroup;
@@ -55,6 +59,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
@@ -568,5 +573,22 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
             e.printStackTrace();
         }
         return itemStack;
+    }
+
+    @Override
+    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+        Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
+        if (!optional.isPresent()) return false;
+        int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
+        level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
+        return true;
+    }
+
+    @Override
+    public void stopJukeBox(Location location) {
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        level.levelEvent(null, LevelEvent.SOUND_STOP_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), 0);
     }
 }

--- a/v1_21_R5/src/main/java/io/th0rgal/oraxen/nms/v1_21_R5/NMSHandler.java
+++ b/v1_21_R5/src/main/java/io/th0rgal/oraxen/nms/v1_21_R5/NMSHandler.java
@@ -576,14 +576,18 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     }
 
     @Override
-    public boolean playJukeBoxSong(Location location, ItemStack itemStack) {
+    public boolean supportsJukeboxPlaying() {
+        return true;
+    }
+
+    @Override
+    public void playJukeBoxSong(Location location, ItemStack itemStack) {
         ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
         net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
         Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(level.registryAccess(), nmsItem);
-        if (!optional.isPresent()) return false;
+        if (!optional.isPresent()) return; // should never happen if the itemstack has the jukeboxPlayable component
         int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
         level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG, new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
-        return true;
     }
 
     @Override


### PR DESCRIPTION
This one should fix most music disc related stuff.

Like music discs not stopping when playing in a turntable
Turntables with volume of 1 and pitch of 1 now also act like normal jukeboxes, i.e. play the disc like a jukebox.

Tho there is one case where a jukebox will land in limbo if an old itemstack can't be parsed from the pdc.
at least now I catch the exception and return null

If I forgot a music disc related issue, let me know.