### PR TITLE
feat: added support for minecraft 1.21.4+ item model definition properties

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -37,6 +37,9 @@ public class OraxenMeta {
     private boolean excludedFromCommands = false;
     private boolean noUpdate = false;
     private boolean disableEnchanting = false;
+    private boolean oversizedInGui = false;
+    private boolean handAnimationOnSwap = true;
+    private float swapAnimationScale = 1.0f;
 
     public void setExcludedFromInventory(boolean excluded) {
         this.excludedFromInventory = excluded;
@@ -122,6 +125,11 @@ public class OraxenMeta {
         this.generatedModelPath = section.getString("generated_model_path", "");
         this.parentModel = section.getString("parent_model", "item/generated");
 
+        // Item model definition settings (1.21.4+)
+        this.oversizedInGui = section.getBoolean("oversized_in_gui", false);
+        this.handAnimationOnSwap = section.getBoolean("hand_animation_on_swap", true);
+        this.swapAnimationScale = (float) section.getDouble("swap_animation_scale", 1.0);
+
         if (generate_model && !modelName.matches("^[a-z0-9-_/]+$")) {
             Logs.logWarning("Item " + section.getParent().getName()
                     + " is set to generate a model, but ItemID does not adhere to [a-z0-9-_]!");
@@ -137,8 +145,8 @@ public class OraxenMeta {
         ConfigurationSection parent = configSection.getParent();
         modelName = modelName != null ? modelName
                 : Settings.GENERATE_MODEL_BASED_ON_TEXTURE_PATH.toBool() && !textures.isEmpty() && parent != null
-                        ? Utils.getParentDirs(textures.stream().findFirst().get()) + parent.getName()
-                        : null;
+                ? Utils.getParentDirs(textures.stream().findFirst().get()) + parent.getName()
+                : null;
 
         if (modelName == null && configString.equals("model") && parent != null)
             return parent.getName();
@@ -336,6 +344,18 @@ public class OraxenMeta {
 
     public boolean isDisableEnchanting() {
         return disableEnchanting;
+    }
+
+    public boolean isOversizedInGui() {
+        return oversizedInGui;
+    }
+
+    public boolean isHandAnimationOnSwap() {
+        return handAnimationOnSwap;
+    }
+
+    public float getSwapAnimationScale() {
+        return swapAnimationScale;
     }
 
 }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
@@ -45,6 +45,18 @@ public class ModelDefinitionGenerator {
         }
 
         root.add("model", model);
+
+        // Add item model definition properties (1.21.4+)
+        if (oraxenMeta.isOversizedInGui()) {
+            root.addProperty("oversized_in_gui", true);
+        }
+        if (!oraxenMeta.isHandAnimationOnSwap()) {
+            root.addProperty("hand_animation_on_swap", false);
+        }
+        if (oraxenMeta.getSwapAnimationScale() != 1.0f) {
+            root.addProperty("swap_animation_scale", oraxenMeta.getSwapAnimationScale());
+        }
+
         return root;
     }
 }


### PR DESCRIPTION
Allows more model-definitions to be usable.

Add support for the following item model definition properties:
- oversized_in_gui: Allows items to extend beyond slot boundaries in GUI when scaled up
- hand_animation_on_swap: Controls whether hand animation plays when swapping items (only when switching from an item to another item)
- swap_animation_scale: Adjusts the scale of the swap animation

The main feature is the oversized_in_gui property.
These properties can now be configured in item pack settings and will be properly included in the generated resource pack.

This feature was added after a request from a user on discord.

**Configuration**
```yml
oversized_item:
  itemname: <yellow>Oversized Item
  Pack:
    generate_model: false
    model: item/large_item
    oversized_in_gui: true
```

**Model - Used for the oversized in gui as an example**
```json
{
	"parent": "item/handheld",
	"textures": {
		"layer0": "default/welcome_disk"
	},
	"display": {
		"gui": {
			"translation": [-2, -2, 0],
			"scale": [2, 2, 2]
		}
	}
}
```
<img width="891" height="743" alt="image" src="https://github.com/user-attachments/assets/07f817f8-bcf4-4a8d-bdb4-e9b68ae7b539" />