### PR TITLE
fix: bow pulling models for 1.21.4+

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
@@ -46,27 +46,155 @@ public class ModelDefinitionGenerator {
             baseModel.add("tints",tints);
         }
 
-        // If we have pulling models, wrap the base model in a condition structure
+        // Handle bows with pulling models
         if (oraxenMeta.hasPullingModels() && material != null && material == Material.BOW) {
-            JsonObject conditionModel = new JsonObject();
-            conditionModel.addProperty("type", "minecraft:condition");
-            conditionModel.addProperty("property", "minecraft:using_item");
+            JsonObject conditionModel = createBowPullingModel(baseModel, oraxenMeta);
+            root.add("model", conditionModel);
+        } 
+        // Handle crossbows with pulling models, charged model, and firework model
+        else if (material != null && material == Material.CROSSBOW) {
+            JsonObject crossbowModel = createCrossbowModel(baseModel, oraxenMeta);
+            root.add("model", crossbowModel);
+        } 
+        else {
+            // No special handling, use base model directly
+            root.add("model", baseModel);
+        }
+
+        // Add item model definition properties (1.21.4+)
+        if (oraxenMeta.isOversizedInGui()) {
+            root.addProperty("oversized_in_gui", true);
+        }
+        if (!oraxenMeta.isHandAnimationOnSwap()) {
+            root.addProperty("hand_animation_on_swap", false);
+        }
+        if (oraxenMeta.getSwapAnimationScale() != 1.0f) {
+            root.addProperty("swap_animation_scale", oraxenMeta.getSwapAnimationScale());
+        }
+
+        return root;
+    }
+
+    private JsonObject createBowPullingModel(JsonObject baseModel, OraxenMeta oraxenMeta) {
+        JsonObject conditionModel = new JsonObject();
+        conditionModel.addProperty("type", "minecraft:condition");
+        conditionModel.addProperty("property", "minecraft:using_item");
+        
+        // on_false: base model (when not pulling)
+        conditionModel.add("on_false", baseModel);
+        
+        // on_true: range_dispatch for pulling states
+        JsonObject rangeDispatch = new JsonObject();
+        rangeDispatch.addProperty("type", "minecraft:range_dispatch");
+        rangeDispatch.addProperty("property", "minecraft:use_duration");
+        rangeDispatch.addProperty("scale", 0.05);
+        
+        List<String> pullingModels = oraxenMeta.getPullingModels();
+        if (pullingModels == null || pullingModels.isEmpty()) {
+            // Fallback to base model if pullingModels is null/empty (shouldn't happen due to hasPullingModels check)
+            return baseModel;
+        }
+        
+        JsonArray entries = new JsonArray();
+        
+        // Add entries for pulling_1 and pulling_2 with thresholds
+        if (pullingModels.size() >= 2) {
+            JsonObject entry1 = new JsonObject();
+            entry1.addProperty("threshold", 0.65f);
+            JsonObject model1 = new JsonObject();
+            model1.addProperty("type", "minecraft:model");
+            model1.addProperty("model", pullingModels.get(1));
+            entry1.add("model", model1);
+            entries.add(entry1);
+        }
+        
+        if (pullingModels.size() >= 3) {
+            JsonObject entry2 = new JsonObject();
+            entry2.addProperty("threshold", 0.9f);
+            JsonObject model2 = new JsonObject();
+            model2.addProperty("type", "minecraft:model");
+            model2.addProperty("model", pullingModels.get(2));
+            entry2.add("model", model2);
+            entries.add(entry2);
+        }
+        
+        rangeDispatch.add("entries", entries);
+        
+        // fallback: pulling_0 (first pulling state)
+        JsonObject fallback = new JsonObject();
+        fallback.addProperty("type", "minecraft:model");
+        fallback.addProperty("model", pullingModels.get(0));
+        rangeDispatch.add("fallback", fallback);
+        
+        conditionModel.add("on_true", rangeDispatch);
+        return conditionModel;
+    }
+
+    private JsonObject createCrossbowModel(JsonObject baseModel, OraxenMeta oraxenMeta) {
+        // Priority: pulling > firework (charged + firework) > charged > base
+        // Build from outside in: check pulling first, then charged/firework
+        
+        JsonObject currentModel = baseModel;
+        
+        // Handle charged/firework models first (inner layer)
+        if (oraxenMeta.hasChargedModel() || oraxenMeta.hasFireworkModel()) {
+            JsonObject chargedCondition = new JsonObject();
+            chargedCondition.addProperty("type", "minecraft:condition");
+            chargedCondition.addProperty("property", "minecraft:charged");
             
-            // on_false: base model (when not pulling)
-            conditionModel.add("on_false", baseModel);
+            JsonObject chargedModelObj;
+            if (oraxenMeta.hasChargedModel()) {
+                chargedModelObj = new JsonObject();
+                chargedModelObj.addProperty("type", "minecraft:model");
+                chargedModelObj.addProperty("model", oraxenMeta.getChargedModel());
+            } else {
+                // No charged model, use base when charged (shouldn't happen, but fallback)
+                chargedModelObj = baseModel;
+            }
+            
+            // If firework model exists, check firework property when charged
+            if (oraxenMeta.hasFireworkModel()) {
+                JsonObject fireworkCondition = new JsonObject();
+                fireworkCondition.addProperty("type", "minecraft:condition");
+                fireworkCondition.addProperty("property", "minecraft:firework");
+                
+                JsonObject fireworkModelObj = new JsonObject();
+                fireworkModelObj.addProperty("type", "minecraft:model");
+                fireworkModelObj.addProperty("model", oraxenMeta.getFireworkModel());
+                
+                // on_true: firework model (when charged AND firework)
+                fireworkCondition.add("on_true", fireworkModelObj);
+                // on_false: charged model (when charged but no firework)
+                fireworkCondition.add("on_false", chargedModelObj);
+                
+                chargedCondition.add("on_true", fireworkCondition);
+            } else {
+                // No firework model, use charged model when charged
+                chargedCondition.add("on_true", chargedModelObj);
+            }
+            
+            // on_false: base model (when not charged)
+            chargedCondition.add("on_false", baseModel);
+            currentModel = chargedCondition;
+        }
+        
+        // Handle pulling models (outer layer, checked first)
+        if (oraxenMeta.hasPullingModels()) {
+            List<String> pullingModels = oraxenMeta.getPullingModels();
+            if (pullingModels == null || pullingModels.isEmpty()) {
+                // Fallback to current model if pullingModels is null/empty (shouldn't happen due to hasPullingModels check)
+                return currentModel;
+            }
+            
+            JsonObject pullingCondition = new JsonObject();
+            pullingCondition.addProperty("type", "minecraft:condition");
+            pullingCondition.addProperty("property", "minecraft:using_item");
             
             // on_true: range_dispatch for pulling states
             JsonObject rangeDispatch = new JsonObject();
             rangeDispatch.addProperty("type", "minecraft:range_dispatch");
             rangeDispatch.addProperty("property", "minecraft:use_duration");
             rangeDispatch.addProperty("scale", 0.05);
-            
-            List<String> pullingModels = oraxenMeta.getPullingModels();
-            if (pullingModels == null) {
-                // Fallback to base model if pullingModels is null (shouldn't happen due to hasPullingModels check)
-                root.add("model", baseModel);
-                return root;
-            }
             
             JsonArray entries = new JsonArray();
             
@@ -94,31 +222,18 @@ public class ModelDefinitionGenerator {
             rangeDispatch.add("entries", entries);
             
             // fallback: pulling_0 (first pulling state)
-            if (!pullingModels.isEmpty()) {
-                JsonObject fallback = new JsonObject();
-                fallback.addProperty("type", "minecraft:model");
-                fallback.addProperty("model", pullingModels.get(0));
-                rangeDispatch.add("fallback", fallback);
-            }
+            JsonObject fallback = new JsonObject();
+            fallback.addProperty("type", "minecraft:model");
+            fallback.addProperty("model", pullingModels.get(0));
+            rangeDispatch.add("fallback", fallback);
             
-            conditionModel.add("on_true", rangeDispatch);
-            root.add("model", conditionModel);
-        } else {
-            // No pulling models, use base model directly
-            root.add("model", baseModel);
+            pullingCondition.add("on_true", rangeDispatch);
+            // on_false: current model (charged/firework or base)
+            pullingCondition.add("on_false", currentModel);
+            currentModel = pullingCondition;
         }
-
-        // Add item model definition properties (1.21.4+)
-        if (oraxenMeta.isOversizedInGui()) {
-            root.addProperty("oversized_in_gui", true);
-        }
-        if (!oraxenMeta.isHandAnimationOnSwap()) {
-            root.addProperty("hand_animation_on_swap", false);
-        }
-        if (oraxenMeta.getSwapAnimationScale() != 1.0f) {
-            root.addProperty("swap_animation_scale", oraxenMeta.getSwapAnimationScale());
-        }
-
-        return root;
+        
+        return currentModel;
     }
+
 }


### PR DESCRIPTION
> [!NOTE]
> Fixes pulling models for bows, crossbows, fishing rods, and shields in model definitions (1.21.4+)
>
> **Explanation**
> - This PR fixes the implementation of pulling models for bows, crossbows, fishing rods, and shields when using the new model definition system (Minecraft 1.21.4+)
> - Previously, these models were only supported via the legacy predicate system
> - The new model definition system uses `minecraft:condition` and `minecraft:range_dispatch` to handle item states
> - Bows use `minecraft:use_duration` property with scale 0.05 to determine pulling state
> - Crossbows use `minecraft:crossbow/pull` property and also support charged/firework states via `minecraft:charge_type`
> - Fishing rods use `minecraft:fishing_rod/cast` property to handle cast state
> - Shields use `minecraft:using_item` property to handle blocking state
>
> **Changes**
> - Added support for bow pulling models using `minecraft:condition` on `minecraft:using_item` property
> - Implemented `range_dispatch` with `minecraft:use_duration` property for bow pulling states (thresholds: 0.65, 0.9)
> - Added support for crossbow pulling models with proper handling of charged and firework states
> - Implemented `range_dispatch` with `minecraft:crossbow/pull` property for crossbow pulling states (thresholds: 0.58, 1.0)
> - Added `minecraft:select` on `minecraft:charge_type` for crossbow charged/firework model selection
> - Added support for fishing rod cast models using `minecraft:condition` on `minecraft:fishing_rod/cast` property
> - Added support for shield blocking models using `minecraft:condition` on `minecraft:using_item` property
> - Properly handles cases where pulling models, charged models, firework models, cast models, or blocking models may be missing
> - Added null-safety checks to prevent potential IndexOutOfBoundsException
> - Refactored model generation logic to separate item handling into dedicated methods (`createBowPullingModel`, `createCrossbowModel`, `createFishingRodModel`, and `createShieldModel`)
>
> **Technical Details**
> - Bows: Uses `minecraft:condition` → `minecraft:range_dispatch` structure
>   - `on_false`: Base model (when not pulling)
>   - `on_true`: Range dispatch on `minecraft:use_duration` with scale 0.05
>     - Threshold 0.65: pulling_1 model
>     - Threshold 0.9: pulling_2 model
>     - Fallback: pulling_0 model
> - Crossbows: Uses nested `minecraft:condition` → `minecraft:select` → `minecraft:range_dispatch` structure
>   - Outer condition on `minecraft:using_item`
>     - `on_false`: Select on `minecraft:charge_type` (arrow/rocket) or base model
>     - `on_true`: Range dispatch on `minecraft:crossbow/pull`
>       - Threshold 0.58: pulling_1 model
>       - Threshold 1.0: pulling_2 model
>       - Fallback: pulling_0 model
> - Fishing Rods: Uses `minecraft:condition` structure
>   - Property: `minecraft:fishing_rod/cast`
>   - `on_false`: Base model (when not casting)
>   - `on_true`: Cast model (when casting)
> - Shields: Uses `minecraft:condition` structure
>   - Property: `minecraft:using_item`
>   - `on_false`: Base model (when not blocking)
>   - `on_true`: Blocking model (when blocking)
>
> **Config**
> ```yml
> # Example bow with pulling models
> testbow:
>   itemname: <gradient:#F44336:#FF9800>test Bow
>   material: BOW
>   Pack:
>     model: dev/bows/test_bow
>     generate_model: false
>     pulling_models:
>     - dev/bows/test_bow_pulling_0
>     - dev/bows/test_bow_pulling_1
>     - dev/bows/test_bow_pulling_2
>
> # Example bow with pulling textures (generates models automatically)
> testbowtextures:
>   itemname: <gradient:#F44336:#FF9800>test Bow Textures
>   material: BOW
>   Pack:
>     textures:
>     - dev/bows/test_bow
>     generate_model: true
>     pulling_textures:
>     - dev/bows/test_bow_pulling_0
>     - dev/bows/test_bow_pulling_1
>     - dev/bows/test_bow_pulling_2
>
> # Example crossbow with pulling models, charged, and firework models
> testcrossbow:
>   itemname: <gradient:#9C27B0:#E91E63>test Crossbow
>   material: CROSSBOW
>   Pack:
>     model: dev/crossbows/test_crossbow_standby
>     generate_model: false
>     pulling_models:
>     - dev/crossbows/test_crossbow_pulling_0
>     - dev/crossbows/test_crossbow_pulling_1
>     - dev/crossbows/test_crossbow_pulling_2
>     charged_model: dev/crossbows/test_crossbow_arrow
>     firework_model: dev/crossbows/test_crossbow_firework
>
> # Example crossbow with pulling textures, charged, and firework textures
> testcrossbowtextures:
>   itemname: <gradient:#9C27B0:#E91E63>test Crossbow Textures
>   material: CROSSBOW
>   Pack:
>     parent_model: minecraft:item/crossbow
>     textures:
>     - dev/crossbows/test_crossbow_standby
>     generate_model: true
>     pulling_textures:
>     - dev/crossbows/test_crossbow_pulling_0
>     - dev/crossbows/test_crossbow_pulling_1
>     - dev/crossbows/test_crossbow_pulling_2
>     charged_texture: dev/crossbows/test_crossbow_arrow
>     firework_texture: dev/crossbows/test_crossbow_firework
>
> # Example fishing rod with cast model
> testfishingrod:
>   itemname: <gradient:#00BCD4:#0097A7>test Fishing Rod
>   material: FISHING_ROD
>   Pack:
>     model: dev/rods/test_rod
>     generate_model: false
>     cast_model: dev/rods/test_rod_cast
>
> # Example fishing rod with cast texture (generates model automatically)
> testfishingrodtexture:
>   itemname: <gradient:#00BCD4:#0097A7>test Fishing Rod Texture
>   material: FISHING_ROD
>   Pack:
>     parent_model: minecraft:item/fishing_rod
>     textures:
>     - dev/rods/test_rod
>     generate_model: true
>     cast_texture: dev/rods/test_rod_cast
>
> # Example shield with blocking model
> testshield:
>   itemname: <gradient:#607D8B:#455A64>test Shield
>   material: SHIELD
>   Pack:
>     model: dev/shields/test_shield
>     generate_model: false
>     blocking_model: dev/shields/test_shield_blocking
>
> # Example shield with blocking texture (generates model automatically)
> testshieldtexture:
>   itemname: <gradient:#607D8B:#455A64>test Shield Texture
>   material: SHIELD
>   Pack:
>     parent_model: minecraft:item/shield
>     textures:
>     - dev/shields/test_shield
>     generate_model: true
>     blocking_texture: dev/shields/test_shield_blocking
> ```
