### PR TITLE
bump: update inventory framework to 0.11.6 for 1.21.11 support

### DIFF
--- a/gradle/oraxenLibs.versions.toml
+++ b/gradle/oraxenLibs.versions.toml
@@ -119,7 +119,7 @@ protectionlib = { module = "io.th0rgal:protectionlib", version = "1.8.0" }
 
 # InventoryFramework https://github.com/stefvanschie/IF
 # Repo: Maven Central
-inventoryframework = { module = "com.github.stefvanschie.inventoryframework:IF", version = "0.11.5" }
+inventoryframework = { module = "com.github.stefvanschie.inventoryframework:IF", version = "0.11.6" }
 
 # Repo: Maven Central
 # https://github.com/mfnalex/CustomBlockData


### PR DESCRIPTION
> [!TIP]
>
> **Summary**
> - Updated inventory framework to 0.11.6 to support 1.21.11 which previously caused exceptions in the recipes menu.