### PR TITLE
fix: 1.21.1 support

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -284,23 +284,40 @@ public class ResourcePack {
             if (!texture.getPath().matches(".*_layer_.*.png")) {
                 if (mcmeta.contains(texture.getPath() + ".mcmeta"))
                     continue;
-                BufferedImage image;
-                InputStream inputStream = texture.getInputStream();
                 try {
-                    image = ImageIO.read(new File("fake_file.png"));
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    inputStream.transferTo(baos);
-                    ImageIO.write(image, "png", baos);
-                    baos.close();
-                    inputStream.reset();
-                    inputStream.close();
-                } catch (IOException e) {
-                    continue;
-                }
+                    InputStream inputStream = texture.getInputStream();
+                    if (inputStream == null) {
+                        Logs.logWarning("Found unreadable texture at <blue>" + texture.getPath() + "</blue>");
+                        malformedTextures.add(texture);
+                        continue;
+                    }
 
-                if (image.getHeight() > 256 || image.getWidth() > 256) {
-                    Logs.logWarning("Found invalid texture at <blue>" + texture.getPath());
-                    Logs.logError("Resolution of textures cannot exceed 256x256");
+                    byte[] data;
+                    try (inputStream) {
+                        data = inputStream.readAllBytes();
+                    }
+
+                    // ImageIO.read returns null if there is no suitable reader
+                    // (corrupt/unsupported)
+                    BufferedImage image = ImageIO.read(new ByteArrayInputStream(data));
+                    if (image == null) {
+                        Logs.logWarning("Found unreadable texture at <blue>" + texture.getPath() + "</blue>");
+                        Logs.logWarning("Image format may be corrupt or unsupported by ImageIO.", true);
+                        malformedTextures.add(texture);
+                        continue;
+                    }
+
+                    if (image.getHeight() > 256 || image.getWidth() > 256) {
+                        Logs.logWarning("Found invalid texture at <blue>" + texture.getPath());
+                        Logs.logError("Resolution of textures cannot exceed 256x256");
+                        malformedTextures.add(texture);
+                    }
+                } catch (Exception e) {
+                    // Be resilient when validating packs: bad files should not crash pack
+                    // generation
+                    Logs.logWarning("Failed to validate texture <blue>" + texture.getPath() + "</blue>");
+                    if (Settings.DEBUG.toBool())
+                        e.printStackTrace();
                     malformedTextures.add(texture);
                 }
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/InputFile.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/slicer/InputFile.java
@@ -37,6 +37,10 @@ public class InputFile {
         if (Files.exists(inputPath)) {
             try (final InputStream is = Files.newInputStream(inputPath)) {
                 final BufferedImage image = ImageIO.read(is);
+                if (image == null) {
+                    Logs.logWarning("Skipping unreadable image during slicing: " + inputPath);
+                    return;
+                }
                 final BufferedImage leftoverImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
                 final Graphics2D leftoverGraphics = leftoverImage.createGraphics();
                 leftoverGraphics.drawImage(image, 0, 0, null);


### PR DESCRIPTION
reported by @pxlarified 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve 1.21.1 compatibility (Adventure ShadowColor and Bukkit registries) and harden resource pack/image/zip handling with robust validation and fallbacks.
> 
> - **Compatibility (1.21.1/Adventure/Bukkit)**
>   - `GlyphTag`: Use reflection for `ShadowColor` application to avoid class resolution issues on older Paper/Adventure bundles.
>   - `SchemaGenerator`: Iterate Bukkit `Registry` entries via raw `Iterable` and reflection (`getKey`, `getMaxLevel`) to prevent `IncompatibleClassChangeError`; add small reflection helpers.
> - **Resource Pack Validation**
>   - Fix image validation: properly read PNG data, detect unreadable/unsupported images (`ImageIO.read == null`), and cap resolution; add resilient error handling and logs.
> - **Texture Slicer**
>   - Skip unreadable images during slicing with warning.
> - **Zipping**
>   - Safeguard against null input streams; safely close zip entries; minor stream handling cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82061dce3fc73f165b275860b2dba2f1d4fafe93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->