### PR TITLE
Exclude Spigot NMS modules from CI builds

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "oraxen"
 
+val isCI = System.getenv("CI") != null
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
@@ -27,25 +29,32 @@ dependencyResolutionManagement {
     }
 }
 
+// Core and Paper NMS modules (always included)
 include(
     "core",
     "v1_20_R1",
     "v1_20_R2",
     "v1_20_R3",
     "v1_20_R4",
-    "v1_20_R4_spigot",
     "v1_21_R1",
-    "v1_21_R1_spigot",
     "v1_21_R2",
-    "v1_21_R2_spigot",
     "v1_21_R3",
-    "v1_21_R3_spigot",
     "v1_21_R4",
-    "v1_21_R4_spigot",
     "v1_21_R5",
-    "v1_21_R5_spigot",
     "v1_21_R6_old",
-    "v1_21_R6_old_spigot",
-    "v1_21_R6",
-    "v1_21_R6_spigot"
+    "v1_21_R6"
 )
+
+// Spigot NMS modules (excluded in CI - requires BuildTools to install Spigot artifacts to local Maven)
+if (!isCI) {
+    include(
+        "v1_20_R4_spigot",
+        "v1_21_R1_spigot",
+        "v1_21_R2_spigot",
+        "v1_21_R3_spigot",
+        "v1_21_R4_spigot",
+        "v1_21_R5_spigot",
+        "v1_21_R6_old_spigot",
+        "v1_21_R6_spigot"
+    )
+}


### PR DESCRIPTION
## Summary
- Move Spigot module exclusion from `build.gradle.kts` `SUPPORTED_VERSIONS` to `settings.gradle.kts` `include()`
- This prevents Gradle from attempting to build Spigot modules in CI, which would fail because they require BuildTools artifacts in local Maven

## Test plan
- [x] Build locally passes with `./gradlew build -x test`
- [x] Build with `CI=true ./gradlew build -x test` excludes Spigot modules
- [ ] CI workflow will test this automatically

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes Spigot NMS modules opt-in locally and excluded on CI via conditional includes in `settings.gradle.kts`.
> 
> - Adds `isCI` flag and wraps Spigot module `include(...)` calls in `if (!isCI)`
> - Keeps core and Paper NMS modules always included; removes Spigot modules from the default include list
> - Centralizes module selection in `settings.gradle.kts` instead of build-time logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1abd95a3a613c3436926b460f97706f09efd9844. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->