### PR TITLE
feat: add Translation Support to Display Entity Furniture

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/DisplayEntityProperties.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/DisplayEntityProperties.java
@@ -24,12 +24,14 @@ public class DisplayEntityProperties {
     private final float displayWidth;
     private final float displayHeight;
     private final Vector3f scale;
+    private final Vector3f translation;
 
     public DisplayEntityProperties() {
         this.displayWidth = 0f;
         this.displayHeight = 0f;
         this.displayTransform = ItemDisplay.ItemDisplayTransform.NONE;
         this.scale = null;
+        this.translation = null;
         this.shadowRadius = null;
         this.shadowStrength = null;
         this.brightness = null;
@@ -52,6 +54,12 @@ public class DisplayEntityProperties {
                     (float) configSection.getDouble("scale.y", 1.0),
                     (float) configSection.getDouble("scale.z", 1.0));
         else scale = null;
+
+        if (configSection.isConfigurationSection("translation"))
+            translation = new Vector3f((float) configSection.getDouble("translation.x", 0.0),
+                    (float) configSection.getDouble("translation.y", 0.0),
+                    (float) configSection.getDouble("translation.z", 0.0));
+        else translation = null;
 
         if (viewRange == 0) viewRange = null;
         if (interpolationDuration == 0) interpolationDuration = null;
@@ -162,6 +170,14 @@ public class DisplayEntityProperties {
         return scale;
     }
 
+    public boolean hasTranslation() {
+        return translation != null;
+    }
+
+    public Vector3f getTranslation() {
+        return translation;
+    }
+
     public boolean ensureSameDisplayProperties(@NotNull Entity entity) {
         if (!(entity instanceof ItemDisplay itemDisplay)) return false;
         itemDisplay.setItemDisplayTransform(displayTransform);
@@ -173,6 +189,7 @@ public class DisplayEntityProperties {
         itemDisplay.setInterpolationDuration(Objects.requireNonNullElse(interpolationDuration, 0));
         itemDisplay.setInterpolationDelay(Objects.requireNonNullElse(interpolationDelay, 0));
         itemDisplay.getTransformation().getScale().set(Objects.requireNonNullElse(scale, new Vector3f(1,1,1)));
+        itemDisplay.getTransformation().getTranslation().set(Objects.requireNonNullElse(translation, new Vector3f(0,0,0)));
 
         return true;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -136,6 +136,16 @@ public class FurnitureFactory extends MechanicFactory {
                         "display_transform", MechanicConfigProperty.enumType("display_transform", "Display transform mode",
                                 List.of("NONE", "THIRDPERSON_LEFTHAND", "THIRDPERSON_RIGHTHAND", "FIRSTPERSON_LEFTHAND",
                                         "FIRSTPERSON_RIGHTHAND", "HEAD", "GUI", "GROUND", "FIXED")),
+                        "scale", MechanicConfigProperty.object("scale", "Scale of the display entity", Map.of(
+                                "x", MechanicConfigProperty.decimal("x", "X-axis scale", 1.0),
+                                "y", MechanicConfigProperty.decimal("y", "Y-axis scale", 1.0),
+                                "z", MechanicConfigProperty.decimal("z", "Z-axis scale", 1.0)
+                        )),
+                        "translation", MechanicConfigProperty.object("translation", "Position offset in blocks", Map.of(
+                                "x", MechanicConfigProperty.decimal("x", "X-axis offset", 0.0),
+                                "y", MechanicConfigProperty.decimal("y", "Y-axis offset", 0.0),
+                                "z", MechanicConfigProperty.decimal("z", "Z-axis offset", 0.0)
+                        )),
                         "brightness", MechanicConfigProperty.object("brightness", "Light levels", Map.of(
                                 "block", MechanicConfigProperty.integer("block", "Block light level", 0, 0, 15),
                                 "sky", MechanicConfigProperty.integer("sky", "Sky light level", 0, 0, 15)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -617,6 +617,11 @@ public class FurnitureMechanic extends Mechanic {
             transform.getScale().set(properties.getScale());
         } else transform.getScale().set(isFixed ? new Vector3f(0.5f, 0.5f, 0.5f) : new Vector3f(1f, 1f, 1f));
 
+        // Apply translation offset if specified
+        if (properties.hasTranslation()) {
+            transform.getTranslation().set(properties.getTranslation());
+        }
+
         // since FIXED is meant to mimic ItemFrames, we rotate it to match the ItemFrame's rotation
         // 1.20 Fixes this, will break for 1.19.4 but added disclaimer in console
         float pitch;

--- a/core/src/main/resources/items/furniture.yml
+++ b/core/src/main/resources/items/furniture.yml
@@ -141,6 +141,13 @@ turntable:
           x: 0.75
           y: 0.75
           z: 0.75
+        # Translation allows fine-tuning the exact position of the display entity
+        # Values are in blocks (0.1 = 1/10th of a block)
+        # Useful for adjusting vertical placement or centering models
+        translation:
+          x: 0.0
+          y: 0.1  # Raise the turntable slightly off the ground
+          z: 0.0
       jukebox:
         # NEW: Use active_model instead of active_stage (references Pack.models key)
         active_model: opened

--- a/schemas/oraxen-schema.json
+++ b/schemas/oraxen-schema.json
@@ -7978,6 +7978,48 @@
                 "FIXED"
               ]
             },
+            "scale": {
+              "type": "object",
+              "description": "Scale of the display entity",
+              "properties": {
+                "x": {
+                  "type": "number",
+                  "description": "X-axis scale",
+                  "default": 1.0
+                },
+                "y": {
+                  "type": "number",
+                  "description": "Y-axis scale",
+                  "default": 1.0
+                },
+                "z": {
+                  "type": "number",
+                  "description": "Z-axis scale",
+                  "default": 1.0
+                }
+              }
+            },
+            "translation": {
+              "type": "object",
+              "description": "Position offset of the display entity (in blocks)",
+              "properties": {
+                "x": {
+                  "type": "number",
+                  "description": "X-axis offset in blocks",
+                  "default": 0.0
+                },
+                "y": {
+                  "type": "number",
+                  "description": "Y-axis offset in blocks",
+                  "default": 0.0
+                },
+                "z": {
+                  "type": "number",
+                  "description": "Z-axis offset in blocks",
+                  "default": 0.0
+                }
+              }
+            },
             "brightness": {
               "type": "object",
               "description": "Light levels",


### PR DESCRIPTION
## 🟠 Add Translation Support to Display Entity Furniture

- **Summary** - Added translation (position offset) support to display entity furniture, allowing fine-tuned positioning of models without modifying placement coordinates.

- **Description** - Implemented a new `translation` property in display entity properties that enables X, Y, Z axis offsets in blocks. This complements the existing `scale` property and provides developers with precise control over furniture placement for better model alignment and visual presentation.

- **Changes**
  - Added `translation` field to `DisplayEntityProperties` class with getter methods
  - Updated `DisplayEntityProperties` constructor to initialize translation as null
  - Added configuration parsing for translation values from YAML (x, y, z in blocks)
  - Implemented `hasTranslation()` and `getTranslation()` methods
  - Applied translation to item display transformation in `ensureSameDisplayProperties()`
  - Updated `FurnitureFactory` to expose translation as a configurable mechanic property
  - Applied translation offset in `FurnitureMechanic` when setting up display transforms
  - Updated `furniture.yml` example with translation configuration for turntable
  - Updated `oraxen-schema.json` with translation property schema definition