### PR TITLE
Fix WorldEdit dependency resolution and generate-schema workflow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,10 @@ allprojects {
             content { includeGroup("com.willfp") } // EcoItems, eco, libreforge
         }
         maven("https://maven.enginehub.org/repo/") {
-            content { includeGroupAndSubgroups("com.sk89q.worldedit") } // world edit
+            content {
+                includeGroupAndSubgroups("com.sk89q.worldedit") // world edit
+                includeGroupAndSubgroups("org.enginehub") // WorldEdit transitive dependencies (lin-bus-bom, etc)
+            }
         }
         maven("https://nexus.phoenixdevt.fr/repository/maven-public/") {
             content {


### PR DESCRIPTION
## Summary
- Fix WorldEdit dependency resolution by adding org.enginehub group access to the EngineHub Maven repository
- This allows WorldEdit's transitive dependencies (specifically `org.enginehub.lin-bus:lin-bus-bom`) to be resolved

## Test plan
- [x] Build locally passes with `./gradlew build -x test`
- [ ] Generate-schema workflow will be tested after PR merge/on workflow dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes dependency resolution for WorldEdit by broadening EngineHub repo includes.
> 
> - Updates `build.gradle.kts` to include `org.enginehub` alongside `com.sk89q.worldedit` in the EngineHub Maven repository, enabling resolution of WorldEdit’s transitive deps (e.g., `org.enginehub.lin-bus:lin-bus-bom`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd1e1be2f4d255979f9b5e8413e9fe0a32a8727. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->