### PR TITLE
Fix CommandAPI jar filename in generate-schema workflow

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -53,7 +53,7 @@ jobs:
           curl -sL -o test-server/paper.jar "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar"
           
           # Download CommandAPI (version must match gradle/oraxenLibs.versions.toml)
-          curl -sL -L -o test-server/plugins/CommandAPI.jar "https://github.com/CommandAPI/CommandAPI/releases/download/11.0.0/CommandAPI-11.0.0.jar"
+          curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/CommandAPI/CommandAPI/releases/download/11.0.0/CommandAPI-11.0.0-Paper.jar"
           
           # Accept EULA
           echo "eula=true" > test-server/eula.txt


### PR DESCRIPTION
## Summary
- Use `CommandAPI-11.0.0-Paper.jar` instead of `CommandAPI-11.0.0.jar` (file doesn't exist with that name)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow update**
> 
> - In `generate-schema.yml`, switch CommandAPI download to the Paper-specific artifact (`CommandAPI-11.0.0-Paper.jar`) to match the Paper server used in tests, removing the extra `-L` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f2c2e00c3ee62f7d8d70e6f6a17f506e9156fa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->