### PR TITLE
Update CommandAPI to 11.1.0 in generate-schema workflow

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -52,8 +52,8 @@ jobs:
           # Download Paper server
           curl -sL -o test-server/paper.jar "https://api.papermc.io/v2/projects/paper/versions/1.21.11/builds/69/downloads/paper-1.21.11-69.jar"
           
-          # Download CommandAPI (version must match gradle/oraxenLibs.versions.toml)
-          curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/CommandAPI/CommandAPI/releases/download/11.0.0/CommandAPI-11.0.0-Paper.jar"
+          # Download CommandAPI (must match version in build.gradle.kts runServer)
+          curl -sL -o test-server/plugins/CommandAPI.jar "https://github.com/CommandAPI/CommandAPI/releases/download/11.1.0/CommandAPI-11.1.0-Paper.jar"
           
           # Accept EULA
           echo "eula=true" > test-server/eula.txt


### PR DESCRIPTION
## Summary
- Update CommandAPI from 11.0.0 to 11.1.0 for Paper 1.21.11 compatibility
- This matches the version used in build.gradle.kts runServer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the schema-generation GitHub Actions workflow to use CommandAPI `11.1.0` instead of `11.0.0`.
> 
> - In `generate-schema.yml`, change CommandAPI download URL to `11.1.0` to align with `build.gradle.kts` runServer configuration and Paper `1.21.11`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b46205cdc918f188d84e9792ae90ce1ccaa3e474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->