### PR TITLE
fix: glyph tags

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/InventoryPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/InventoryPacketListener.java
@@ -8,7 +8,6 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.PacketHelpers;
-import io.th0rgal.oraxen.utils.VersionUtil;
 
 public class InventoryPacketListener extends PacketAdapter {
 
@@ -18,9 +17,6 @@ public class InventoryPacketListener extends PacketAdapter {
 
     @Override
     public void onPacketSending(PacketEvent event) {
-        if (VersionUtil.atOrAbove("1.21.4")) {
-            return;
-        }
         PacketContainer packet = event.getPacket();
         try {
             String chat = PacketHelpers.readJson(packet.getChatComponents().read(0).getJson());


### PR DESCRIPTION
> [!NOTE]
> Fixes glyph tags not rendering in GUI titles on 1.21.4+
>
> **Bug**
> - Glyph tags like <glyph:id> were not being parsed in inventory titles
> - Players saw the literal text <glyph:id> instead of the rendered glyph
> - Affected versions: 1.21.8, 1.21.10, and all 1.21.4+ servers using ProtocolLib
> - Reproduction steps
>   - Use <glyph:id> in a GUI title (Deluxemenus, Skript, etc.)
>   - Open the GUI on a 1.21.4+ server
>   - Glyph tag displays as literal text instead of rendering the glyph
>   - Workaround was to use PlaceholderAPI or raw unicode characters
>
>**Cause**
> - A version check in InventoryPacketListener disabled inventory packet processing for 1.21.4+
> - This prevented MiniMessage deserialization/serialization which handles glyph tag resolution
> - The check was added to prevent a ProtocolLib error but was too broad
>
> **Fix**
> - Removed the version check (if (VersionUtil.atOrAbove("1.21.4")) return;)
> - Kept the robust exception handling to gracefully handle any version-specific issues
> - The PacketEvents adapter (alternative packet handler) has no such check and works fine, proving this is safe
> - Glyph tags now properly parse on all server versions including 1.21.4+