### PR TITLE
fix: better handling for armor trim settings & bugfix

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorType.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/customarmor/CustomArmorType.java
@@ -26,10 +26,33 @@ public enum CustomArmorType {
             }
             return customArmorType;
         } catch (IllegalArgumentException e) {
-            CustomArmorType defaultType = VersionUtil.atOrAbove("1.21.2") ? COMPONENT : VersionUtil.atOrAbove("1.20") ? TRIMS : NONE;
-            Logs.logError("Invalid custom armor type: " + type);
-            Logs.logError("Defaulting to %s.".formatted(defaultType));
+            CustomArmorType defaultType = getBestForCurrentVersion();
+            Logs.logError("Invalid or incompatible custom armor type - " + type);
+            Logs.logError("Defaulting to %s based on your Minecraft version.".formatted(defaultType));
+
+            // Persist the corrected value back to settings.yml so future loads use the compatible type
+            Settings.CUSTOM_ARMOR_TYPE.setValue(defaultType.name());
             return defaultType;
+        }
+    }
+
+    /**
+     * Determines the most suitable CustomArmorType for the running server version.
+     *
+     * Components: 1.21.2+
+     * Trims:      1.20 - 1.21.1
+     * Shaders:    1.18 - 1.19.4
+     * None:       below 1.18 or when custom armor is not supported
+     */
+    private static CustomArmorType getBestForCurrentVersion() {
+        if (VersionUtil.atOrAbove("1.21.2")) {
+            return COMPONENT;
+        } else if (VersionUtil.atOrAbove("1.20")) {
+            return TRIMS;
+        } else if (VersionUtil.atOrAbove("1.18")) {
+            return SHADER;
+        } else {
+            return NONE;
         }
     }
 }


### PR DESCRIPTION
## 🟠 Fix `SHADER` armor type skipped in version fallback logic

- **Summary** - Fixes custom armor type fallback to correctly default to SHADER on Minecraft 1.18-1.19.4, and auto-persists corrected values to prevent repeated errors

- **Description** - The original ternary fallback logic incorrectly skipped SHADER, causing servers running Minecraft 1.18-1.19.4 with invalid/incompatible custom armor configs to default to NONE instead of SHADER, breaking custom armor functionality. This fix extracts the logic into `getBestForCurrentVersion()` which properly includes all version ranges (COMPONENT for 1.21.2+, TRIMS for 1.20-1.21.1, SHADER for 1.18-1.19.4, NONE for <1.18). Additionally, the corrected value is now auto-persisted to `settings.yml` to prevent repeated error messages on reload.

- **Verification** - On a Minecraft 1.18-1.19.4 test server: (1) Set `CustomArmor.type: COMPONENT` in settings.yml, (2) Start server and verify logs show "Defaulting to SHADER based on your Minecraft version", (3) Confirm custom armor works correctly, (4) Check settings.yml is auto-corrected to `type: SHADER`, (5) Run `/oraxen reload` and verify no repeated errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures version-appropriate custom armor selection and prevents repeated misconfiguration errors.
> 
> - Extracts `getBestForCurrentVersion()` to map versions → `COMPONENT` (1.21.2+), `TRIMS` (1.20–1.21.1), `SHADER` (1.18–1.19.4), `NONE` (<1.18)
> - On invalid/incompatible types in `fromString`, logs concise errors, defaults using the helper, and persists via `Settings.CUSTOM_ARMOR_TYPE.setValue(...)`
> - Single-file change: `CustomArmorType.java`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d3322407601558c9f7500731de14bd2187473b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->