### PR TITLE
Fix misc mechanic false deprecation warnings for unconfigured properties

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanic.java
@@ -28,7 +28,8 @@ public class MiscMechanic extends Mechanic {
         compostable = section.getBoolean("compostable", false);
         allowInVanillaRecipes = section.getBoolean("allow_in_vanilla_recipes", false);
 
-        if (VersionUtil.atOrAbove("1.20.5") && (burnsInFire || burnsInLava)) {
+        if (VersionUtil.atOrAbove("1.20.5") && (burnsInFire || burnsInLava) && 
+            (section.contains("burns_in_fire") || section.contains("burns_in_lava"))) {
             Logs.logWarning(getItemID() + " seems to be using " + (burnsInFire ? "burns_in_fire" : "burns_in_lava") + " which is deprecated....");
             Logs.logWarning("It is heavily advised to swap to the new fire_resistant-property on all 1.20.5+ servers");
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscMechanicFactory.java
@@ -23,10 +23,11 @@ public class MiscMechanicFactory extends MechanicFactory {
         MiscMechanic mechanic = new MiscMechanic(this, section);
 
         if (VersionUtil.atOrAbove("1.21.2")) {
-            if (!mechanic.burnsInLava() || !mechanic.burnsInLava()) {
+            if ((!mechanic.burnsInFire() || !mechanic.burnsInLava()) && 
+                (section.contains("burns_in_fire") || section.contains("burns_in_lava"))) {
                 Logs.logWarning(mechanic.getItemID() + " is using deprecated Misc-Mechanic burns_in_fire/lava...");
                 Logs.logWarning("It is heavily advised to swap to the new `damage_resistant`-component on 1.21.2+ servers...");
-            } else if (!mechanic.breaksFromCactus()) {
+            } else if (!mechanic.breaksFromCactus() && section.contains("breaks_from_cactus")) {
                 Logs.logWarning(mechanic.getItemID() + " is using deprecated Misc-Mechanic breaks_from_cactus...");
                 Logs.logWarning("It is heavily advised to swap to the new `damage_resistant`-component on 1.21.2+ servers...");
             }


### PR DESCRIPTION
## Problem
When using the `misc:` mechanic with only specific properties (e.g., `allow_in_vanilla_recipes: false`), the plugin would incorrectly show deprecation warnings for other properties that weren't explicitly configured.

For example, adding just:
```yaml
misc:
  allow_in_vanilla_recipes: false
```

Would trigger warnings like:
```
[18:19:09 INFO]: Oraxen | [ITEM] seems to be using burns_in_fire which is deprecated....
[18:19:09 INFO]: Oraxen | It is heavily advised to swap to the new fire_resistant-property on all 1.20.5+ servers
```

Even though `burns_in_fire`, `burns_in_lava` or `breaks_from_cactus` were never explicitly set in the item's configuration.

## Root Cause
1. **Buggy condition in MiscMechanicFactory**: Line 26 had `!mechanic.burnsInLava() || !mechanic.burnsInLava()` - calling `burnsInLava()` twice instead of checking both `burnsInFire()` and `burnsInLava()`

2. **Incorrect deprecation logic**: The deprecation warnings were triggered based on property values (which default to `true`) rather than whether the properties were actually configured

## Changes
- `MiscMechanicFactory.java`: Fixed condition logic and added configuration checks
- `MiscMechanic.java`: Added configuration checks for deprecation warnings

## Result
Now deprecation warnings only appear when deprecated properties are explicitly set in the configuration, not when using default values. The `allow_in_vanilla_recipes` functionality no longer triggers false warnings.

