### PR TITLE
Fixes breaking blocks with PacketEvents

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/commands/ReportCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/ReportCommand.java
@@ -9,52 +9,53 @@ public class ReportCommand {
 
     CommandAPICommand getReportCommand() {
         return new CommandAPICommand("report")
-                .withPermission("oraxen.command.report")
-                .executes((sender, args) -> {
-                    // Get Oraxen version
-                    String oraxenVersion = OraxenPlugin.get().getDescription().getVersion();
+            .withPermission("oraxen.command.report")
+            .executes((sender, args) -> {
+                // Get Oraxen version
+                String oraxenVersion = OraxenPlugin.get().getDescription().getVersion();
 
-                    // Get ProtocolLib version
-                    Plugin protocolLib = Bukkit.getPluginManager().getPlugin("ProtocolLib");
-                    String protocolLibVersion = protocolLib != null ? protocolLib.getDescription().getVersion()
-                            : "Not installed";
+                // Get Protocol Library version
+                Plugin protocolPlugin = OraxenPlugin.get().getPacketAdapter().getPlugin();
+                Bukkit.getPluginManager().getPlugin("ProtocolLib");
+                String protocolLibVersion = protocolPlugin != null ? protocolPlugin.getName() + "-" + protocolPlugin.getDescription().getVersion()
+                    : "Not installed";
 
-                    // Get server info
-                    String serverSoftware = Bukkit.getName();
-                    String serverVersion = Bukkit.getVersion();
+                // Get server info
+                String serverSoftware = Bukkit.getName();
+                String serverVersion = Bukkit.getVersion();
 
-                    // Get OS info
-                    String osName = System.getProperty("os.name");
-                    String osVersion = System.getProperty("os.version");
-                    String osArch = System.getProperty("os.arch");
+                // Get OS info
+                String osName = System.getProperty("os.name");
+                String osVersion = System.getProperty("os.version");
+                String osArch = System.getProperty("os.arch");
 
-                    // Format report
-                    String report = String.format("""
+                // Format report
+                String report = String.format("""
+                        
+                        ### System Report
+                        **Plugin Versions:**
+                        - Oraxen: %s
+                        - ProtocolAPI: %s
+                        
+                        **Server Information:**
+                        - Software: %s
+                        - Version: %s
+                        
+                        **System Information:**
+                        - OS: %s
+                        - OS Version: %s
+                        - Architecture: %s
+                        """,
+                    oraxenVersion,
+                    protocolLibVersion,
+                    serverSoftware,
+                    serverVersion,
+                    osName,
+                    osVersion,
+                    osArch);
 
-                            ### System Report
-                            **Plugin Versions:**
-                            - Oraxen: %s
-                            - ProtocolLib: %s
-
-                            **Server Information:**
-                            - Software: %s
-                            - Version: %s
-
-                            **System Information:**
-                            - OS: %s
-                            - OS Version: %s
-                            - Architecture: %s
-                            """,
-                            oraxenVersion,
-                            protocolLibVersion,
-                            serverSoftware,
-                            serverVersion,
-                            osName,
-                            osVersion,
-                            osArch);
-
-                    // Send report to sender
-                    sender.sendMessage(report);
-                });
+                // Send report to sender
+                sender.sendMessage(report);
+            });
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -48,7 +48,7 @@ import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureM
 public class FurnitureListener implements Listener {
 
     public FurnitureListener() {
-        if (PluginUtils.isEnabled("ProtocolLib"))
+        if (OraxenPlugin.get().getPacketAdapter().isEnabled())
             BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -43,7 +43,7 @@ import static io.th0rgal.oraxen.utils.BlockHelpers.isLoaded;
 public class NoteBlockMechanicListener implements Listener {
 
     public NoteBlockMechanicListener() {
-        if (PluginUtils.isEnabled("ProtocolLib")) BreakerSystem.MODIFIERS.add(getHardnessModifier());
+        if (OraxenPlugin.get().getPacketAdapter().isEnabled()) BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 
     public static class NoteBlockMechanicPaperListener implements Listener {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -41,7 +41,7 @@ import java.util.Random;
 public class StringBlockMechanicListener implements Listener {
 
     public StringBlockMechanicListener() {
-        if (PluginUtils.isEnabled("ProtocolLib"))
+        if (OraxenPlugin.get().getPacketAdapter().isEnabled())
             BreakerSystem.MODIFIERS.add(getHardnessModifier());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
@@ -3,6 +3,8 @@ package io.th0rgal.oraxen.packets;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.SnapshotVersion;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -28,6 +30,7 @@ public interface PacketAdapter {
 
     String getLatestMCVersion();
     boolean isNewer(SnapshotVersion snapshot);
+    @Nullable Plugin getPlugin();
     public static class EmptyAdapter implements PacketAdapter {
         @Override
         public boolean isEnabled() {
@@ -67,6 +70,12 @@ public interface PacketAdapter {
 
         @Override public boolean isNewer(SnapshotVersion snapshot) {
             return true; // no way to know
+        }
+
+        @Nullable
+        @Override
+        public Plugin getPlugin() {
+            return null;
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
@@ -12,6 +12,9 @@ import io.th0rgal.oraxen.packets.packetevents.ScoreboardPacketListener;
 import io.th0rgal.oraxen.packets.packetevents.TitlePacketListener;
 import io.th0rgal.oraxen.packets.packetevents.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
 import io.th0rgal.oraxen.utils.SnapshotVersion;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 public class PacketEventsAdapter implements PacketAdapter {
     private PacketListenerCommon scoreboardPacketListener;
@@ -82,6 +85,12 @@ public class PacketEventsAdapter implements PacketAdapter {
     @Override
     public boolean isNewer(SnapshotVersion snapshot) {
         return true; // no way to know
+    }
+
+    @Nullable
+    @Override
+    public Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("PacketEvents");
     }
 
     private PacketListenerCommon register(PacketListener listener, PacketListenerPriority priority) {

--- a/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
@@ -8,6 +8,9 @@ import io.th0rgal.oraxen.packets.protocollib.TitlePacketListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import io.th0rgal.oraxen.packets.protocollib.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
 import io.th0rgal.oraxen.utils.SnapshotVersion;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -90,5 +93,11 @@ public class ProtocolLibAdapter implements PacketAdapter {
             // will never happen we know what format the date has.
             return true;
         }
+    }
+
+    @Nullable
+    @Override
+    public Plugin getPlugin() {
+        return Bukkit.getPluginManager().getPlugin("ProtocolLib");
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/PacketEventsBreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/PacketEventsBreakerSystem.java
@@ -52,6 +52,6 @@ public class PacketEventsBreakerSystem extends BreakerSystem {
 
     @Override
     public void registerListener() {
-        PacketEvents.getAPI().getEventManager().registerListener(listener, PacketListenerPriority.LOWEST);
+        PacketEvents.getAPI().getEventManager().registerListener(listener, PacketListenerPriority.LOW);
     }
 }


### PR DESCRIPTION
This removes the last occurances of raw ProtocolLib usage that I missed the first time around, this fixes block breaking for all oraxen blocks when using PacketEvents.

This fixes: #1656 