### PR TITLE
feat: Add bleeding mechanic for combat items

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.mechanics;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.events.OraxenNativeMechanicsRegisteredEvent;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
+import io.th0rgal.oraxen.mechanics.provided.combat.bleeding.BleedingMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.combat.lifeleech.LifeLeechMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.combat.spell.energyblast.EnergyBlastMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.combat.spell.fireball.FireballMechanicFactory;
@@ -87,6 +88,7 @@ public class MechanicsManager {
         // combat
         registerFactory("thor", ThorMechanicFactory::new);
         registerFactory("lifeleech", LifeLeechMechanicFactory::new);
+        registerFactory("bleeding", BleedingMechanicFactory::new);
         registerFactory("energyblast", EnergyBlastMechanicFactory::new);
         registerFactory("witherskull", WitherSkullMechanicFactory::new);
         registerFactory("fireball", FireballMechanicFactory::new);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/bleeding/BleedingMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/bleeding/BleedingMechanic.java
@@ -1,0 +1,38 @@
+package io.th0rgal.oraxen.mechanics.provided.combat.bleeding;
+
+import io.th0rgal.oraxen.mechanics.Mechanic;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import org.bukkit.configuration.ConfigurationSection;
+
+public class BleedingMechanic extends Mechanic {
+
+    private final double chance;
+    private final int duration;
+    private final double damagePerTick;
+    private final int tickInterval;
+
+    public BleedingMechanic(MechanicFactory mechanicFactory, ConfigurationSection section) {
+        super(mechanicFactory, section);
+        this.chance = section.getDouble("chance", 0.3);
+        this.duration = section.getInt("duration", 100);
+        this.damagePerTick = section.getDouble("damage_per_tick", 0.5);
+        this.tickInterval = section.getInt("tick_interval", 20);
+    }
+
+    public double getChance() {
+        return chance;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public double getDamagePerTick() {
+        return damagePerTick;
+    }
+
+    public int getTickInterval() {
+        return tickInterval;
+    }
+
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/bleeding/BleedingMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/bleeding/BleedingMechanicFactory.java
@@ -1,0 +1,23 @@
+package io.th0rgal.oraxen.mechanics.provided.combat.bleeding;
+
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.mechanics.Mechanic;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.mechanics.MechanicsManager;
+import org.bukkit.configuration.ConfigurationSection;
+
+public class BleedingMechanicFactory extends MechanicFactory {
+
+    public BleedingMechanicFactory(ConfigurationSection section) {
+        super(section);
+        MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new BleedingMechanicListener(this));
+    }
+
+    @Override
+    public Mechanic parse(ConfigurationSection itemMechanicConfiguration) {
+        Mechanic mechanic = new BleedingMechanic(this, itemMechanicConfiguration);
+        addToImplemented(mechanic);
+        return mechanic;
+    }
+
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/bleeding/BleedingMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/bleeding/BleedingMechanicListener.java
@@ -1,0 +1,86 @@
+package io.th0rgal.oraxen.mechanics.provided.combat.bleeding;
+
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.protectionlib.ProtectionLib;
+import org.bukkit.Bukkit;
+import org.bukkit.Particle;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class BleedingMechanicListener implements Listener {
+
+    private final MechanicFactory factory;
+    private final Map<UUID, BukkitTask> bleedingTasks = new HashMap<>();
+
+    public BleedingMechanicListener(MechanicFactory factory) {
+        this.factory = factory;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onHit(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player damager))
+            return;
+        if (!(event.getEntity() instanceof LivingEntity victim))
+            return;
+        if (!ProtectionLib.canInteract(damager, event.getEntity().getLocation()))
+            return;
+
+        String itemID = OraxenItems.getIdByItem(damager.getInventory().getItemInMainHand());
+        if (!OraxenItems.exists(itemID))
+            return;
+        BleedingMechanic mechanic = (BleedingMechanic) factory.getMechanic(itemID);
+        if (mechanic == null)
+            return;
+
+        if (Math.random() > mechanic.getChance())
+            return;
+
+        applyBleeding(victim, mechanic);
+    }
+
+    private void applyBleeding(LivingEntity victim, BleedingMechanic mechanic) {
+        UUID victimId = victim.getUniqueId();
+
+        if (bleedingTasks.containsKey(victimId)) {
+            bleedingTasks.get(victimId).cancel();
+        }
+
+        final int[] ticksRemaining = {mechanic.getDuration()};
+        
+        BukkitTask task = Bukkit.getScheduler().runTaskTimer(OraxenPlugin.get(), () -> {
+            if (!victim.isValid() || victim.isDead() || ticksRemaining[0] <= 0) {
+                BukkitTask existingTask = bleedingTasks.remove(victimId);
+                if (existingTask != null) {
+                    existingTask.cancel();
+                }
+                return;
+            }
+
+            victim.damage(mechanic.getDamagePerTick());
+            victim.getWorld().spawnParticle(
+                Particle.BLOCK,
+                victim.getLocation().add(0, 1, 0),
+                10,
+                0.3, 0.5, 0.3,
+                0.1,
+                org.bukkit.Material.REDSTONE_BLOCK.createBlockData()
+            );
+
+            ticksRemaining[0] -= mechanic.getTickInterval();
+        }, 0L, mechanic.getTickInterval());
+
+        bleedingTasks.put(victimId, task);
+    }
+
+}

--- a/core/src/main/resources/items/weapons.yml
+++ b/core/src/main/resources/items/weapons.yml
@@ -93,6 +93,30 @@ blood_sword:
     durability:
       value: 500 #diamond sword is 1561
 
+serrated_blade:
+  displayname: "<gradient:#8B0000:#DC143C>Serrated Blade"
+  material: DIAMOND_SWORD
+  lore:
+    - "<#6f737d>» <#D5D6D8>Causes enemies to bleed"
+  AttributeModifiers:
+    # diamond sword has an attack damage of 7
+    - { attribute: ATTACK_DAMAGE, amount: 7, operation: 0, slot: HAND }
+    # it has as much full-strength attacks per second than diamond sword
+    - { attribute: ATTACK_SPEED, amount: 1.6, operation: 0, slot: HAND }
+  Pack:
+    generate_model: true
+    parent_model: "item/handheld"
+    textures:
+      - default/blood_sword.png # reusing blood_sword texture as example
+  Mechanics:
+    bleeding:
+      chance: 0.3 # 30% chance to apply bleeding on hit
+      duration: 100 # bleeding lasts for 100 ticks (5 seconds)
+      damage_per_tick: 0.5 # deals 0.5 damage (1/4 heart) per tick
+      tick_interval: 20 # damage is applied every 20 ticks (1 second)
+    durability:
+      value: 800 #diamond sword is 1561
+
 octavia_sword:
   displayname: "<#D5D6D8>Octavia Sword"
   material: DIAMOND_SWORD

--- a/core/src/main/resources/mechanics.yml
+++ b/core/src/main/resources/mechanics.yml
@@ -126,6 +126,9 @@ skinnable:
 lifeleech:
   enabled: true
 
+bleeding:
+  enabled: true
+
 energyblast:
   enabled: true
 


### PR DESCRIPTION
- Add BleedingMechanic with configurable chance, duration, damage, and tick interval
- Implement BleedingMechanicListener to apply bleeding effect on entity damage
- Register bleeding mechanic in MechanicsManager
- Add example serrated_blade weapon with bleeding mechanic
- Enable bleeding mechanic in mechanics.yml configuration
- Tested on several server versions with no issues. (so far lol)