### PR TITLE
fix: race condition when self hosting

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/SelfHost.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/SelfHost.java
@@ -44,8 +44,8 @@ public class SelfHost implements HostingProvider {
             this.packFile = resourcePack;
             stopServer();
             calculateSHA1(resourcePack);
-            startServer(resourcePack);
             this.packUrl = "http://" + domain + "/pack.zip";
+            startServer(resourcePack);
             return true;
         } catch (Exception e) {
             Logs.logError("Failed to self-host the resource pack");


### PR DESCRIPTION
> [!NOTE]
> Fixes a race condition in SelfHost that could cause null values to be displayed.
>
> **Changes**
> - Moved `packUrl` assignment to before `startServer()` in `uploadPack()` method
> - Ensures `packUrl` is initialized before the HTTP server starts accepting requests
> - Prevents the rootHandler lambda from reading null when requests arrive during server startup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `packUrl` before `startServer(...)` in `SelfHost.uploadPack` to avoid null reads during server startup.
> 
> - **Backend**
>   - **SelfHost** (`core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/SelfHost.java`):
>     - Reorder `uploadPack(...)` to set `packUrl` before calling `startServer(...)`, preventing null access by the root handler during startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4e77a9bd750fc8225185908180fce56f1263da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->