### PR TITLE
fix: correct release detection for tags in Maven publish workflow

### DIFF
--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -128,10 +128,11 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          
+
           # Only commit if changed
           if [ -f "schemas/oraxen-schema.json" ]; then
             git add schemas/oraxen-schema.json
             git diff --staged --quiet || git commit -m "chore: update oraxen-schema.json for v${{ steps.version.outputs.version }}"
+            git pull --rebase origin master
             git push
           fi

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -101,9 +101,11 @@ class PublishData(private val project: Project) {
     private var hashLength: Int = 7
 
     private fun getReleaseType(): Type {
+        val ref = System.getenv("GITHUB_REF") ?: ""
         val branch = getCheckedOutBranch()
         println("Branch: $branch")
         return when {
+            ref.startsWith("refs/tags/") -> Type.RELEASE
             branch.contentEquals("master") -> Type.RELEASE
             branch.contentEquals("develop") -> Type.SNAPSHOT
             else -> Type.DEV


### PR DESCRIPTION
## Summary
- Add tag detection to `getReleaseType()` so releases from tags publish to the releases repository instead of development
- Add `git pull --rebase` before pushing in schema workflow to handle concurrent commits

## Context
The Maven publish workflow was failing because when triggered by a release tag (e.g., `refs/tags/1.203.2`), the branch detection logic fell back to `DEV` type and tried to publish to `repo.oraxen.com/development/` instead of `repo.oraxen.com/releases/`.

The schema workflow was failing when remote had newer commits by the time the build finished.

## Test plan
- [ ] Re-run the Maven publish workflow for 1.203.2 release after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Release detection:** `core/build.gradle.kts` updates `PublishData.getReleaseType()` to read `GITHUB_REF` and treat `refs/tags/*` as `RELEASE`, ensuring tagged builds publish to the releases repo.
> - **Schema workflow robustness:** `.github/workflows/generate-schema.yml` adds `git pull --rebase origin master` before `git push` to avoid push conflicts when committing generated `schemas/oraxen-schema.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 367f4338fc4864be1781a6de0f6f976e5449d891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->