### PR TITLE
Add compaitibility for PacketEvents

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 }
 
 class NMSVersion(val nmsVersion: String, val serverVersion: String)
+
 infix fun String.toNms(that: String): NMSVersion = NMSVersion(this, that)
 val SUPPORTED_VERSIONS: List<NMSVersion> = listOf(
     "v1_20_R1" toNms "1.20.1-R0.1-SNAPSHOT",
@@ -41,76 +42,64 @@ val apacheLang3Version = "3.14.0"
 group = "io.th0rgal"
 version = pluginVersion
 
+
+
 allprojects {
     apply(plugin = "java")
+
     repositories {
+        maven("https://repo.papermc.io/repository/maven-public/") {
+            content {
+                includeGroup("io.papermc.paper") // Paper
+                // extra stuff required by paper
+                includeGroup("net.md-5")
+                includeGroup("com.mojang")
+            }
+        }
+        maven("https://libraries.minecraft.net/") {
+            content { includeGroup("net.minecraft") } // Minecraft repo (commodore)
+        }
+        maven("https://repo.extendedclip.com/content/repositories/placeholderapi/") {
+            content { includeGroup("me.clip") } // PlaceHolderAPI
+        }
+//        maven("https://maven.elmakers.com/repository/") // EffectLib
+        maven("https://repo.triumphteam.dev/snapshots") {
+            content { includeGroup("me.gabytm.util") } // actions-code, actions-spigot
+        }
+        maven("https://mvn.lumine.io/repository/maven-public/") {
+            metadataSources { artifact() }
+            content {
+                includeModule("io.lumine", "MythicLib")
+                includeModule("io.lumine", "Mythic-Dist")
+                includeModule("io.lumine", "MythicCrucible-API")
+                includeGroup("com.ticxo.modelengine") // ModelEngine
+            }
+        }
+        maven("https://repo.oraxen.com/releases") {
+            content { includeGroup("io.th0rgal") } // protectionlib
+        }
+        maven("https://repo.oraxen.com/snapshots") {
+            content { includeGroup("io.th0rgal") }
+        }
+        maven("https://repo.auxilor.io/repository/maven-public/") {
+            content { includeGroup("com.willfp") } // EcoItems, eco, libreforge
+        }
+        maven("https://maven.enginehub.org/repo/") {
+            content { includeGroupAndSubgroups("com.sk89q.worldedit") } // world edit
+        }
+        maven("https://nexus.phoenixdevt.fr/repository/maven-public/") {
+            content {
+                includeModule("io.lumine", "MythicLib-dist")
+                includeGroup("net.Indyuce") // MMOItems
+            }
+        }
+        maven("https://repo.codemc.org/repository/maven-public/") {
+            content { includeGroup("nl.rutgerkok") } // BlockLocker
+        }
+        maven("https://repo.codemc.io/repository/maven-releases/") {
+            content { includeGroup("com.github.retrooper") }
+        }
         mavenCentral()
-
-        maven("https://repo.papermc.io/repository/maven-public/") // Paper
-        maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") // Spigot
-        maven("https://oss.sonatype.org/content/repositories/snapshots") // Because Spigot depends on Bungeecord ChatComponent-API
-        maven("https://repo.dmulloy2.net/repository/public/") // ProtocolLib
-        maven("https://libraries.minecraft.net/") // Minecraft repo (commodore)
-        maven("https://repo.extendedclip.com/content/repositories/placeholderapi/") // PlaceHolderAPI
-        maven("https://maven.elmakers.com/repository/") // EffectLib
-        maven("https://hub.jeff-media.com/nexus/repository/jeff-media-public/") // CustomBlockData
-        maven("https://repo.triumphteam.dev/snapshots") // actions-code, actions-spigot
-        maven("https://mvn.lumine.io/repository/maven-public/") { metadataSources { artifact() } }// MythicMobs
-        maven("https://s01.oss.sonatype.org/content/repositories/snapshots") // commandAPI snapshots
-        maven("https://repo.oraxen.com/releases")
-        maven("https://repo.oraxen.com/snapshots")
-        maven("https://repo.auxilor.io/repository/maven-public/") // EcoItems
-        maven("https://maven.enginehub.org/repo/")
-        maven("https://jitpack.io") // JitPack
-        maven("https://nexus.phoenixdevt.fr/repository/maven-public/") // MMOItems
-        maven("https://repo.codemc.org/repository/maven-public/") // BlockLocker
-
-        mavenLocal()
-    }
-
-    dependencies {
-        val actionsVersion = "1.0.0-SNAPSHOT"
-        compileOnly("gs.mclo:java:2.2.1")
-
-        compileOnly("net.kyori:adventure-text-minimessage:$adventureVersion")
-        compileOnly("net.kyori:adventure-text-serializer-plain:$adventureVersion")
-        compileOnly("net.kyori:adventure-text-serializer-ansi:$adventureVersion")
-        compileOnly("net.kyori:adventure-platform-bukkit:$platformVersion")
-        compileOnly("net.dmulloy2:ProtocolLib:5.4.0")
-        compileOnly("me.clip:placeholderapi:2.11.6")
-        compileOnly("me.gabytm.util:actions-core:$actionsVersion")
-        compileOnly("org.springframework:spring-expression:6.0.6")
-        compileOnly("io.lumine:Mythic-Dist:5.7.0-SNAPSHOT")
-        compileOnly("io.lumine:MythicCrucible:1.6.0-SNAPSHOT")
-        compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.2.9")
-        compileOnly("commons-io:commons-io:2.11.0")
-        compileOnly("com.google.code.gson:gson:$googleGsonVersion")
-        compileOnly("com.ticxo.modelengine:ModelEngine:R4.0.4")
-        compileOnly("com.ticxo.modelengine:api:R3.1.8")
-        compileOnly(files("../libs/compile/BSP.jar"))
-        compileOnly("io.lumine:MythicLib:1.1.6") // Remove and add deps needed for Polymath
-        compileOnly("io.lumine:MythicLib-dist:1.6.2-SNAPSHOT")
-        compileOnly("net.Indyuce:MMOItems-API:6.9.5-SNAPSHOT")
-        compileOnly("org.joml:joml:1.10.5") // Because pre 1.19.4 api does not have this in the server-jar
-        compileOnly("com.willfp:EcoItems:5.23.0")
-        compileOnly("com.willfp:eco:6.65.5")
-        compileOnly("com.willfp:libreforge:4.36.0")
-        compileOnly("nl.rutgerkok:blocklocker:1.10.4-SNAPSHOT")
-        compileOnly("org.apache.commons:commons-lang3:$apacheLang3Version")
-
-        implementation("team.unnamed:creative-api:1.7.3") { exclude("net.kyori") }
-        implementation("dev.jorel:commandapi-bukkit-shade:$commandApiVersion")
-        implementation("org.bstats:bstats-bukkit:3.0.0")
-        implementation("org.glassfish:javax.json:1.1.4")
-        implementation("io.th0rgal:protectionlib:1.8.0")
-        implementation("com.github.stefvanschie.inventoryframework:IF:0.10.12")
-        implementation("com.jeff-media:custom-block-data:2.2.2")
-        implementation("com.jeff-media:MorePersistentDataTypes:2.4.0")
-        implementation("com.jeff-media:persistent-data-serializer:1.0")
-        implementation("org.jetbrains:annotations:24.1.0") { isTransitive = false }
-        implementation("dev.triumphteam:triumph-gui:3.1.10") { exclude("net.kyori") }
-
-        implementation("me.gabytm.util:actions-spigot:$actionsVersion") { exclude(group = "com.google.guava") }
     }
 }
 
@@ -119,12 +108,18 @@ dependencies {
     SUPPORTED_VERSIONS.forEach { implementation(project(path = ":${it.nmsVersion}", configuration = "reobf")) }
 }
 
-
-
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(21))
     }
+}
+
+tasks.withType(xyz.jpenilla.runtask.task.AbstractRun::class) {
+    javaLauncher = javaToolchains.launcherFor {
+        vendor = JvmVendorSpec.JETBRAINS
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    jvmArgs("-XX:+AllowEnhancedClassRedefinition")
 }
 
 tasks {
@@ -138,7 +133,16 @@ tasks {
     }
 
     processResources {
-        filesNotMatching(listOf("**/*.png", "**/*.ogg", "**/models/**", "**/textures/**", "**/font/**.json", "**/plugin.yml")) {
+        filesNotMatching(
+            listOf(
+                "**/*.png",
+                "**/*.ogg",
+                "**/models/**",
+                "**/textures/**",
+                "**/font/**.json",
+                "**/plugin.yml"
+            )
+        ) {
             expand(mapOf(project.version.toString() to pluginVersion))
         }
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
@@ -147,23 +151,35 @@ tasks {
 
     runServer {
         downloadPlugins {
-            url("https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/build/libs/ProtocolLib.jar")
+            hangar("ProtocolLib", "5.4.0")
         }
-        minecraftVersion("1.20.4")
+        minecraftVersion("1.21.8")
+        jvmArgs("-Dcom.mojang.eula.agree=true")
     }
 
     shadowJar {
         SUPPORTED_VERSIONS.forEach { dependsOn(":${it.nmsVersion}:reobfJar") }
 
         archiveClassifier = null
-        relocate("org.bstats", "io.th0rgal.oraxen.shaded.bstats")
-        relocate("dev.triumphteam.gui", "io.th0rgal.oraxen.shaded.triumphteam.gui")
-        relocate("com.jeff_media", "io.th0rgal.oraxen.shaded.jeff_media")
-        relocate("com.github.stefvanschie.inventoryframework", "io.th0rgal.oraxen.shaded.inventoryframework")
-        relocate("me.gabytm.util.actions", "io.th0rgal.oraxen.shaded.actions")
+        oraxenLibs.bundles.libraries.shade.get().forEach {
+            val plugin = it;
+            val group = it.group!!
+                .replace("jeff-media", "jeff_media") // they use a different package than the group...
+            val parts = group
+                .split(".")
+            var relocated = parts[parts.size - 1]
+            if (parts.size > 2) {
+                relocated = parts[parts.size - 2] + "." + relocated
+            }
+            logger.lifecycle("Relocating ${group} to io.th0rgal.oraxen.shaded." + relocated)
+            relocate(group, "io.th0rgal.oraxen.shaded." + relocated) {
+                exclude("io.th0rgal.oraxen.**")
+            }
+        }
+        // exception for this one dunno who includes that...
         relocate("org.intellij.lang.annotations", "io.th0rgal.oraxen.shaded.intellij.annotations")
-        relocate("org.jetbrains.annotations", "io.th0rgal.oraxen.shaded.jetbrains.annotations")
-        relocate("dev.jorel", "io.th0rgal.oraxen.shaded")
+        relocate("com.udojava.evalex", "io.th0rgal.oraxen.shaded.udojava.evalex")
+        relocate("javax.json", "io.th0rgal.oraxen.shaded.javax.json")
 
         manifest {
             attributes(
@@ -172,8 +188,16 @@ tasks {
                     "Version" to pluginVersion,
                     "Build-Timestamp" to SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss.SSSZ").format(Date.from(Instant.now())),
                     "Created-By" to "Gradle ${gradle.gradleVersion}",
-                    "Build-Jdk" to "${System.getProperty("java.version")} ${System.getProperty("java.vendor")} ${System.getProperty("java.vm.version")}",
-                    "Build-OS" to "${System.getProperty("os.name")} ${System.getProperty("os.arch")} ${System.getProperty("os.version")}",
+                    "Build-Jdk" to "${System.getProperty("java.version")} ${System.getProperty("java.vendor")} ${
+                        System.getProperty(
+                            "java.vm.version"
+                        )
+                    }",
+                    "Build-OS" to "${System.getProperty("os.name")} ${System.getProperty("os.arch")} ${
+                        System.getProperty(
+                            "os.version"
+                        )
+                    }",
                     "Compiled" to (project.findProperty("oraxen_compiled")?.toString() ?: "true").toBoolean()
                 )
             )
@@ -204,18 +228,7 @@ bukkit {
         description = "Allows the player to use the /oraxen command"
         default = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission.Default.TRUE
     }
-    libraries = listOf(
-        "org.springframework:spring-expression:6.0.6",
-        "org.apache.httpcomponents:httpmime:4.5.13",
-        "org.joml:joml:1.10.5",
-        "net.kyori:adventure-text-minimessage:$adventureVersion",
-        "net.kyori:adventure-text-serializer-plain:$adventureVersion",
-        "net.kyori:adventure-text-serializer-ansi:$adventureVersion",
-        "net.kyori:adventure-platform-bukkit:$platformVersion",
-        "com.google.code.gson:gson:$googleGsonVersion",
-        "org.apache.commons:commons-lang3:$apacheLang3Version",
-        "gs.mclo:java:2.2.1",
-    )
+    libraries = oraxenLibs.bundles.libraries.bukkit.get().map { it.toString() }
 }
 
 if (spigotPluginPath != null) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,12 +13,28 @@ tasks {
     build.get().dependsOn(shadowJar)
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT")
+    // libraries in plugin.yml > libraries
+    compileOnly(oraxenLibs.bundles.libraries.bukkit) {
+        exclude("org.jetbrains", "annotations")
+    }
+    // things that are included in minecraft but not exposed
+    compileOnly(oraxenLibs.bundles.libraries.included)
+    // Plugin dependencies
+    compileOnly(oraxenLibs.bundles.plugins) {
+        exclude("org.jetbrains", "annotations")
+        exclude("com.google.code.gson", "gson")
+        exclude("net.kyori")
+    }
+    compileOnly(files("../libs/compile/BSP.jar"))
+    // shaded dependencies
+    implementation(oraxenLibs.bundles.libraries.shade) {
+        exclude("com.google.code.gson", "gson")
+        exclude("net.kyori")
+        exclude(group = "com.google.guava")
+    }
 }
 
 java {
@@ -42,8 +58,10 @@ publishing {
         maven {
             authentication {
                 credentials(PasswordCredentials::class) {
-                    username = System.getenv("MAVEN_USERNAME") ?: project.findProperty("oraxenUsername") as? String ?: ""
-                    password = System.getenv("MAVEN_PASSWORD") ?: project.findProperty("oraxenPassword") as? String ?: ""
+                    username =
+                        System.getenv("MAVEN_USERNAME") ?: project.findProperty("oraxenUsername") as? String ?: ""
+                    password =
+                        System.getenv("MAVEN_PASSWORD") ?: project.findProperty("oraxenPassword") as? String ?: ""
                 }
                 authentication {
                     create<BasicAuthentication>("basic")
@@ -75,7 +93,8 @@ class PublishData(private val project: Project) {
         System.getenv("GITHUB_SHA")?.substring(0, hashLength) ?: "local"
 
     private fun getCheckedOutBranch(): String =
-        System.getenv("GITHUB_REF")?.replace("refs/heads/", "") ?: grgitService.service.get().grgit.branch.current().name
+        System.getenv("GITHUB_REF")?.replace("refs/heads/", "")
+            ?: grgitService.service.get().grgit.branch.current().name
 
     fun getVersion(): String = getVersion(false)
 

--- a/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/CommandsManager.java
@@ -17,8 +17,6 @@ import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import com.comphenix.protocol.error.Report;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/worldedit/WorldEditHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/worldedit/WorldEditHandlers.java
@@ -75,8 +75,8 @@ public class WorldEditHandlers {
                 // Remove interaction-tag from baseEntity-nbt
                 CompoundTag compoundTag = baseEntity.getNbtData();
                 if (compoundTag == null) return super.createEntity(location, baseEntity);
-                Map<String, Tag> compoundTagMap = new HashMap<>(compoundTag.getValue());
-                Map<String, Tag> bukkitValues = new HashMap<>((Map<String, Tag>) compoundTagMap.get("BukkitValues").getValue());
+                Map<String, Tag<?,?>> compoundTagMap = new HashMap<>(compoundTag.getValue());
+                Map<String, Tag<?,?>> bukkitValues = new HashMap<>((Map<String, Tag<?,?>>) compoundTagMap.get("BukkitValues").getValue());
                 bukkitValues.remove("oraxen:interaction");
                 compoundTagMap.put("BukkitValues", new CompoundTag(bukkitValues));
                 baseEntity.setNbtData(new CompoundTag(compoundTagMap));
@@ -95,7 +95,7 @@ public class WorldEditHandlers {
             public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 pos, T block) throws WorldEditException {
                 BlockData blockData = BukkitAdapter.adapt(block);
                 World world = Bukkit.getWorld(event.getWorld().getName());
-                Location loc = new Location(world, pos.getX(), pos.getY(), pos.getZ());
+                Location loc = new Location(world, pos.x(), pos.y(), pos.z());
                 Mechanic mechanic = OraxenBlocks.getOraxenBlock(blockData);
                 if (blockData.getMaterial() == Material.NOTE_BLOCK) {
                     if (mechanic != null && Settings.WORLDEDIT_NOTEBLOCKS.toBool()) {

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -1,18 +1,14 @@
 package io.th0rgal.oraxen.font;
 
-import com.comphenix.protocol.ProtocolLibrary;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.ConfigsManager;
 import io.th0rgal.oraxen.config.Settings;
-import io.th0rgal.oraxen.font.packets.InventoryPacketListener;
-import io.th0rgal.oraxen.font.packets.TitlePacketListener;
 import io.th0rgal.oraxen.nms.GlyphHandlers;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.OraxenYaml;
-import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
@@ -74,10 +70,10 @@ public class FontManager {
             NMSHandlers.getHandler().glyphHandler().setupNmsGlyphs();
             Logs.logSuccess("Oraxens NMS Glyph system has been enabled!");
             Logs.logInfo("Disabling packet-based glyph systems", true);
-            if (PluginUtils.isEnabled("ProtocolLib")){
-                ProtocolLibrary.getProtocolManager().removePacketListener(new InventoryPacketListener());
-                ProtocolLibrary.getProtocolManager().removePacketListener(new TitlePacketListener());
-            }
+            OraxenPlugin.get().getPacketAdapter().whenEnabled(adapter -> {
+                adapter.removeInventoryListener();
+                adapter.removeTitleListener();
+            });
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/efficiency/EfficiencyMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/efficiency/EfficiencyMechanicFactory.java
@@ -1,20 +1,17 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency;
 
-import com.comphenix.protocol.ProtocolLibrary;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
-import io.th0rgal.oraxen.utils.PluginUtils;
 import org.bukkit.configuration.ConfigurationSection;
 
 public class EfficiencyMechanicFactory extends MechanicFactory {
 
     public EfficiencyMechanicFactory(ConfigurationSection section) {
         super(section);
-        if (PluginUtils.isEnabled("ProtocolLib")) {
-            ProtocolLibrary.getProtocolManager().getPacketListeners().stream().filter(l -> l.getClass().equals(EfficiencyMechanicListener.class))
-                            .findFirst().ifPresent(l -> ProtocolLibrary.getProtocolManager().removePacketListener(l));
-            ProtocolLibrary.getProtocolManager().addPacketListener(new EfficiencyMechanicListener(this));
-        }
+        OraxenPlugin.get().getPacketAdapter().whenEnabled(adapter -> {
+            adapter.reregisterEfficencyMechanicListener(this);
+        });
     }
 
     @Override

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.pack.generation;
 
-import com.comphenix.protocol.ProtocolLibrary;
 import com.google.gson.*;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
@@ -10,7 +9,6 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.font.Font;
 import io.th0rgal.oraxen.font.FontManager;
 import io.th0rgal.oraxen.font.Glyph;
-import io.th0rgal.oraxen.font.packets.ScoreboardPacketListener;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.items.OraxenMeta;
 import io.th0rgal.oraxen.pack.upload.UploadManager;
@@ -805,8 +803,8 @@ public class ResourcePack {
             "vec_it", "vi_vn", "yi_de", "yo_ng", "zh_cn", "zh_hk", "zh_tw", "zlm_arab"));
 
     private void hideScoreboardNumbers() {
-        if (PluginUtils.isEnabled("ProtocolLib") && VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.20.3")) {
-            ProtocolLibrary.getProtocolManager().addPacketListener(new ScoreboardPacketListener());
+        if (OraxenPlugin.get().getPacketAdapter().isEnabled() && VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.20.3")) {
+            OraxenPlugin.get().getPacketAdapter().registerScoreboardListener();
         } else { // Pre 1.20.3 rely on shaders
             writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
             writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh", getScoreboardVsh());

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
@@ -1,0 +1,72 @@
+package io.th0rgal.oraxen.packets;
+
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
+import io.th0rgal.oraxen.utils.PluginUtils;
+import io.th0rgal.oraxen.utils.SnapshotVersion;
+
+import java.util.function.Consumer;
+
+public interface PacketAdapter {
+    static boolean isPacketEventsEnabled() {
+        return PluginUtils.isEnabled("PacketEvents");
+    }
+    static boolean isProtocolLibEnabled() {
+        return PluginUtils.isEnabled("ProtocolLib");
+    }
+    boolean isEnabled();
+    default boolean whenEnabled(Consumer<PacketAdapter> whenEnabled) {
+        boolean enabled = isEnabled();
+        if (enabled && whenEnabled != null) whenEnabled.accept(this);
+        return enabled;
+    }
+    void registerInventoryListener();
+    void registerScoreboardListener();
+    void registerTitleListener();
+    void removeInventoryListener();
+    void removeTitleListener();
+    void reregisterEfficencyMechanicListener(EfficiencyMechanicFactory efficiencyMechanicFactory);
+
+    String getLatestMCVersion();
+    boolean isNewer(SnapshotVersion snapshot);
+    public static class EmptyAdapter implements PacketAdapter {
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public void registerInventoryListener() {
+        }
+
+        @Override
+        public void registerScoreboardListener() {
+        }
+
+        @Override
+        public void registerTitleListener() {
+        }
+
+        @Override
+        public void removeInventoryListener() {
+
+        }
+
+        @Override
+        public void removeTitleListener() {
+
+        }
+
+        @Override
+        public void reregisterEfficencyMechanicListener(EfficiencyMechanicFactory efficiencyMechanicFactory) {
+
+        }
+
+        @Override public String getLatestMCVersion() {
+            return "1.21.8"; // TODO: update for the next mc update
+        }
+
+        @Override public boolean isNewer(SnapshotVersion snapshot) {
+            return true; // no way to know
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
@@ -1,0 +1,75 @@
+package io.th0rgal.oraxen.packets;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
+import io.th0rgal.oraxen.packets.packetevents.InventoryPacketListener;
+import io.th0rgal.oraxen.packets.packetevents.ScoreboardPacketListener;
+import io.th0rgal.oraxen.packets.packetevents.TitlePacketListener;
+import io.th0rgal.oraxen.packets.packetevents.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
+import io.th0rgal.oraxen.utils.SnapshotVersion;
+
+public class PacketEventsAdapter implements PacketAdapter {
+    private PacketListenerCommon titlePacketListener;
+    private PacketListenerCommon inventoryPacketListener;
+
+    private PacketListenerCommon efficiencyMechanicListener;
+
+    @Override
+    public boolean isEnabled() {
+        return PacketAdapter.isPacketEventsEnabled();
+    }
+
+    @Override
+    public void registerInventoryListener() {
+        inventoryPacketListener = register(new InventoryPacketListener(), PacketListenerPriority.MONITOR);
+    }
+
+    @Override
+    public void registerScoreboardListener() {
+        register(new ScoreboardPacketListener(), PacketListenerPriority.MONITOR);
+    }
+
+    @Override
+    public void registerTitleListener() {
+        titlePacketListener = register(new TitlePacketListener(), PacketListenerPriority.MONITOR);
+    }
+
+    @Override
+    public void removeInventoryListener() {
+        if(inventoryPacketListener != null)
+            PacketEvents.getAPI().getEventManager().unregisterListener(inventoryPacketListener);
+        inventoryPacketListener = null;
+    }
+
+    @Override
+    public void removeTitleListener() {
+        if(titlePacketListener != null)
+            PacketEvents.getAPI().getEventManager().unregisterListener(titlePacketListener);
+        titlePacketListener = null;
+    }
+
+    @Override
+    public void reregisterEfficencyMechanicListener(EfficiencyMechanicFactory efficiencyMechanicFactory) {
+        if (efficiencyMechanicListener != null)
+            PacketEvents.getAPI().getEventManager().unregisterListener(efficiencyMechanicListener);
+        efficiencyMechanicListener =register(new EfficiencyMechanicListener(efficiencyMechanicFactory), PacketListenerPriority.LOW);
+    }
+
+    @Override
+    public String getLatestMCVersion() {
+        return ServerVersion.getLatest().getReleaseName();
+    }
+
+    @Override
+    public boolean isNewer(SnapshotVersion snapshot) {
+        return true; // no way to know
+    }
+
+    private PacketListenerCommon register(PacketListener listener, PacketListenerPriority priority) {
+        return PacketEvents.getAPI().getEventManager().registerListener(listener, priority);
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
@@ -5,6 +5,7 @@ import com.github.retrooper.packetevents.event.PacketListener;
 import com.github.retrooper.packetevents.event.PacketListenerCommon;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import io.th0rgal.oraxen.packets.packetevents.InventoryPacketListener;
 import io.th0rgal.oraxen.packets.packetevents.ScoreboardPacketListener;
@@ -13,6 +14,8 @@ import io.th0rgal.oraxen.packets.packetevents.mechanics.provided.gameplay.effici
 import io.th0rgal.oraxen.utils.SnapshotVersion;
 
 public class PacketEventsAdapter implements PacketAdapter {
+    private PacketListenerCommon scoreboardPacketListener;
+
     private PacketListenerCommon titlePacketListener;
     private PacketListenerCommon inventoryPacketListener;
 
@@ -25,16 +28,28 @@ public class PacketEventsAdapter implements PacketAdapter {
 
     @Override
     public void registerInventoryListener() {
+        if(inventoryPacketListener!= null) {
+            OraxenPlugin.get().getLogger().severe("[PacketEventsAdapter]: Inventory Listener is already registered!");
+            return;
+        }
         inventoryPacketListener = register(new InventoryPacketListener(), PacketListenerPriority.MONITOR);
     }
 
     @Override
     public void registerScoreboardListener() {
-        register(new ScoreboardPacketListener(), PacketListenerPriority.MONITOR);
+        if(scoreboardPacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[PacketEventsAdapter]: Scoreboard Listener is already registered!");
+            return;
+        }
+        scoreboardPacketListener = register(new ScoreboardPacketListener(), PacketListenerPriority.MONITOR);
     }
 
     @Override
     public void registerTitleListener() {
+        if(titlePacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[PacketEventsAdapter]: Title Listener is already registered!");
+            return;
+        }
         titlePacketListener = register(new TitlePacketListener(), PacketListenerPriority.MONITOR);
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.packets;
 
 import com.comphenix.protocol.ProtocolLibrary;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.packets.protocollib.InventoryPacketListener;
 import io.th0rgal.oraxen.packets.protocollib.ScoreboardPacketListener;
 import io.th0rgal.oraxen.packets.protocollib.TitlePacketListener;
@@ -13,6 +14,8 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 public class ProtocolLibAdapter implements PacketAdapter {
+    private ScoreboardPacketListener scoreboardPacketListener;
+
     private InventoryPacketListener inventoryPacketListener;
     private TitlePacketListener titlePacketListener;
 
@@ -25,17 +28,30 @@ public class ProtocolLibAdapter implements PacketAdapter {
 
     @Override
     public void registerInventoryListener() {
+        if(inventoryPacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[ProtocolLibAdapter]: Inventory Listener is already registered!");
+            return;
+        }
         inventoryPacketListener = new InventoryPacketListener();
         ProtocolLibrary.getProtocolManager().addPacketListener(inventoryPacketListener);
     }
 
     @Override
     public void registerScoreboardListener() {
-        ProtocolLibrary.getProtocolManager().addPacketListener(new ScoreboardPacketListener());
+        if(scoreboardPacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[ProtocolLibAdapter]: Scoreboard Listener is already registered!");
+            return;
+        }
+        scoreboardPacketListener = new ScoreboardPacketListener();
+        ProtocolLibrary.getProtocolManager().addPacketListener(scoreboardPacketListener);
     }
 
     @Override
     public void registerTitleListener() {
+        if(titlePacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[ProtocolLibAdapter]: Title Listener is already registered!");
+            return;
+        }
         titlePacketListener = new TitlePacketListener();
         ProtocolLibrary.getProtocolManager().addPacketListener(titlePacketListener);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
@@ -1,0 +1,78 @@
+package io.th0rgal.oraxen.packets;
+
+import com.comphenix.protocol.ProtocolLibrary;
+import io.th0rgal.oraxen.packets.protocollib.InventoryPacketListener;
+import io.th0rgal.oraxen.packets.protocollib.ScoreboardPacketListener;
+import io.th0rgal.oraxen.packets.protocollib.TitlePacketListener;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
+import io.th0rgal.oraxen.packets.protocollib.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
+import io.th0rgal.oraxen.utils.SnapshotVersion;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public class ProtocolLibAdapter implements PacketAdapter {
+    private InventoryPacketListener inventoryPacketListener;
+    private TitlePacketListener titlePacketListener;
+
+    private EfficiencyMechanicListener efficiencyMechanicListener;
+
+    @Override
+    public boolean isEnabled() {
+        return PacketAdapter.isProtocolLibEnabled();
+    }
+
+    @Override
+    public void registerInventoryListener() {
+        inventoryPacketListener = new InventoryPacketListener();
+        ProtocolLibrary.getProtocolManager().addPacketListener(inventoryPacketListener);
+    }
+
+    @Override
+    public void registerScoreboardListener() {
+        ProtocolLibrary.getProtocolManager().addPacketListener(new ScoreboardPacketListener());
+    }
+
+    @Override
+    public void registerTitleListener() {
+        titlePacketListener = new TitlePacketListener();
+        ProtocolLibrary.getProtocolManager().addPacketListener(titlePacketListener);
+    }
+
+    @Override public void removeInventoryListener() {
+        if (inventoryPacketListener != null)
+            ProtocolLibrary.getProtocolManager().removePacketListener(inventoryPacketListener);
+        inventoryPacketListener = null;
+    }
+
+    @Override public void removeTitleListener() {
+        if (titlePacketListener != null)
+            ProtocolLibrary.getProtocolManager().removePacketListener(titlePacketListener);
+        titlePacketListener = null;
+    }
+
+    @Override
+    public void reregisterEfficencyMechanicListener(EfficiencyMechanicFactory efficiencyMechanicFactory) {
+        if (efficiencyMechanicListener != null)
+            ProtocolLibrary.getProtocolManager().removePacketListener(efficiencyMechanicListener);
+        efficiencyMechanicListener = new EfficiencyMechanicListener(efficiencyMechanicFactory);
+        ProtocolLibrary.getProtocolManager().addPacketListener(efficiencyMechanicListener);
+    }
+
+    @Override public String getLatestMCVersion() {
+        return ProtocolLibrary.MAXIMUM_MINECRAFT_VERSION;
+    }
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+
+    @Override
+    public boolean isNewer(SnapshotVersion snapshot) {
+        try {
+            return snapshot.getSnapshotDate().after(DATE_FORMAT.parse(ProtocolLibrary.MINECRAFT_LAST_RELEASE_DATE));
+        } catch (ParseException ignored) {
+            // will never happen we know what format the date has.
+            return true;
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/InventoryPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/InventoryPacketListener.java
@@ -1,0 +1,15 @@
+package io.th0rgal.oraxen.packets.packetevents;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenWindow;
+import io.th0rgal.oraxen.utils.PacketHelpers;
+
+public class InventoryPacketListener implements PacketListener {
+    @Override public void onPacketSend(PacketSendEvent event) {
+        if(event.getPacketType() != PacketType.Play.Server.OPEN_WINDOW) return;
+        var wrapper = new WrapperPlayServerOpenWindow(event);
+        wrapper.setTitle(PacketHelpers.translateTitle(wrapper.getTitle()));
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/ScoreboardPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/ScoreboardPacketListener.java
@@ -1,0 +1,19 @@
+package io.th0rgal.oraxen.packets.packetevents;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.score.ScoreFormat;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerScoreboardObjective;
+import net.kyori.adventure.text.Component;
+
+public class ScoreboardPacketListener implements PacketListener {
+    private final ScoreFormat numberFormat = ScoreFormat.fixedScore(Component.text("test"));
+
+    @Override public void onPacketSend(PacketSendEvent event) {
+        if(event.getPacketType() != PacketType.Play.Server.SCOREBOARD_OBJECTIVE) return;
+        var wrapper = new WrapperPlayServerScoreboardObjective(event);
+        if(wrapper.getMode() == WrapperPlayServerScoreboardObjective.ObjectiveMode.REMOVE) return;
+        wrapper.setScoreFormat(numberFormat);
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/TitlePacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/TitlePacketListener.java
@@ -1,0 +1,29 @@
+package io.th0rgal.oraxen.packets.packetevents;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerActionBar;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleSubtitle;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleText;
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.PacketHelpers;
+
+import static com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Server.ACTION_BAR;
+import static com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Server.SET_TITLE_SUBTITLE;
+import static com.github.retrooper.packetevents.protocol.packettype.PacketType.Play.Server.SET_TITLE_TEXT;
+
+public class TitlePacketListener implements PacketListener {
+    @Override
+    public void onPacketSend(PacketSendEvent event) {
+        if(event.getPacketType() == SET_TITLE_TEXT  && Settings.FORMAT_TITLES.toBool()) {
+            var wrapper = new WrapperPlayServerSetTitleText(event);
+            wrapper.setTitle(PacketHelpers.translateTitle(wrapper.getTitle()));
+        } else if(event.getPacketType() == SET_TITLE_SUBTITLE && Settings.FORMAT_SUBTITLES.toBool()) {
+            var wrapper = new WrapperPlayServerSetTitleSubtitle(event);
+            wrapper.setSubtitle(PacketHelpers.translateTitle(wrapper.getSubtitle()));
+        } else if(event.getPacketType() == ACTION_BAR && Settings.FORMAT_ACTION_BAR.toBool()) {
+            var wrapper = new WrapperPlayServerActionBar(event);
+            wrapper.setActionBarText(PacketHelpers.translateTitle(wrapper.getActionBarText()));
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/mechanics/provided/gameplay/efficiency/EfficiencyMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/mechanics/provided/gameplay/efficiency/EfficiencyMechanicListener.java
@@ -1,0 +1,50 @@
+package io.th0rgal.oraxen.packets.packetevents.mechanics.provided.gameplay.efficiency;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.DiggingAction;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+
+public class EfficiencyMechanicListener implements PacketListener {
+
+    private final EfficiencyMechanicFactory factory;
+
+    public EfficiencyMechanicListener(final EfficiencyMechanicFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() != PacketType.Play.Client.PLAYER_DIGGING) return;
+
+        final Player player = event.getPlayer();
+        if (player.getGameMode() == GameMode.CREATIVE) return;
+
+        final var wrapper = new WrapperPlayClientPlayerDigging(event);
+
+        final ItemStack item = player.getInventory().getItemInMainHand();
+        final String itemID = OraxenItems.getIdByItem(item);
+        if (factory.isNotImplementedIn(itemID))
+            return;
+        final EfficiencyMechanic mechanic = (EfficiencyMechanic) factory.getMechanic(itemID);
+        if (wrapper.getAction() == DiggingAction.START_DIGGING) {
+            Bukkit.getScheduler().runTask(OraxenPlugin.get(), () ->
+                player.addPotionEffect(new PotionEffect(mechanic.getType(),
+                    20 * 60 * 5,
+                    mechanic.getAmount() - 1,
+                    false, false, false)));
+        } else {
+            Bukkit.getScheduler().runTask(OraxenPlugin.get(), () ->
+                player.removePotionEffect(mechanic.getType()));
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/InventoryPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/InventoryPacketListener.java
@@ -1,4 +1,4 @@
-package io.th0rgal.oraxen.font.packets;
+package io.th0rgal.oraxen.packets.protocollib;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerPriority;

--- a/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/ScoreboardPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/ScoreboardPacketListener.java
@@ -1,7 +1,11 @@
-package io.th0rgal.oraxen.font.packets;
+package io.th0rgal.oraxen.packets.protocollib;
 
 import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.events.*;
+import com.comphenix.protocol.events.InternalStructure;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedNumberFormat;
 import io.th0rgal.oraxen.OraxenPlugin;

--- a/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/TitlePacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/TitlePacketListener.java
@@ -1,4 +1,4 @@
-package io.th0rgal.oraxen.font.packets;
+package io.th0rgal.oraxen.packets.protocollib;
 
 import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
@@ -23,7 +23,6 @@ public class TitlePacketListener extends PacketAdapter {
     @Override
     public void onPacketSending(PacketEvent event) {
         PacketContainer packet = event.getPacket();
-
         if (packet.getType() == SET_TITLE_TEXT && Settings.FORMAT_TITLES.toBool()) {
             WrappedChatComponent title = formatTitle(packet);
             if (title != null) packet.getChatComponents().write(0, title);

--- a/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/mechanics/provided/gameplay/efficiency/EfficiencyMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/mechanics/provided/gameplay/efficiency/EfficiencyMechanicListener.java
@@ -1,4 +1,4 @@
-package io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency;
+package io.th0rgal.oraxen.packets.protocollib.mechanics.provided.gameplay.efficiency;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerPriority;
@@ -9,6 +9,8 @@ import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.wrappers.EnumWrappers;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanic;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
@@ -1,6 +1,5 @@
 package io.th0rgal.oraxen.recipes.loaders;
 
-import io.lumine.mythiccrucible.MythicCrucible;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;

--- a/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
+++ b/core/src/main/java/io/th0rgal/oraxen/sound/CustomSound.java
@@ -178,9 +178,7 @@ public class CustomSound {
         songJson.add("sound_event", soundEvent);
 
         // Add jukebox-specific properties
-        JsonObject description = new JsonObject();
-        description.addProperty("text", AdventureUtils.LEGACY_SERIALIZER.serialize(getDescription()));
-        songJson.add("description", description);
+        songJson.add("description", AdventureUtils.GSON_SERIALIZER.serializeToTree(getDescription()));
 
         songJson.addProperty("length_in_seconds", getLengthInSeconds());
         songJson.addProperty("comparator_output", getComparatorOutput());

--- a/core/src/main/java/io/th0rgal/oraxen/utils/MinecraftVersion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/MinecraftVersion.java
@@ -17,15 +17,13 @@
 
 package io.th0rgal.oraxen.utils;
 
-import com.comphenix.protocol.ProtocolLibrary;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
+import io.th0rgal.oraxen.OraxenPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -213,11 +211,9 @@ public final class MinecraftVersion implements Comparable<MinecraftVersion>, Ser
             try {
                 // Determine if the snapshot is newer than the current release version
                 snapshot = new SnapshotVersion(section[0]);
-                SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
-
-                MinecraftVersion latest = new MinecraftVersion(ProtocolLibrary.MAXIMUM_MINECRAFT_VERSION, false);
-                boolean newer = snapshot.getSnapshotDate().compareTo(
-                        format.parse(ProtocolLibrary.MINECRAFT_LAST_RELEASE_DATE)) > 0;
+                var adapter = OraxenPlugin.get().getPacketAdapter();
+                MinecraftVersion latest = new MinecraftVersion(adapter.getLatestMCVersion(), false);
+                boolean newer = adapter.isNewer(snapshot);
 
                 numbers[0] = latest.getMajor();
                 numbers[1] = latest.getMinor() + (newer ? 1 : -1);

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PacketHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PacketHelpers.java
@@ -1,6 +1,10 @@
 package io.th0rgal.oraxen.utils;
 
+import net.kyori.adventure.text.Component;
+
 public class PacketHelpers {
+
+    public static final String BACKSLASH_REMOVAL_REGEX = "\\\\(?!u)(?!n)(?!\")";
 
     // Serialize initial string from json to component, then parse to handle tags and serialize again to json string
     public static String readJson(String text) {
@@ -8,6 +12,13 @@ public class PacketHelpers {
     }
 
     public static String toJson(String text) {
-        return AdventureUtils.GSON_SERIALIZER.serialize(AdventureUtils.MINI_MESSAGE.deserialize(text)).replaceAll("\\\\(?!u)(?!n)(?!\")", "");
+        return AdventureUtils.GSON_SERIALIZER.serialize(AdventureUtils.MINI_MESSAGE.deserialize(text)).replaceAll(BACKSLASH_REMOVAL_REGEX, "");
+    }
+
+    public static Component translateTitle(Component component) {
+        return AdventureUtils.MINI_MESSAGE.deserialize(
+            AdventureUtils.parseMiniMessageThroughLegacy(component)
+                .replaceAll("\\\\(?!u)(?!n)(?!\")", "")
+        );
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/PacketEventsBreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/PacketEventsBreakerSystem.java
@@ -1,0 +1,57 @@
+package io.th0rgal.oraxen.utils.breaker;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.DiggingAction;
+import com.github.retrooper.packetevents.util.Vector3i;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPlayerDigging;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockBreakAnimation;
+import io.th0rgal.oraxen.OraxenPlugin;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+
+public class PacketEventsBreakerSystem extends BreakerSystem {
+    private final PacketListener listener = new PacketListener() {
+        @Override public void onPacketReceive(PacketReceiveEvent event) {
+            if (!event.getPacketType().equals(PacketType.Play.Client.PLAYER_DIGGING)) return;
+            final var wrapper = new WrapperPlayClientPlayerDigging(event);
+            final Player player = event.getPlayer();
+
+            final Vector3i pos = wrapper.getBlockPosition();
+            BlockFace blockFace;
+            try {
+                blockFace = BlockFace.valueOf(wrapper.getBlockFace().name());
+            } catch (IllegalArgumentException e) {
+                OraxenPlugin.get().getLogger().warning("[PacketEvents] Failed to decode BlockFace: " + wrapper.getBlockFace().name());
+                blockFace = BlockFace.UP;
+            }
+
+            final World world = player.getWorld();
+            final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+            final Location location = block.getLocation();
+
+            handleEvent(player, block, location, blockFace, world, () -> event.setCancelled(true), wrapper.getAction() == DiggingAction.START_DIGGING);
+        }
+    };
+
+    @Override
+    protected void sendBlockBreak(final Player player, final Location location, final int stage) {
+        var wrapper = new WrapperPlayServerBlockBreakAnimation(
+            player.getEntityId(),
+            new Vector3i(location.getBlockX(), location.getBlockY(), location.getBlockZ()),
+            (byte) stage
+        );
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, wrapper);
+    }
+
+    @Override
+    public void registerListener() {
+        PacketEvents.getAPI().getEventManager().registerListener(listener, PacketListenerPriority.LOWEST);
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/ProtocolLibBreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/ProtocolLibBreakerSystem.java
@@ -1,0 +1,65 @@
+package io.th0rgal.oraxen.utils.breaker;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.reflect.StructureModifier;
+import com.comphenix.protocol.wrappers.BlockPosition;
+import com.comphenix.protocol.wrappers.EnumWrappers;
+import io.th0rgal.oraxen.OraxenPlugin;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class ProtocolLibBreakerSystem extends BreakerSystem {
+    private final PacketAdapter listener = new PacketAdapter(OraxenPlugin.get(),
+        ListenerPriority.LOW, PacketType.Play.Client.BLOCK_DIG) {
+        @Override
+        public void onPacketReceiving(final PacketEvent event) {
+            final PacketContainer packet = event.getPacket();
+            final Player player = event.getPlayer();
+            final ItemStack item = player.getInventory().getItemInMainHand();
+            if (player.getGameMode() == GameMode.CREATIVE) return;
+
+            final StructureModifier<BlockPosition> dataTemp = packet.getBlockPositionModifier();
+            final StructureModifier<EnumWrappers.Direction> dataDirection = packet.getDirections();
+            final StructureModifier<EnumWrappers.PlayerDigType> data = packet
+                .getEnumModifier(EnumWrappers.PlayerDigType.class, 2);
+            EnumWrappers.PlayerDigType type;
+            try {
+                type = data.getValues().getFirst();
+            } catch (IllegalArgumentException exception) {
+                type = EnumWrappers.PlayerDigType.SWAP_HELD_ITEMS;
+            }
+
+            final BlockPosition pos = dataTemp.getValues().getFirst();
+            final World world = player.getWorld();
+            final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+            final Location location = block.getLocation();
+            final BlockFace blockFace = dataDirection.size() > 0 ?
+                BlockFace.valueOf(dataDirection.read(0).name()) :
+                BlockFace.UP;
+
+            handleEvent(player, block, location, blockFace, world, () -> event.setCancelled(true), type == EnumWrappers.PlayerDigType.START_DESTROY_BLOCK);
+        }
+    };
+
+    @Override
+    protected void sendBlockBreak(final Player player, final Location location, final int stage) {
+        final PacketContainer packet = ProtocolLibrary.getProtocolManager().createPacket(PacketType.Play.Server.BLOCK_BREAK_ANIMATION);
+        packet.getIntegers().write(0, location.hashCode()).write(1, stage);
+        packet.getBlockPositionModifier().write(0, new BlockPosition(location.toVector()));
+
+        ProtocolLibrary.getProtocolManager().sendServerPacket(player, packet);
+    }
+
+    @Override
+    public void registerListener() {
+        ProtocolLibrary.getProtocolManager().addPacketListener(listener);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.192.1
+pluginVersion=1.193.0

--- a/gradle/oraxenLibs.versions.toml
+++ b/gradle/oraxenLibs.versions.toml
@@ -1,0 +1,161 @@
+[versions]
+# often changed version numbers
+adventure = "4.17.0"
+adventure-platform = "4.3.4"
+commandapi = "10.1.2"
+
+actions = "1.0.0-SNAPSHOT"
+
+[libraries]
+
+#
+# Plugin Dependencies
+#
+    # ProtocolLib https://github.com/dmulloy2/ProtocolLib
+    # Repo: Maven Central
+    protocol-lib = { module = "net.dmulloy2:ProtocolLib", version = "5.4.0" }
+    # PacketEvents https://docs.packetevents.com/getting-started
+    # Repo: https://repo.codemc.io/repository/maven-releases/
+    packet-events = { module = "com.github.retrooper:packetevents-spigot", version = "2.9.5" }
+
+
+    # PlaceholderAPI https://github.com/PlaceholderAPI/PlaceholderAPI/wiki/Hook-into-PlaceholderAPI
+    # Repo: https://repo.extendedclip.com/content/repositories/placeholderapi
+    placeholderapi = { module = "me.clip:placeholderapi", version = "2.11.6" }
+
+    # MythicMobs https://git.lumine.io/mythiccraft/MythicMobs/-/wikis/API
+    # Repo: https://mvn.lumine.io/repository/maven-public/
+    mythicmobs = { module = "io.lumine:Mythic-Dist", version = "5.7.0-SNAPSHOT" }
+    # https://git.lumine.io/mythiccraft/mythiccrucible
+    # Repo: https://mvn.lumine.io/repository/maven-public/
+    mythic-crucible = { module = "io.lumine:MythicCrucible-API", version = "2.2.0-SNAPSHOT" }
+
+    # MMOItems https://gitlab.com/phoenix-dvpmt/mmoitems
+    # Repo: https://nexus.phoenixdevt.fr/repository/maven-public/
+    mmoitems = { module = "net.Indyuce:MMOItems-API", version = "6.9.5-SNAPSHOT" }
+    mythic-lib-dist = { module = "io.lumine:MythicLib-dist", version = "1.7.1-SNAPSHOT" }
+
+    # WorldEdit https://worldedit.enginehub.org/en/latest/api/
+    # Repo: https://maven.enginehub.org/repo/
+    worldedit-bukkit = { module = "com.sk89q.worldedit:worldedit-bukkit", version = "7.4.0-SNAPSHOT" }
+
+    # ModelEngine https://git.lumine.io/mythiccraft/model-engine-4/-/wikis/API
+    # Repo: https://mvn.lumine.io/repository/maven-public/
+    modelengine = { module = "com.ticxo.modelengine:ModelEngine", version = "R4.0.9" }
+    modelengine-api = { module = "com.ticxo.modelengine:api", version = "R3.1.8" } # not needed just an older version of ModelEngine
+
+    # EcoItems https://plugins.auxilor.io/ecoitems/api
+    # Repo: https://repo.auxilor.io/repository/maven-public/
+    ecoitems = { module = "com.willfp:EcoItems", version = "5.64.0" }
+    eco = { module = "com.willfp:eco", version = "6.73.0" }
+    libreforge = { module = "com.willfp:libreforge", version = "4.36.0" }
+
+    # BlockLocker https://github.com/rutgerkok/BlockLocker
+    # Repo: https://repo.codemc.org/repository/maven-public/
+    blocklocker = { module = "nl.rutgerkok:blocklocker", version = "1.13-SNAPSHOT" }
+
+    #
+    # Libraries that are included in MC
+    # But are not exposed
+    #
+    commons-io = { module = "commons-io:commons-io", version = "2.11.0" }
+
+#
+# Libraries that are in Maven Central
+# And therefore can be in the plugins.yml > libraries section
+#
+    gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
+    commons-lang3 = { module = "org.apache.commons:commons-lang3", version = "3.14.0" }
+    joml = { module = "org.joml:joml", version = "1.10.5" }  # Because pre 1.19.4 api does not have this in the server-jar
+    annotations = { module = "org.jetbrains:annotations", version = "26.0.2" }
+
+    # Adventure
+    adventure-minimessage = { module = "net.kyori:adventure-text-minimessage", version.ref = "adventure" }
+    adventure-plain = { module = "net.kyori:adventure-text-serializer-plain", version.ref = "adventure" }
+    adventure-ansi = { module = "net.kyori:adventure-text-serializer-ansi", version.ref = "adventure" }
+    adventure-platform = { module = "net.kyori:adventure-platform-bukkit", version.ref = "adventure-platform" }
+
+    # Actions https://github.com/iGabyTM/actions
+    actions-core = { module = "me.gabytm.util:actions-core", version.ref = "actions" }
+    actions-spigot = { module = "me.gabytm.util:actions-spigot", version.ref = "actions" }
+
+    # Spring Expressions
+    spring-expression = { module = "org.springframework:spring-expression", version = "6.0.6" }
+
+    # MCLogs https://github.com/aternosorg/mclogs
+    mc-logs = { module = "gs.mclo:java", version = "2.2.1" }
+
+    # http https://hc.apache.org/httpcomponents-client-5.5.x/
+    # No clue where its used in the code tho??
+    http = {module = "org.apache.httpcomponents:httpmime", version = "4.5.13"}
+
+#
+# Libraries that are shaded and relocated
+#
+
+    # BStats https://github.com/Bastian/bstats-metrics
+    # Repo: Maven Central
+    bstats = { module = "org.bstats:bstats-bukkit", version = "3.1.0" }
+
+    # Creative API https://github.com/unnamed/creative
+    # Repo: Maven Central
+    creative = { module = "team.unnamed:creative-api", version = "1.7.3" }
+
+    # CommandAPI https://commandapi-live-docs.jorel.dev/setup_dev.html
+    # Repo: Maven Central
+    commandapi = { module = "dev.jorel:commandapi-bukkit-shade", version.ref = "commandapi" }
+
+    # JSON
+    javax-json = { module = "org.glassfish:javax.json", version = "1.1.4" }
+
+    # ProtectionLib
+    # Repo: https://repo.oraxen.com/releases/
+    protectionlib = { module = "io.th0rgal:protectionlib", version = "1.8.0" }
+
+    # InventoryFramework https://github.com/stefvanschie/IF
+    # Repo: Maven Central
+    inventoryframework = { module = "com.github.stefvanschie.inventoryframework:IF", version = "0.11.3" }
+
+    # Repo: Maven Central
+    # https://github.com/mfnalex/CustomBlockData
+    custom-block-data = { module = "com.jeff-media:custom-block-data", version = "2.2.5" }
+    # https://github.com/mfnalex/MorePersistentDataTypes
+    more-persistent-data-types = { module = "com.jeff-media:MorePersistentDataTypes", version = "2.4.0" }
+    # https://github.com/mfnalex/PersistentDataSerializer
+    persistent-data-serializer = { module = "com.jeff-media:persistent-data-serializer", version = "1.0" }
+
+    # Triumph GUI https://github.com/TriumphTeam/triumph-gui
+    # Repo: Maven Central
+    triumph-gui = { module = "dev.triumphteam:triumph-gui", version = "3.1.10" }
+
+[bundles]
+# libraries that are included somewher but not exposed
+libraries-included = [
+    "commons-io", # included in minecraft
+    "actions-core" # included in actions-spigot
+]
+libraries-bukkit = ["spring-expression", "http", "joml",
+    "adventure-ansi", "adventure-minimessage", "adventure-plain", "adventure-platform",
+    "gson", "commons-lang3", "mc-logs",
+    "creative"
+]
+libraries-shade = [
+    "bstats", "annotations",
+    "triumph-gui", "commandapi",
+    "javax-json", "protectionlib",
+    "inventoryframework",
+    "custom-block-data", "more-persistent-data-types", "persistent-data-serializer",
+    "actions-spigot"
+]
+plugins = [
+    "mythic-lib-dist", "mmoitems", # mmo items
+    "mythic-crucible",  # mythic curcible
+    "mythicmobs", # MythicMobs
+    "modelengine", # Model Engine
+    "packet-events", # PacketEvents
+    "protocol-lib", # ProtocolLib
+    "placeholderapi", # PlaceholderAPI
+    "worldedit-bukkit", # WorldEdit
+    "eco", "libreforge", "ecoitems", # EcoÍtems
+    "blocklocker", # BlockLocker
+]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,15 +8,22 @@ pluginManagement {
     }
 }
 
+plugins {
+    // allows for better class redefinitions with run-paper
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 dependencyResolutionManagement {
-    repositories {
-        maven("https://repo.mineinabyss.com/releases")
-        maven("https://repo.mineinabyss.com/snapshots")
-        mavenLocal()
-    }
+//    repositories {
+//        maven("https://repo.mineinabyss.com/releases")
+//        maven("https://repo.mineinabyss.com/snapshots")
+//        mavenLocal()
+//    }
 
     versionCatalogs {
-        create("oraxenLibs").from(files("gradle/oraxenLibs.versions.toml"))
+        create("oraxenLibs") {
+            from(files("gradle/oraxenLibs.versions.toml"))
+        }
     }
 }
 

--- a/v1_20_R1/build.gradle.kts
+++ b/v1_20_R1/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.20.1-R0.1-SNAPSHOT")

--- a/v1_20_R2/build.gradle.kts
+++ b/v1_20_R2/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.20.2-R0.1-SNAPSHOT")

--- a/v1_20_R3/build.gradle.kts
+++ b/v1_20_R3/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.20.4-R0.1-SNAPSHOT")

--- a/v1_20_R4/build.gradle.kts
+++ b/v1_20_R4/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.20.6-R0.1-SNAPSHOT")

--- a/v1_21_R1/build.gradle.kts
+++ b/v1_21_R1/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.21-R0.1-SNAPSHOT")

--- a/v1_21_R2/build.gradle.kts
+++ b/v1_21_R2/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/") // Paper
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.21.3-R0.1-SNAPSHOT")

--- a/v1_21_R3/build.gradle.kts
+++ b/v1_21_R3/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/")
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.21.4-R0.1-SNAPSHOT")

--- a/v1_21_R4/build.gradle.kts
+++ b/v1_21_R4/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/")
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.21.5-no-moonrise-SNAPSHOT")

--- a/v1_21_R5/build.gradle.kts
+++ b/v1_21_R5/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("io.github.goooler.shadow") version "8.1.8"
 }
 
-repositories {
-    maven("https://repo.papermc.io/repository/maven-public/")
-}
-
 dependencies {
     compileOnly(project(":core"))
     paperweight.paperDevBundle("1.21.8-R0.1-SNAPSHOT")


### PR DESCRIPTION
This PR adds compatibility for the use of PacketEvents as an alternative to ProtocolLib

the code should do 1:1 what ProtocolLib would do except parsing of snapshot cannot be done reliably since how it was done was to use the field of ProtocolLib to get the release date of the newest version.

I would appreciate if someone tested this before releasing tho.

this is based on #1650 so merge that first.