### PR TITLE
fix: item unenchanting with grindstone

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
@@ -173,11 +173,18 @@ public class ItemUpdater implements Listener {
             List<Map<?, ?>> oldPdcMap = PersistentDataSerializer.toMapList(oldPdc);
             PersistentDataSerializer.fromMapList(oldPdcMap, itemPdc);
 
-            // Add all enchantments from oldItem and add all from newItem aslong as it is not the same Enchantments
-            for (Map.Entry<Enchantment, Integer> entry : oldMeta.getEnchants().entrySet())
-                itemMeta.addEnchant(entry.getKey(), entry.getValue(), true);
-            for (Map.Entry<Enchantment, Integer> entry : newMeta.getEnchants().entrySet().stream().filter(e -> !oldMeta.getEnchants().containsKey(e.getKey())).toList())
-                itemMeta.addEnchant(entry.getKey(), entry.getValue(), true);
+            // If oldItem had all enchantments removed, don't restore configured enchantments
+            if (oldMeta.getEnchants().isEmpty() && !newMeta.getEnchants().isEmpty()) {
+                // Remove all configured enchantments since user intentionally unenchanted the item
+                for (Enchantment enchantment : newMeta.getEnchants().keySet())
+                    itemMeta.removeEnchant(enchantment);
+            } else {
+                // Add all enchantments from oldItem and add all from newItem as long as it is not the same Enchantments
+                for (Map.Entry<Enchantment, Integer> entry : oldMeta.getEnchants().entrySet())
+                    itemMeta.addEnchant(entry.getKey(), entry.getValue(), true);
+                for (Map.Entry<Enchantment, Integer> entry : newMeta.getEnchants().entrySet().stream().filter(e -> !oldMeta.getEnchants().containsKey(e.getKey())).toList())
+                    itemMeta.addEnchant(entry.getKey(), entry.getValue(), true);
+            }
 
             Integer cmd = newMeta.hasCustomModelData() ? (Integer) newMeta.getCustomModelData() : oldMeta.hasCustomModelData() ? (Integer) oldMeta.getCustomModelData() : null;
             itemMeta.setCustomModelData(cmd);


### PR DESCRIPTION
> [!NOTE]
> Fixes a bug with enchants added via item configuration and grindstones
>
> **Bug**
> - Allowed players to unenchant their items over and over again, due the item being updated
> - Recreation steps
>   - Create an item that uses enchantments via the item configuration (e.g. example_sword from default configs)
>   - Use the item in the grindstone to remove all enchants and receive xp
>   - Drop the item (or do something else that updates it) and the enchants will be reapplied
> 
> **Fix**
> - If oldItem had all enchantments removed, don't restore configured enchantments
