### PR TITLE
Fix CommandAPI download URL in generate-schema workflow

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -53,7 +53,7 @@ jobs:
           curl -sL -o test-server/paper.jar "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar"
           
           # Download CommandAPI (version must match gradle/oraxenLibs.versions.toml)
-          curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/JorelAli/CommandAPI/releases/download/11.0.0/CommandAPI-11.0.0.jar"
+          curl -sL -L -o test-server/plugins/CommandAPI.jar "https://github.com/CommandAPI/CommandAPI/releases/download/11.0.0/CommandAPI-11.0.0.jar"
           
           # Accept EULA
           echo "eula=true" > test-server/eula.txt


### PR DESCRIPTION
## Summary
- Update CommandAPI download URL from JorelAli/CommandAPI to CommandAPI/CommandAPI (repo was renamed)
- The previous URL caused the downloaded file to be an HTML redirect page, not a JAR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the CI workflow downloads the actual CommandAPI JAR during schema generation.
> 
> - In `generate-schema.yml`, switch URL to `github.com/CommandAPI/CommandAPI/...` and add `-L` to `curl` for redirects when fetching `CommandAPI.jar`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1a08a07d072ef537f22ed40d401fe3a6b7fc391. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->