### PR TITLE
Update generate-schema workflow to use Paper 1.21.11

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -50,7 +50,7 @@ jobs:
           cp build/libs/oraxen-*.jar test-server/plugins/
           
           # Download Paper server
-          curl -sL -o test-server/paper.jar "https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds/224/downloads/paper-1.21.4-224.jar"
+          curl -sL -o test-server/paper.jar "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar"
           
           # Download CommandAPI
           curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/JorelAli/CommandAPI/releases/download/9.7.0/CommandAPI-9.7.0.jar"


### PR DESCRIPTION
## Summary
- Update Paper server version from 1.21.4 to 1.21.11 for schema generation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the CI workflow to use a newer Paper server for schema generation.
> 
> - In `.github/workflows/generate-schema.yml`, changes the Paper download URL from `1.21.4-224` to `1.21.11-69` used by the test server during schema generation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bba5dac5c087ae308224ebcccb8a9145fb09cb1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->