### PR TITLE
feat: auto-update Paper config to disable block updates

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/chorusblock/ChorusBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/chorusblock/ChorusBlockMechanicFactory.java
@@ -69,13 +69,10 @@ public class ChorusBlockMechanicFactory extends MechanicFactory {
                     new ChorusBlockMechanicListener.ChorusBlockMechanicPhysicsListener());
         }
 
-        // Warn if Paper config is not set
+        // Warn if Paper config is not set (auto-update happens earlier in plugin enable)
         if (VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.20.1")
                 && !NMSHandlers.isChorusPlantUpdatesDisabled()) {
-            Logs.logError("Paper's block-updates.disable-chorus-plant-updates is not enabled.");
-            Logs.logWarning("It is recommended to enable this setting for improved performance and prevent bugs with chorus plants");
-            Logs.logWarning("Otherwise Oraxen needs to listen to very taxing events, which also introduces some bugs");
-            Logs.logWarning("You can enable this setting in ServerFolder/config/paper-global.yml", true);
+            Logs.logWarning("Paper's block-updates.disable-chorus-plant-updates is not enabled, restart may be required");
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicFactory.java
@@ -70,11 +70,9 @@ public class NoteBlockMechanicFactory extends MechanicFactory {
             MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new NoteBlockMechanicListener.NoteBlockMechanicPaperListener());
         if (!VersionUtil.isPaperServer() || !NMSHandlers.isNoteblockUpdatesDisabled())
             MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new NoteBlockMechanicListener.NoteBlockMechanicPhysicsListener());
+        // Warn if Paper config is not set (auto-update happens earlier in plugin enable)
         if (VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.20.1") && !NMSHandlers.isNoteblockUpdatesDisabled()) {
-            Logs.logError("Papers block-updates.disable-noteblock-updates is not enabled.");
-            Logs.logWarning("It is recommended to enable this setting for improved performance and prevent bugs with noteblocks");
-            Logs.logWarning("Otherwise Oraxen needs to listen to very taxing events, which also introduces some bugs");
-            Logs.logWarning("You can enable this setting in ServerFolder/config/paper-global.yml", true);
+            Logs.logWarning("Papers block-updates.disable-noteblock-updates is not enabled, restart may be required");
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicFactory.java
@@ -67,11 +67,9 @@ public class StringBlockMechanicFactory extends MechanicFactory {
             MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new StringBlockMechanicListener.StringBlockMechanicPaperListener());
         if (!VersionUtil.isPaperServer() || !NMSHandlers.isTripwireUpdatesDisabled())
             MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new StringBlockMechanicListener.StringBlockMechanicPhysicsListener());
+        // Warn if Paper config is not set (auto-update happens earlier in plugin enable)
         if (VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.20.1") && !NMSHandlers.isTripwireUpdatesDisabled()) {
-            Logs.logError("Papers block-updates.disable-tripwire-updates is not enabled.");
-            Logs.logWarning("It is recommended to enable this setting for improved performance and prevent bugs with tripwires");
-            Logs.logWarning("Otherwise Oraxen needs to listen to very taxing events, which also introduces some bugs");
-            Logs.logWarning("You can enable this setting in ServerFolder/config/paper-global.yml", true);
+            Logs.logWarning("Papers block-updates.disable-tripwire-updates is not enabled, restart may be required");
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PaperConfigUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PaperConfigUpdater.java
@@ -1,0 +1,123 @@
+package io.th0rgal.oraxen.utils;
+
+import io.th0rgal.oraxen.utils.logs.Logs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to update Paper's paper-global.yml configuration file.
+ * Uses line-by-line processing to preserve comments and formatting.
+ * <p>
+ * Disable auto-update with: -Doraxen.autoUpdatePaperConfig=false
+ */
+public final class PaperConfigUpdater {
+
+    private static final String CONFIG_FILE = "config/paper-global.yml";
+
+    private PaperConfigUpdater() {}
+
+    /**
+     * Ensures all block update settings are disabled in paper-global.yml.
+     * Updates: disable-noteblock-updates, disable-tripwire-updates, disable-chorus-plant-updates
+     * <p>
+     * Only runs on Paper 1.20.1+ servers.
+     *
+     * @return list of setting names that were updated (empty if none changed)
+     */
+    public static List<String> ensureAllBlockUpdatesDisabled() {
+        List<String> updatedSettings = new ArrayList<>();
+
+        // Check if disabled via system property
+        String prop = System.getProperty("oraxen.autoUpdatePaperConfig");
+        if ("false".equalsIgnoreCase(prop)) {
+            return updatedSettings;
+        }
+
+        if (!VersionUtil.isPaperServer() || !VersionUtil.atOrAbove("1.20.1")) {
+            return updatedSettings;
+        }
+
+        Path configPath = Path.of(CONFIG_FILE);
+        if (!Files.exists(configPath)) {
+            return updatedSettings;
+        }
+
+        try {
+            List<String> lines = Files.readAllLines(configPath);
+            List<String> updatedLines = new ArrayList<>(lines);
+
+            boolean inBlockUpdates = false;
+            int blockUpdatesIndent = -1;
+
+            for (int i = 0; i < updatedLines.size(); i++) {
+                String line = updatedLines.get(i);
+                String trimmed = line.trim();
+
+                // Track when we enter the block-updates section
+                if (trimmed.startsWith("block-updates:")) {
+                    inBlockUpdates = true;
+                    blockUpdatesIndent = getIndent(line);
+                    continue;
+                }
+
+                // Check if we've exited the block-updates section
+                if (inBlockUpdates && !trimmed.isEmpty() && !trimmed.startsWith("#")) {
+                    int currentIndent = getIndent(line);
+                    if (currentIndent <= blockUpdatesIndent) {
+                        inBlockUpdates = false;
+                    }
+                }
+
+                // Process settings within block-updates
+                if (inBlockUpdates) {
+                    String updated = tryUpdateSetting(line, "disable-noteblock-updates", updatedSettings);
+                    if (updated != null) { updatedLines.set(i, updated); continue; }
+
+                    updated = tryUpdateSetting(line, "disable-tripwire-updates", updatedSettings);
+                    if (updated != null) { updatedLines.set(i, updated); continue; }
+
+                    updated = tryUpdateSetting(line, "disable-chorus-plant-updates", updatedSettings);
+                    if (updated != null) { updatedLines.set(i, updated); }
+                }
+            }
+
+            // Only write if we made changes
+            if (!updatedSettings.isEmpty()) {
+                Files.write(configPath, updatedLines);
+            }
+
+        } catch (IOException e) {
+            Logs.logWarning("Failed to auto-update paper-global.yml: " + e.getMessage());
+        }
+
+        return updatedSettings;
+    }
+
+    private static String tryUpdateSetting(String line, String settingName, List<String> updatedSettings) {
+        // Pattern: "  disable-noteblock-updates: false" -> true
+        Pattern pattern = Pattern.compile("^(\\s*)" + Pattern.quote(settingName) + ":\\s*false\\s*$");
+        Matcher matcher = pattern.matcher(line);
+
+        if (matcher.matches()) {
+            updatedSettings.add(settingName);
+            return matcher.group(1) + settingName + ": true";
+        }
+        return null;
+    }
+
+    private static int getIndent(String line) {
+        int indent = 0;
+        for (char c : line.toCharArray()) {
+            if (c == ' ') indent++;
+            else if (c == '\t') indent += 2;
+            else break;
+        }
+        return indent;
+    }
+}


### PR DESCRIPTION
Adds PaperConfigUpdater utility that automatically updates paper-global.yml to set disable-noteblock-updates, disable-tripwire-updates, and disable-chorus-plant-updates to true on Paper 1.20.1+ servers.

This improves performance and prevents bugs with custom blocks. The auto-update can be disabled with -Doraxen.autoUpdatePaperConfig=false.

Also simplifies the warning messages in mechanic factories since config is now auto-updated (just shows "restart may be required" if setting not yet active).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Auto-configure Paper block updates**
> 
> - Adds `PaperConfigUpdater.ensureAllBlockUpdatesDisabled` to edit `config/paper-global.yml` on Paper 1.20.1+ and set `disable-noteblock-updates`, `disable-tripwire-updates`, and `disable-chorus-plant-updates` to `true`. Preserves comments/formatting, only writes when changes occur, and can be disabled via `-Doraxen.autoUpdatePaperConfig=false`.
> - Simplifies warnings in `NoteBlockMechanicFactory`, `StringBlockMechanicFactory`, and `ChorusBlockMechanicFactory` to a single notice indicating a restart may be required when the setting isn't active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0e04d92d517dd9a82aeafca85a7cb1b8834bf3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->