### PR TITLE
Fix generate-schema: Update CommandAPI to 11.0.0

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -52,8 +52,8 @@ jobs:
           # Download Paper server
           curl -sL -o test-server/paper.jar "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar"
           
-          # Download CommandAPI
-          curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/JorelAli/CommandAPI/releases/download/9.7.0/CommandAPI-9.7.0.jar"
+          # Download CommandAPI (version must match gradle/oraxenLibs.versions.toml)
+          curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/JorelAli/CommandAPI/releases/download/11.0.0/CommandAPI-11.0.0.jar"
           
           # Accept EULA
           echo "eula=true" > test-server/eula.txt


### PR DESCRIPTION
## Summary
- Update CommandAPI from 9.7.0 to 11.0.0 to match the version used in gradle/oraxenLibs.versions.toml
- The previous version caused `NoClassDefFoundError: dev/jorel/commandapi/AbstractCommandAPICommand`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub Actions `generate-schema.yml` workflow to align the test server dependency with the project.
> 
> - Bumps downloaded `CommandAPI` in the test server setup from `9.7.0` to `11.0.0` (to match `gradle/oraxenLibs.versions.toml`)
> - Adds clarifying comment about version alignment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 915c932f3160966b2a4555a46fd90f9f6f55ab41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->