### PR TITLE
feat: still support custom model data for versions above 1.21.4

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -601,31 +601,30 @@ public class ItemParser {
                 }
             }
 
-        // starting from 1.21.4, we no longer use Custom Model Data to set the item
-        // appearance
+        // starting from 1.21.4, we use model definitions, but custom_model_data is still supported
         if (oraxenMeta.hasPackInfos() && VersionUtil.atOrAbove("1.21.4")) {
             // if there is not an item model component overriding it, we set its value
             // to the automatically created item model definition
             if (!item.hasItemModel()) {
                 item.setItemModel(new NamespacedKey(OraxenPlugin.get(), section.getName()));
             }
-        } else {
-            final Integer customModelData;
-            if (MODEL_DATAS_BY_ID.containsKey(section.getName())) {
-                customModelData = MODEL_DATAS_BY_ID.get(section.getName()).getModelData();
-            } else if (!item.hasItemModel()) {
-                customModelData = ModelData.generateId(oraxenMeta.getModelName(), type);
-                configUpdated = true;
-                if (!Settings.DISABLE_AUTOMATIC_MODEL_DATA.toBool())
-                    Optional.ofNullable(section.getConfigurationSection("Pack"))
-                            .ifPresent(c -> c.set("custom_model_data", customModelData));
-            } else
-                customModelData = null;
+        }
 
-            if (customModelData != null) {
-                item.setCustomModelData(customModelData);
-                oraxenMeta.setCustomModelData(customModelData);
-            }
+        final Integer customModelData;
+        if (MODEL_DATAS_BY_ID.containsKey(section.getName())) {
+            customModelData = MODEL_DATAS_BY_ID.get(section.getName()).getModelData();
+        } else if (oraxenMeta.hasPackInfos() && !item.hasItemModel()) {
+            customModelData = ModelData.generateId(oraxenMeta.getModelName(), type);
+            configUpdated = true;
+            if (!Settings.DISABLE_AUTOMATIC_MODEL_DATA.toBool())
+                Optional.ofNullable(section.getConfigurationSection("Pack"))
+                        .ifPresent(c -> c.set("custom_model_data", customModelData));
+        } else
+            customModelData = null;
+
+        if (customModelData != null) {
+            item.setCustomModelData(customModelData);
+            oraxenMeta.setCustomModelData(customModelData);
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
@@ -47,6 +47,9 @@ public class ModelDefinitionGenerator {
         root.add("model", model);
 
         // Add item model definition properties (1.21.4+)
+        if (oraxenMeta.getCustomModelData() != null) {
+            root.addProperty("custom_model_data", oraxenMeta.getCustomModelData());
+        }
         if (oraxenMeta.isOversizedInGui()) {
             root.addProperty("oversized_in_gui", true);
         }


### PR DESCRIPTION
> [!NOTE]
> Allows custom model data to still be used in 1.21.4 or higher
>
> **Explanation**
> - Since devs have shown that they do not want to update, custom model data is "re-added" back.
>
> Newer versions of minecraft use 2 things to display item models.
> - item_model component - Points to a model definition file (what Oraxen sets automatically)
> - custom_model_data - An integer property for backward compatibility
>
> **Changes**
> - Removed the version check from the custom_model_data assignment logic
> - Model definitions are still created in 1.21.4+ (for the item appearance)
> - Custom_model_data is now also applied to items and OraxenMeta for all versions
>
> **Config**
> ```yml
> Pack:
>  custom_model_data: 6710312
>  generate_model: false
>  model: default/myitem
> ```
<img width="233" height="98" alt="/o iteminfo" src="https://github.com/user-attachments/assets/3fa6868d-bcc2-4b83-8cab-222f247664b4" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reintroduces applying custom_model_data across versions while still using item model definitions on 1.21.4+ and includes it in generated model definitions.
> 
> - **Item parsing (`ItemParser`)**:
>   - For 1.21.4+, still sets `item_model` when missing, but now also computes/applies `custom_model_data` (from config or auto-generated) and stores it in `OraxenMeta` across versions.
> - **Pack generation (`ModelDefinitionGenerator`)**:
>   - Emits `custom_model_data` in model definition JSON when present, alongside existing model properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dff5b249af76ff9d630b2ff604d80e32586f43ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->