### PR TITLE
feat: add config option to disable PaperConfigUpdater

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -15,6 +15,7 @@ public enum Settings {
     PLUGIN_LANGUAGE("Plugin.language"),
     KEEP_UP_TO_DATE("Plugin.keep_this_up_to_date"),
     REPAIR_COMMAND_ORAXEN_DURABILITY("Plugin.commands.repair.oraxen_durability_only"),
+    AUTO_UPDATE_PAPER_CONFIG("Plugin.auto_update_paper_config"),
     GENERATE_DEFAULT_ASSETS("Plugin.generation.default_assets"),
     GENERATE_DEFAULT_CONFIGS("Plugin.generation.default_configs"),
     FORMAT_INVENTORY_TITLES("Plugin.formatting.inventory_titles"),

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PaperConfigUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PaperConfigUpdater.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.utils;
 
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.logs.Logs;
 
 import java.io.IOException;
@@ -14,7 +15,8 @@ import java.util.regex.Pattern;
  * Utility class to update Paper's paper-global.yml configuration file.
  * Uses line-by-line processing to preserve comments and formatting.
  * <p>
- * Disable auto-update with: -Doraxen.autoUpdatePaperConfig=false
+ * Disable auto-update via settings.yml: Plugin.auto_update_paper_config: false
+ * Or via system property: -Doraxen.autoUpdatePaperConfig=false
  */
 public final class PaperConfigUpdater {
 
@@ -33,7 +35,10 @@ public final class PaperConfigUpdater {
     public static List<String> ensureAllBlockUpdatesDisabled() {
         List<String> updatedSettings = new ArrayList<>();
 
-        // Check if disabled via system property
+        // Check if disabled via config or system property
+        if (!Settings.AUTO_UPDATE_PAPER_CONFIG.toBool()) {
+            return updatedSettings;
+        }
         String prop = System.getProperty("oraxen.autoUpdatePaperConfig");
         if ("false".equalsIgnoreCase(prop)) {
             return updatedSettings;

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -5,6 +5,7 @@ Plugin:
   commands:
     repair:
       oraxen_durability_only: false # will not repair vanilla items if set to true
+  auto_update_paper_config: true # Auto-update paper-global.yml to disable block updates for custom blocks
   generation:
     default_assets: true
     default_configs: true


### PR DESCRIPTION
Add Plugin.auto_update_paper_config setting (default: true) to control automatic paper-global.yml updates. System property override still works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable toggle for Paper config auto-updates.
> 
> - New `Settings.AUTO_UPDATE_PAPER_CONFIG` with `settings.yml` default `Plugin.auto_update_paper_config: true`
> - `PaperConfigUpdater.ensureAllBlockUpdatesDisabled` now checks `Settings.AUTO_UPDATE_PAPER_CONFIG` before applying changes
> - Updated docs/comments to reflect settings-based and system property (`-Doraxen.autoUpdatePaperConfig=false`) controls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9407df8cc00b8b4fdf326f5b11e16c2e34d0906. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->