### PR TITLE
feat(placeholderapi): feat support for positive and negative shift placeholders

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
@@ -39,13 +39,31 @@ public class OraxenExpansion extends PlaceholderExpansion {
 
     @Override
     public String onRequest(final OfflinePlayer player, @NotNull final String params) {
-        final Glyph glyph = plugin.getFontManager().getGlyphFromName(params);
-
         if (params.equals("pack_url"))
             return plugin.getUploadManager().getHostingProvider().getPackURL();
         else if (params.equals("pack_hash"))
             return plugin.getUploadManager().getHostingProvider().getOriginalSHA1();
-        else if (glyph != null)
+
+        // Handle positive shift: %oraxen_shift_N%
+        if (params.startsWith("shift_")) {
+            try {
+                int pixels = Integer.parseInt(params.substring(6));
+                return plugin.getFontManager().getShift(pixels);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        // Handle negative shift: %oraxen_neg_shift_N%
+        if (params.startsWith("neg_shift_")) {
+            try {
+                int pixels = Integer.parseInt(params.substring(10));
+                return plugin.getFontManager().getShift(-pixels);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        final Glyph glyph = plugin.getFontManager().getGlyphFromName(params);
+        if (glyph != null)
             return glyph.getCharacter();
         return null; // Placeholder is unknown by the Expansion
     }


### PR DESCRIPTION
> [!NOTE]
> (Re-)Add shift-based placeholder support to PlaceholderAPI expansion
>
> Reported in https://github.com/oraxen/oraxen/issues/1697
>
> **Explanation**
> - The PlaceholderAPI expansion previously only supported glyph name lookups and pack metadata placeholders
> - Users need a way to apply dynamic pixel shifts to text in PlaceholderAPI placeholders (e.g., for alignment or spacing)
> - The new shift placeholders allow applying positive and negative pixel offsets through the existing `FontManager.getShift()` method
> - This enables placeholder patterns like `%oraxen_shift_5%` for +5 pixel shift and `%oraxen_neg_shift_3%` for -3 pixel shift
> - Placeholder resolution now checks shift values before falling back to glyph lookup, allowing shift placeholders to be processed independently
>
> **Changes**
> - Moved pack metadata checks (`pack_url`, `pack_hash`) to the beginning of placeholder resolution
> - Added handler for positive shift placeholders: `%oraxen_shift_<pixels>%`
> - Added handler for negative shift placeholders: `%oraxen_neg_shift_<pixels>%`
> - Both shift handlers use `FontManager.getShift()` to retrieve the shift character
> - Moved glyph lookup to the end as a fallback after shift and pack metadata checks
> - Added try-catch blocks with silent failure for malformed shift values
>
> **Usage**
> - Use `%oraxen_shift_<N>%` to apply a positive N-pixel shift to text
> - Use `%oraxen_neg_shift_<N>%` to apply a negative N-pixel shift to text
> - Example: `&f%oraxen_shift_10%Hello` shifts "Hello" 10 pixels to the right
> - Example: `&f%oraxen_neg_shift_5%World` shifts "World" 5 pixels to the left
> - Invalid numbers are silently ignored and return null (treated as unknown placeholder)
>
> <sup>Written by [Zen](https://zencoder.ai/) for commit 1b43f7a65ff35f3a4cfbaf30556dc7631f568b5a.</sup>
