### PR TITLE
Implement opt-in marker for text effects

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/font/TextEffectEncoding.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/TextEffectEncoding.java
@@ -55,9 +55,10 @@ public interface TextEffectEncoding {
      * @param lowMask Mask for low bits
      * @param dataMin Lowest allowed encoded low-nibble value
      * @param dataGap Optional gap value to skip (set to -1 for none)
+     * @param rHighMarker High nibble marker for red channel (e.g., 0xF0); shader checks (R & 0xF0) == rHighMarker
      * @param charIndexFromVertexId Whether shader should derive char index from gl_VertexID
      */
-    record ShaderEncoding(int lsbBits, int dataMask, int lowMask, int dataMin, int dataGap, boolean charIndexFromVertexId) {
+    record ShaderEncoding(int lsbBits, int dataMask, int lowMask, int dataMin, int dataGap, int rHighMarker, boolean charIndexFromVertexId) {
         public int dataMax() {
             int max = dataMin + dataMask;
             if (dataGap >= dataMin && dataGap <= max) {
@@ -68,6 +69,10 @@ public interface TextEffectEncoding {
 
         public boolean hasGap() {
             return dataGap >= 0;
+        }
+
+        public boolean hasHighMarker() {
+            return rHighMarker >= 0;
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -1007,10 +1007,12 @@ public class ResourcePack {
                 const bool ORAXEN_ANIMATED_GLYPHS = %s;
                 const bool ORAXEN_TEXT_EFFECTS = %s;
                 const int ORAXEN_TEXT_LOW_MASK = %d;
+                const int ORAXEN_TEXT_HIGH_MASK = 0xF0;
                 const int ORAXEN_TEXT_DATA_MASK = %d;
                 const int ORAXEN_TEXT_DATA_MIN = %d;
                 const int ORAXEN_TEXT_DATA_MAX = %d;
                 const int ORAXEN_TEXT_DATA_GAP = %d;
+                const int ORAXEN_TEXT_R_HIGH_MARKER = %d;
                 """,
                 features.animatedGlyphs() ? "true" : "false",
                 features.textEffects() ? "true" : "false",
@@ -1018,7 +1020,8 @@ public class ResourcePack {
                 encoding.dataMask(),
                 encoding.dataMin(),
                 dataMax,
-                encoding.dataGap());
+                encoding.dataGap(),
+                encoding.rHighMarker());
     }
 
     private TextEffectSnippets getTextEffectSnippets(TextShaderTarget target) {
@@ -1210,7 +1213,9 @@ public class ResourcePack {
                             int gLow = gRaw & ORAXEN_TEXT_LOW_MASK;
                             int bLow = bRaw & ORAXEN_TEXT_LOW_MASK;
                             bool hasGap = ORAXEN_TEXT_DATA_GAP >= 0;
-                            bool hasMarker = (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
+                            bool hasHighMarker = (rInt & ORAXEN_TEXT_HIGH_MASK) == ORAXEN_TEXT_R_HIGH_MARKER;
+                            bool hasMarker = hasHighMarker
+                                    && (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
                                     && (gLow >= ORAXEN_TEXT_DATA_MIN && gLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || gLow != ORAXEN_TEXT_DATA_GAP))
                                     && (bLow >= ORAXEN_TEXT_DATA_MIN && bLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || bLow != ORAXEN_TEXT_DATA_GAP));
 
@@ -1307,13 +1312,15 @@ public class ResourcePack {
                         }
                     }
 
-                    // Text effects: encoded in low RGB bits (alpha_lsb)
+                    // Text effects: encoded in low RGB bits (alpha_lsb) with high-nibble marker
                     if (ORAXEN_TEXT_EFFECTS && (!ORAXEN_ANIMATED_GLYPHS || (!isPrimaryAnim && !isShadowAnim))) {
                         int rLow = rInt & ORAXEN_TEXT_LOW_MASK;
                         int gLow = gRaw & ORAXEN_TEXT_LOW_MASK;
                         int bLow = bRaw & ORAXEN_TEXT_LOW_MASK;
                         bool hasGap = ORAXEN_TEXT_DATA_GAP >= 0;
-                        bool hasMarker = (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
+                        bool hasHighMarker = (rInt & ORAXEN_TEXT_HIGH_MASK) == ORAXEN_TEXT_R_HIGH_MARKER;
+                        bool hasMarker = hasHighMarker
+                                && (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
                                 && (gLow >= ORAXEN_TEXT_DATA_MIN && gLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || gLow != ORAXEN_TEXT_DATA_GAP))
                                 && (bLow >= ORAXEN_TEXT_DATA_MIN && bLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || bLow != ORAXEN_TEXT_DATA_GAP));
 
@@ -1417,7 +1424,9 @@ public class ResourcePack {
                             int gLow = gRaw & ORAXEN_TEXT_LOW_MASK;
                             int bLow = bRaw & ORAXEN_TEXT_LOW_MASK;
                             bool hasGap = ORAXEN_TEXT_DATA_GAP >= 0;
-                            bool hasMarker = (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
+                            bool hasHighMarker = (rInt & ORAXEN_TEXT_HIGH_MASK) == ORAXEN_TEXT_R_HIGH_MARKER;
+                            bool hasMarker = hasHighMarker
+                                    && (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
                                     && (gLow >= ORAXEN_TEXT_DATA_MIN && gLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || gLow != ORAXEN_TEXT_DATA_GAP))
                                     && (bLow >= ORAXEN_TEXT_DATA_MIN && bLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || bLow != ORAXEN_TEXT_DATA_GAP));
 
@@ -1513,13 +1522,15 @@ public class ResourcePack {
                         }
                     }
 
-                    // Text effects: encoded in low RGB bits (alpha_lsb)
+                    // Text effects: encoded in low RGB bits (alpha_lsb) with high-nibble marker
                     if (ORAXEN_TEXT_EFFECTS && (!ORAXEN_ANIMATED_GLYPHS || (!isPrimaryAnim && !isShadowAnim))) {
                         int rLow = rInt & ORAXEN_TEXT_LOW_MASK;
                         int gLow = gRaw & ORAXEN_TEXT_LOW_MASK;
                         int bLow = bRaw & ORAXEN_TEXT_LOW_MASK;
                         bool hasGap = ORAXEN_TEXT_DATA_GAP >= 0;
-                        bool hasMarker = (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
+                        bool hasHighMarker = (rInt & ORAXEN_TEXT_HIGH_MASK) == ORAXEN_TEXT_R_HIGH_MARKER;
+                        bool hasMarker = hasHighMarker
+                                && (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
                                 && (gLow >= ORAXEN_TEXT_DATA_MIN && gLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || gLow != ORAXEN_TEXT_DATA_GAP))
                                 && (bLow >= ORAXEN_TEXT_DATA_MIN && bLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || bLow != ORAXEN_TEXT_DATA_GAP));
 
@@ -1889,13 +1900,15 @@ public class ResourcePack {
                         }
                     }
 
-                    // Text effects: encoded in low RGB bits (alpha_lsb)
+                    // Text effects: encoded in low RGB bits (alpha_lsb) with high-nibble marker
                     if (ORAXEN_TEXT_EFFECTS && (!ORAXEN_ANIMATED_GLYPHS || (!isPrimaryAnim && !isShadowAnim))) {
                         int rLow = rInt & ORAXEN_TEXT_LOW_MASK;
                         int gLow = gRaw & ORAXEN_TEXT_LOW_MASK;
                         int bLow = bRaw & ORAXEN_TEXT_LOW_MASK;
                         bool hasGap = ORAXEN_TEXT_DATA_GAP >= 0;
-                        bool hasMarker = (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
+                        bool hasHighMarker = (rInt & ORAXEN_TEXT_HIGH_MASK) == ORAXEN_TEXT_R_HIGH_MARKER;
+                        bool hasMarker = hasHighMarker
+                                && (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
                                 && (gLow >= ORAXEN_TEXT_DATA_MIN && gLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || gLow != ORAXEN_TEXT_DATA_GAP))
                                 && (bLow >= ORAXEN_TEXT_DATA_MIN && bLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || bLow != ORAXEN_TEXT_DATA_GAP));
 
@@ -2004,13 +2017,15 @@ public class ResourcePack {
                         }
                     }
 
-                    // Text effects: encoded in low RGB bits (alpha_lsb)
+                    // Text effects: encoded in low RGB bits (alpha_lsb) with high-nibble marker
                     if (ORAXEN_TEXT_EFFECTS && (!ORAXEN_ANIMATED_GLYPHS || (!isPrimaryAnim && !isShadowAnim))) {
                         int rLow = rInt & ORAXEN_TEXT_LOW_MASK;
                         int gLow = gRaw & ORAXEN_TEXT_LOW_MASK;
                         int bLow = bRaw & ORAXEN_TEXT_LOW_MASK;
                         bool hasGap = ORAXEN_TEXT_DATA_GAP >= 0;
-                        bool hasMarker = (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
+                        bool hasHighMarker = (rInt & ORAXEN_TEXT_HIGH_MASK) == ORAXEN_TEXT_R_HIGH_MARKER;
+                        bool hasMarker = hasHighMarker
+                                && (rLow >= ORAXEN_TEXT_DATA_MIN && rLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || rLow != ORAXEN_TEXT_DATA_GAP))
                                 && (gLow >= ORAXEN_TEXT_DATA_MIN && gLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || gLow != ORAXEN_TEXT_DATA_GAP))
                                 && (bLow >= ORAXEN_TEXT_DATA_MIN && bLow <= ORAXEN_TEXT_DATA_MAX && (!hasGap || bLow != ORAXEN_TEXT_DATA_GAP));
 


### PR DESCRIPTION
Adds a high-nibble marker (0xF0) to the red channel for text effect detection, making the system opt-in. This prevents accidental matches with regular text colors while maintaining the existing low-nibble encoding for effect parameters.

The marker ensures only intentionally encoded colors trigger text effects, avoiding false positives from natural colors. Red channel values are constrained to 241-249 (0xF1-0xF9).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an opt-in detection marker to make text effects explicit and avoid accidental matches.
> 
> - `AlphaLsbEncoding`: adds `HIGH_MASK` and `R_HIGH_MARKER (0xF0)`, forces R high nibble during `encode`, checks marker in `matches`, updates javadoc; removes sentinel nudge; passes `rHighMarker` to shader encoding
> - `TextEffectEncoding.ShaderEncoding`: extends record with `rHighMarker` and `hasHighMarker()`
> - `ResourcePack`: emits new shader constants (`ORAXEN_TEXT_HIGH_MASK`, `ORAXEN_TEXT_R_HIGH_MARKER`) and updates all text shaders to verify the R high-nibble marker before decoding `effectType/speed/param`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 328a80f31a394208f43e92f2cc6d7d28316135e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->