### PR TITLE
Fix stair blockstate rotations for top-half variants

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/shaped/ShapedBlockMechanicFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/shaped/ShapedBlockMechanicFactory.java
@@ -614,24 +614,21 @@ public class ShapedBlockMechanicFactory extends MechanicFactory {
         model.addProperty("model", modelPath);
 
         // Calculate rotations based on facing, half, and shape
+        // This follows vanilla Minecraft's stair rotation logic:
+        // - Bottom half: _left shapes rotate -90 (270), _right and straight use base rotation
+        // - Top half: _right shapes rotate +90, _left and straight use base rotation
         int x = half.equals("top") ? 180 : 0;
         int y = baseY;
 
-        // Adjust y rotation for shape variants
-        if (shape.equals("inner_left") || shape.equals("outer_left")) {
-            y = (y + 270) % 360;
-        }
-        if (half.equals("top")) {
-            if (shape.equals("straight")) {
-                y = (y + 180) % 360;
-            } else if (shape.equals("inner_left")) {
+        if (half.equals("bottom")) {
+            // Bottom half: _left shapes rotate -90 (270)
+            if (shape.equals("inner_left") || shape.equals("outer_left")) {
                 y = (y + 270) % 360;
-            } else if (shape.equals("inner_right")) {
-                y = (y + 180) % 360;
-            } else if (shape.equals("outer_left")) {
-                y = (y + 270) % 360;
-            } else if (shape.equals("outer_right")) {
-                y = (y + 180) % 360;
+            }
+        } else {
+            // Top half: _right shapes rotate +90
+            if (shape.equals("inner_right") || shape.equals("outer_right")) {
+                y = (y + 90) % 360;
             }
         }
 


### PR DESCRIPTION
Fixes X-ray effect on top-half (upside-down) custom stairs caused by incorrect blockstate rotations.

The bug caused top-half stairs to render with wrong y-rotations, creating gaps in face culling that made adjacent blocks appear transparent. This change aligns the rotation logic with vanilla Minecraft's stair blockstate behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix rotations for custom stairs**
> 
> - Updates `createStairModelVariant` to follow vanilla stair logic: bottom `_left` shapes rotate -90 (270), top `_right` shapes rotate +90; others use base rotation with `x=180` for top
> - Ensures correct blockstate rotations for top-half stairs, eliminating rendering gaps/X-ray artifacts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee6e6f0028c23d9d2344422e56ba543ace8a059a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->