### PR TITLE
fix: huds not working

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -26,6 +26,7 @@ import io.th0rgal.oraxen.utils.breaker.PacketEventsBreakerSystem;
 import io.th0rgal.oraxen.utils.breaker.ProtocolLibBreakerSystem;
 import io.th0rgal.oraxen.utils.customarmor.CustomArmorListener;
 import io.th0rgal.oraxen.utils.inventories.InvManager;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import io.th0rgal.protectionlib.ProtectionLib;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bstats.bukkit.Metrics;
@@ -89,12 +90,15 @@ public class OraxenPlugin extends JavaPlugin {
         if (Settings.KEEP_UP_TO_DATE.toBool())
             new SettingsUpdater().handleSettingsUpdate();
         if (PacketAdapter.isProtocolLibEnabled()) {
+            Logs.logInfo("[OraxenPlugin] ProtocolLib is enabled, using ProtocolLibAdapter");
             packetAdapter = new ProtocolLibAdapter();
             new ProtocolLibBreakerSystem().registerListener();
         } else if (PacketAdapter.isPacketEventsEnabled()) {
+            Logs.logInfo("[OraxenPlugin] ProtocolLib is NOT enabled, PacketEvents is enabled, using PacketEventsAdapter");
             packetAdapter = new PacketEventsAdapter();
             new PacketEventsBreakerSystem().registerListener();
         } else {
+            Logs.logWarning("[OraxenPlugin] Neither ProtocolLib nor PacketEvents is enabled, using EmptyAdapter");
             packetAdapter = new PacketAdapter.EmptyAdapter();
             Message.MISSING_PROTOCOLLIB.log();
         }

--- a/core/src/main/java/io/th0rgal/oraxen/hud/HudEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hud/HudEvents.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.hud;
 
 import com.jeff_media.morepersistentdatatypes.DataType;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.GameMode;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -23,9 +24,18 @@ public class HudEvents implements Listener {
                 ? hudManager.getActiveHud(player) : hudManager.getDefaultEnabledHuds().stream().findFirst().orElse(null);
         String hudId = hudManager.getHudID(hud);
 
-        if (hud == null || hudId == null) return;
-        if (!player.hasPermission(hud.getPerm())) return;
-        if (!hudManager.getHudState(player)) return;
+        if (hud == null || hudId == null) {
+            Logs.logWarning("[HUD] No default HUD found for player " + player.getName());
+            return;
+        }
+        if (!player.hasPermission(hud.getPerm())) {
+            Logs.logWarning("[HUD] Player " + player.getName() + " doesn't have permission: " + hud.getPerm());
+            return;
+        }
+        if (!hudManager.getHudState(player)) {
+            Logs.logWarning("[HUD] HUD is disabled for player " + player.getName());
+            return;
+        }
 
         pdc.set(hudManager.hudDisplayKey, DataType.STRING, hudManager.getHudID(hud));
         pdc.set(hudManager.hudToggleKey, DataType.BOOLEAN, true);

--- a/core/src/main/java/io/th0rgal/oraxen/hud/HudTask.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hud/HudTask.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.hud;
 
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.EntityUtils;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -18,12 +19,25 @@ public class HudTask extends BukkitRunnable {
 
     @Override
     public void run() {
-        for (Player player : hudEnabledPlayers()) {
+        List<? extends Player> enabled = hudEnabledPlayers();
+        for (Player player : enabled) {
             Hud hud = manager.hasActiveHud(player) ? manager.getActiveHud(player) : manager.getDefaultEnabledHuds().stream().findFirst().orElse(null);
 
-            if (hud == null || manager.getHudID(hud) == null) continue;
-            if (hud.disableWhilstInWater() && EntityUtils.isUnderWater(player)) continue;
-            if (!player.hasPermission(hud.getPerm())) continue;
+            if (hud == null) {
+                Logs.logWarning("[HUD] No HUD found for player " + player.getName());
+                continue;
+            }
+            if (manager.getHudID(hud) == null) {
+                Logs.logWarning("[HUD] HUD ID is null for player " + player.getName());
+                continue;
+            }
+            if (hud.disableWhilstInWater() && EntityUtils.isUnderWater(player)) {
+                continue;
+            }
+            if (!player.hasPermission(hud.getPerm())) {
+                Logs.logWarning("[HUD] Player " + player.getName() + " doesn't have permission: " + hud.getPerm());
+                continue;
+            }
 
             manager.updateHud(player);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
@@ -8,6 +8,7 @@ import io.th0rgal.oraxen.packets.protocollib.TitlePacketListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import io.th0rgal.oraxen.packets.protocollib.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
 import io.th0rgal.oraxen.utils.SnapshotVersion;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
@@ -51,12 +52,14 @@ public class ProtocolLibAdapter implements PacketAdapter {
 
     @Override
     public void registerTitleListener() {
+        Logs.logInfo("[ProtocolLibAdapter] registerTitleListener called");
         if(titlePacketListener != null) {
             OraxenPlugin.get().getLogger().severe("[ProtocolLibAdapter]: Title Listener is already registered!");
             return;
         }
         titlePacketListener = new TitlePacketListener();
         ProtocolLibrary.getProtocolManager().addPacketListener(titlePacketListener);
+        Logs.logInfo("[ProtocolLibAdapter] Title Listener registered successfully");
     }
 
     @Override public void removeInventoryListener() {

--- a/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/TitlePacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/protocollib/TitlePacketListener.java
@@ -29,27 +29,35 @@ public class TitlePacketListener extends PacketAdapter {
         } else if (packet.getType() == SET_SUBTITLE_TEXT && Settings.FORMAT_SUBTITLES.toBool()) {
             WrappedChatComponent subtitle = formatTitle(packet);
             if (subtitle != null) packet.getChatComponents().write(0, subtitle);
-        } else if (packet.getType() == SET_ACTION_BAR_TEXT && Settings.FORMAT_ACTION_BAR.toBool()) {
-            WrappedChatComponent actionbar = formatTitle(packet);
-            if (actionbar != null) packet.getChatComponents().write(0, actionbar);
+        } else if (packet.getType() == SET_ACTION_BAR_TEXT) {
+            if (Settings.FORMAT_ACTION_BAR.toBool()) {
+                WrappedChatComponent actionbar = formatTitle(packet);
+                if (actionbar != null) packet.getChatComponents().write(0, actionbar);
+            }
         }
     }
 
     private WrappedChatComponent formatTitle(PacketContainer packet) {
         try {
             String title;
-            if (packet.getChatComponents().read(0) == null)
-                title = AdventureUtils.MINI_MESSAGE.serialize((Component) packet.getModifier().read(1));
-            else title = PacketHelpers.readJson(packet.getChatComponents().read(0).getJson());
+            if (packet.getChatComponents().read(0) == null) {
+                if (packet.getModifier().size() > 1) {
+                    title = AdventureUtils.MINI_MESSAGE.serialize((Component) packet.getModifier().read(1));
+                } else {
+                    return null;
+                }
+            } else {
+                title = PacketHelpers.readJson(packet.getChatComponents().read(0).getJson());
+            }
             return WrappedChatComponent.fromJson(PacketHelpers.toJson(title));
         } catch (Exception e) {
             String type;
             if (packet.getType() == SET_TITLE_TEXT) type = "title";
             else if (packet.getType() == SET_SUBTITLE_TEXT) type = "subtitle";
             else type = "actionbar";
+            Logs.logWarning("Error whilst reading " + type + " packet: " + e.getMessage());
             if (Settings.DEBUG.toBool()) {
-                Logs.logWarning("Error whilst reading " + type + " packet");
-                if (Settings.DEBUG.toBool()) e.printStackTrace();
+                e.printStackTrace();
             }
         }
         return null;


### PR DESCRIPTION
> [!NOTE]
> Fixes critical issues in the HUD system that were causing NPEs and missing updates
>
> **Explanation**
> The HUD system had several stability issues that made it difficult to debug problems, as well as a bug where HUDs weren't shown. The main issues were.
> - `parsedHudDisplays` was not initialized, causing NPE when enabling HUDs before parsing
> - Unnecessary use of `OraxenPlugin.get().getAudience()` for sending actionbars
> - `huds.clear()` was incorrectly placed inside the loading loop
> - Compound return guards made error tracing difficult
>
> **Changes**
> - Initialize `parsedHudDisplays` in constructor to prevent NPE
> - Replace `OraxenPlugin.get().getAudience().player(player).sendActionBar()` with direct `player.sendActionBar()` calls
> - Split all compound return guards into individual checks with specific logging for each failure case
> - Move `huds.clear()` outside the loading loop to avoid clearing on every iteration
> - Cache parsed HUD displays after loading via `generateHudDisplays()`
> - Add try-catch with logging for actionbar serialization errors
> - Add comprehensive logging throughout HUD initialization and updates in `HudManager`, `HudEvents`, and `HudTask`
> - Improve null checks in packet listeners for safer handling of title/actionbar packets
> - Add logging to `ProtocolLibAdapter` to track when listeners are registered
>
> **Config Changes**
> No configuration changes required. Existing HUD configs continue to work as before.
