### PR TITLE
chore: add Claude Code context setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,212 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Oraxen is a Minecraft Spigot/Paper plugin that allows server administrators to add custom items, weapons, blocks, furniture, and more. It automatically generates resource packs from configuration files, simplifying the work for administrators. The plugin includes an extensive API for developers to extend functionality.
+
+## Build Commands
+
+### Building the Plugin
+```bash
+# Build the plugin (creates shadowed jar with all NMS versions)
+./gradlew build
+
+# Build without running tests
+./gradlew build -x test
+
+# Clean build
+./gradlew clean build
+
+# Run a test server (Paper 1.21.11)
+./gradlew runServer
+```
+
+### Testing
+```bash
+# Run all tests
+./gradlew test
+
+# Run tests for specific module
+./gradlew :core:test
+
+# Run PackMerger debug tool
+./gradlew :core:runPackMergerDebug --args="path/to/pack.zip"
+```
+
+### Development Workflow
+```bash
+# Build and copy to plugin directory (if oraxen_spigot_plugin_path is set in gradle.properties)
+./gradlew build
+
+# The build automatically copies to the configured plugin path and removes old versions
+```
+
+## Architecture
+
+### Multi-Version NMS Support
+
+Oraxen uses a multi-module architecture to support multiple Minecraft versions:
+- **core**: Main plugin logic (io.th0rgal.oraxen.*)
+- **v1_20_R1** through **v1_21_R6**: Version-specific NMS implementations
+
+Each NMS module:
+- Contains version-specific packet and entity handling code
+- Uses paperweight for remapping (except v1_21_R6 which ships Mojang-mapped)
+- Gets embedded into the final jar via the reobf configuration
+- Is registered in SUPPORTED_VERSIONS list in build.gradle.kts
+
+When adding NMS-dependent code:
+1. Define an interface in core (e.g., in io.th0rgal.oraxen.nms)
+2. Implement it in each version module
+3. Load the correct implementation at runtime based on server version
+
+### Resource Pack Generation
+
+The resource pack system (io.th0rgal.oraxen.pack) automatically generates Minecraft resource packs:
+- **pack/generation**: Builds packs from configuration and assets
+- **pack/upload**: Handles automatic upload to hosting services
+- Resources are in core/src/main/resources/pack/ (models, textures, fonts, sounds)
+
+The pack includes:
+- Custom item models and textures (core/src/main/resources/pack/models, textures)
+- Font glyphs for chat and UI (core/src/main/resources/glyphs/)
+- Sound definitions (sound.yml)
+
+### Mechanics System
+
+Mechanics are modular features that can be attached to items (io.th0rgal.oraxen.mechanics):
+
+1. **MechanicFactory**: Creates and manages mechanic instances for items
+2. **Mechanic**: Item-specific mechanic instance (stores config for one item)
+3. Registered in MechanicsManager.registerNativeMechanics()
+
+Categories:
+- **misc**: armor_effects, soulbound, consumable, commands, backpack, music_disc
+- **gameplay**: durability, efficiency, block, noteblock, stringblock, furniture, repair
+- **farming**: harvesting, smelting, watering, bigmining, bedrockbreak, bottledexp
+- **combat**: lifeleech, bleeding, thor, energyblast, fireball, witherskull, spear
+- **cosmetic**: hat, skin, skinnable, aura
+
+To add a new mechanic:
+1. Create XMechanic extending Mechanic
+2. Create XMechanicFactory extending MechanicFactory
+3. Create XMechanicListener if needed
+4. Register in MechanicsManager.registerNativeMechanics()
+
+### API Structure
+
+Primary API classes (io.th0rgal.oraxen.api):
+- **OraxenItems**: Item creation, retrieval, and identification
+- **OraxenBlocks**: Custom block placement, breaking, and queries
+- **OraxenFurniture**: Furniture entity management
+- **OraxenPack**: Resource pack operations
+
+Events in io.th0rgal.oraxen.api.events allow listening to plugin lifecycle and item operations.
+
+### Configuration System
+
+Configuration is managed through:
+- **ConfigsManager**: Loads and manages all config files
+- **ResourcesManager**: Extracts default configs from jar
+- **Settings**: Type-safe settings access (from settings.yml)
+- **Message**: Localized messages (from languages/)
+
+Config files in core/src/main/resources:
+- settings.yml: Main plugin configuration
+- mechanics.yml: Mechanic-specific settings
+- font.yml, hud.yml, sound.yml: Asset configuration
+- items/: Item definitions
+- recipes/: Crafting recipes
+
+### Packet Adapters
+
+Oraxen supports both ProtocolLib and PacketEvents:
+- **PacketAdapter**: Abstract interface for packet operations
+- **ProtocolLibAdapter**: Implementation using ProtocolLib
+- **PacketEventsAdapter**: Implementation using PacketEvents
+- Plugin detects available library at runtime and uses appropriate adapter
+
+### Dependency Management
+
+Dependencies are managed via gradle/oraxenLibs.versions.toml:
+- **libraries-bukkit**: Loaded via plugin.yml libraries (Adventure, Gson, etc.)
+- **libraries-shade**: Shaded and relocated (BStats, ProtectionLib, InventoryFramework)
+- **plugins**: Soft dependencies (ProtocolLib, PlaceholderAPI, MythicMobs, etc.)
+
+All shaded dependencies are relocated to io.th0rgal.oraxen.shaded.* to avoid conflicts.
+
+### Compatibilities
+
+Integration with third-party plugins (io.th0rgal.oraxen.compatibilities.provided):
+- Each compatibility has a provider class that checks if the plugin is available
+- Wrapped classes (e.g., WrappedMMOItem) provide type-safe access to external APIs
+- CompatibilitiesManager loads all compatible plugins at runtime
+
+Supported: MythicMobs, MythicCrucible, MMOItems, WorldEdit, PlaceholderAPI, EcoItems, BlockLocker, BossShopPro, Skript, ModelEngine
+
+## Key Paths
+
+| Purpose | Location |
+|---------|----------|
+| Plugin entry | `core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java` |
+| NMS interface | `core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java` |
+| Pack generation | `core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java` |
+| Mechanics | `core/src/main/java/io/th0rgal/oraxen/mechanics/provided/` |
+| Commands | `core/src/main/java/io/th0rgal/oraxen/commands/` |
+| Compatibility | `core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/` |
+| Item configs | `core/src/main/resources/items/` |
+| YAML resources | `core/src/main/resources/` (glyphs/, recipes/, languages/, pack/, hud.yml, mechanics.yml) |
+
+## Gradle Properties
+
+Set in gradle.properties for development:
+- `oraxen_spigot_plugin_path`: Auto-copy built jar to this directory
+- `oraxen_dev_plugin_path`, `oraxen_folia_plugin_path`: Alternative plugin paths
+- `oraxen_compiled`: Whether this is a compiled/production build
+
+## Coding Conventions
+
+### Java Style
+- **Language**: Java 21 via Gradle toolchain
+- **Naming**: Classes `PascalCase`, methods/fields `camelCase`, constants `SCREAMING_SNAKE_CASE`
+- **Nullability**: Use `@NotNull`/`@Nullable` (org.jetbrains) on public APIs and NMS boundaries
+- **Logging**: Use `io.th0rgal.oraxen.utils.logs.Logs` for console, `Message` enum for user strings
+- **Exceptions**: Fail fast with guard clauses; log via `Logs`, don't swallow exceptions
+- **Imports**: Keep explicit (no wildcards)
+- **Text Components**: Use Adventure for text components (not legacy chat)
+
+### Code Organization
+- Public APIs and shared logic in `core`
+- Server-version-specific code in `v1_xx_Ry` modules
+- Match existing code style and formatting
+
+### Over-Engineering Avoidance
+- Only make changes directly requested
+- Keep solutions simple and focused
+- Don't add features, refactor code, or make "improvements" beyond what was asked
+- Don't create abstractions for one-time operations
+- Trust internal code and framework guarantees
+
+## Adding Support for New MC Versions
+
+1. Create new `v1_xx_Ry` module
+2. Implement `NMSHandler` against Paper dev bundle
+3. Update `SUPPORTED_VERSIONS` in root `build.gradle.kts`
+4. Include module in `settings.gradle.kts`
+
+## Important Notes
+
+- The main plugin class is io.th0rgal.oraxen.OraxenPlugin
+- NMS handlers are initialized in io.th0rgal.oraxen.nms.NMSHandlers and GlyphHandlers
+- Item builders use creative-api for resource pack generation
+- Custom block data uses Jeff Media's CustomBlockData library
+- Folia support is enabled
+- Paper API version: 1.18+
+
+## Security
+
+- Never paste secrets into code, docs, or commits
+- Wire code to read from environment variables
+- Validate external input at boundaries

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew:*)",
+      "Bash(java:*)",
+      "Bash(git:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(rm:*)",
+      "Bash(jq:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ local.properties
 
 # Test server for schema generation
 test-server/
+
+# Claude Code
+.claude/secrets.json


### PR DESCRIPTION
## Summary
Add `.claude/` directory with project documentation, tool configuration, and local secrets management. This enables Claude Code to understand Oraxen's architecture, coding conventions, and build system, improving code assistance and consistency.

## Changes
- `.claude/CLAUDE.md` — Comprehensive project documentation including tech stack, build commands, module structure, and coding conventions
- `.claude/settings.json` — Tool permissions configuration for Bash commands
- `.claude/secrets.json` — Local secrets copied from `~/minecraft/secrets.json` (gitignored)
- Updated `.gitignore` to exclude secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up Claude Code project context and tightens ignore rules. No runtime code changes.
> 
> - Adds `.claude/CLAUDE.md` with build commands, architecture overview, APIs, and coding conventions
> - Adds `.claude/settings.json` defining allowed Bash commands for Claude Code
> - Updates `.gitignore` to ignore `test-server/` and `.claude/secrets.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c421ffd403855bf2259e4da2590e03557e0673a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->