### PR TITLE
refactor: remove 8-effect limit for unlimited text effects (up to 256)

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/font/EffectFontEncoding.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/EffectFontEncoding.java
@@ -11,7 +11,10 @@ import org.jetbrains.annotations.Nullable;
  * explicitly opt-in, we can use the color space freely for encoding without
  * needing to preserve the original color.
  * <p>
- * Color layout:
+ * The shader matches the exact 24-bit RGB value configured per-effect in text_effects.yml.
+ * Each effect has a unique trigger_color that is matched precisely by the shader.
+ * <p>
+ * Default color layout (for backwards compatibility with effects 0-7):
  * <ul>
  *   <li>R = 253 (0xFD) - primary marker</li>
  *   <li>G high nibble = effect type (0-7)</li>
@@ -19,8 +22,10 @@ import org.jetbrains.annotations.Nullable;
  *   <li>B = 0 (unused)</li>
  * </ul>
  * <p>
- * The shader matches the exact 24-bit RGB value, so false positives from gradients
- * are extremely unlikely. For example, effect 0 uses #FD0D00, effect 1 uses #FD1D00.
+ * For effects 8+, unique colors are auto-generated using a spread algorithm
+ * that distributes colors across the color space to minimize collision risk.
+ * <p>
+ * The encoding now supports up to 256 effects (0-255) instead of the previous 8 (0-7).
  */
 public final class EffectFontEncoding implements TextEffectEncoding {
 
@@ -44,8 +49,18 @@ public final class EffectFontEncoding implements TextEffectEncoding {
      */
     public static final int HIGH_NIBBLE_MASK = 0xF0;
 
+    /**
+     * Maximum number of effects supported (0-255).
+     */
+    public static final int MAX_EFFECTS = 256;
+
+    /**
+     * Data mask for effect IDs (0xFF = 255, supporting 256 effects).
+     */
+    public static final int EFFECT_ID_MASK = 0xFF;
+
     private static final ShaderEncoding SHADER_ENCODING =
-            new ShaderEncoding(4, 0x07, 0x0F, 0, -1, R_MARKER, true);
+            new ShaderEncoding(8, EFFECT_ID_MASK, 0xFF, 0, -1, -1, true);
 
     @Override
     public String getName() {
@@ -55,15 +70,38 @@ public final class EffectFontEncoding implements TextEffectEncoding {
     @Override
     @NotNull
     public TextColor encode(TextColor baseColor, int effectId, int speed, int param, int charIndex) {
-        // R = marker (253)
+        // For effect font encoding, the trigger color comes from the TextEffect.Definition
+        // This method generates a default trigger color based on effect ID for legacy compatibility
+        // The actual trigger color used is from Definition.getTriggerColor()
+        return generateDefaultTriggerColor(effectId);
+    }
+
+    /**
+     * Generates a default trigger color for an effect ID.
+     * <p>
+     * For IDs 0-7: Uses the legacy format #FDxD00 for backwards compatibility.
+     * For IDs 8+: Uses a spread algorithm to generate unique colors across the color space.
+     *
+     * @param effectId The effect ID (0-255)
+     * @return A unique trigger color for this effect
+     */
+    @NotNull
+    public static TextColor generateDefaultTriggerColor(int effectId) {
+        int id = effectId & EFFECT_ID_MASK;
+
+        if (id < 8) {
+            // Legacy format for effects 0-7: #FDxD00
+            int r = R_MARKER;
+            int g = (id << 4) | G_LOW_MARKER;
+            int b = 0;
+            return TextColor.color(r, g, b);
+        }
+
+        // For effects 8+, generate unique colors using a spread algorithm
+        // Use R = 0xFD (marker), vary G and B to spread across color space
         int r = R_MARKER;
-
-        // G = (effectType << 4) | G_LOW_MARKER
-        int effectType = effectId & 0x07;
-        int g = (effectType << 4) | G_LOW_MARKER;
-
-        // B = 0 (unused - speed/param come from config, baked into shader)
-        int b = 0;
+        int g = id; // Use effect ID directly for G channel
+        int b = ((id * 37) & 0xFF); // Spread B using prime multiplier for better distribution
 
         return TextColor.color(r, g, b);
     }
@@ -72,11 +110,11 @@ public final class EffectFontEncoding implements TextEffectEncoding {
     public boolean matches(int rgb) {
         int color = rgb & 0xFFFFFF;
         int r = (color >> 16) & 0xFF;
-        int g = (color >> 8) & 0xFF;
-        int b = color & 0xFF;
 
-        // Match exact trigger color format: R=253, G low nibble=0xD, B=0
-        return r == R_MARKER && (g & LOW_NIBBLE_MASK) == G_LOW_MARKER && b == 0;
+        // With the new unlimited effects system, we check if R channel matches our marker
+        // The actual effect matching is done by the shader using exact color comparison
+        // against the ORAXEN_EFFECT_TRIGGERS array, not by this method
+        return r == R_MARKER;
     }
 
     @Override
@@ -88,8 +126,18 @@ public final class EffectFontEncoding implements TextEffectEncoding {
 
         int color = rgb & 0xFFFFFF;
         int g = (color >> 8) & 0xFF;
+        int b = color & 0xFF;
 
-        int effectType = (g >> 4) & 0x07;
+        // For legacy colors (effects 0-7): G high nibble contains effect ID, B=0
+        // For new colors (effects 8+): G contains effect ID directly
+        int effectType;
+        if (b == 0 && (g & LOW_NIBBLE_MASK) == G_LOW_MARKER) {
+            // Legacy format: extract from G high nibble
+            effectType = (g >> 4) & 0x07;
+        } else {
+            // New format: G channel is the effect ID
+            effectType = g & EFFECT_ID_MASK;
+        }
 
         // Speed and param come from config, not encoding
         // Return defaults here for API compatibility

--- a/core/src/main/java/io/th0rgal/oraxen/font/EffectFontProvider.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/EffectFontProvider.java
@@ -5,6 +5,11 @@ import com.google.gson.JsonObject;
 import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Provides effect-specific fonts for text effects.
  * <p>
@@ -15,13 +20,17 @@ import org.jetbrains.annotations.NotNull;
  * This approach ensures:
  * - Default font text: 100% color preserved, never triggers effects
  * - Effect font text: Color encodes effect parameters freely
+ * <p>
+ * The font generation is now dynamic, supporting unlimited effects (up to 256).
+ * Font keys are generated on-demand and cached for performance.
  */
 public final class EffectFontProvider {
 
     /**
-     * Font keys for each effect type (0-7).
+     * Legacy font keys for backwards compatibility with effects 0-7.
+     * These are kept for any code that might reference them directly.
      */
-    public static final Key[] EFFECT_FONT_KEYS = {
+    public static final Key[] LEGACY_EFFECT_FONT_KEYS = {
             Key.key("oraxen", "effect_rainbow"),
             Key.key("oraxen", "effect_wave"),
             Key.key("oraxen", "effect_shake"),
@@ -33,28 +42,60 @@ public final class EffectFontProvider {
     };
 
     /**
+     * Cache for dynamically created font keys.
+     * Thread-safe for concurrent access during pack generation.
+     */
+    private static final Map<Integer, Key> fontKeyCache = new ConcurrentHashMap<>();
+
+    /**
      * Returns the font key for a given effect ID.
+     * <p>
+     * For effects 0-7, returns the legacy named keys for backwards compatibility.
+     * For effects 8+, generates a key based on the effect's name from TextEffect.Definition.
      *
-     * @param effectId Effect type ID (0-7)
+     * @param effectId Effect type ID (0-255)
      * @return The font key for this effect
      */
     @NotNull
     public static Key getFontKey(int effectId) {
-        int index = effectId & 0x07;
-        return EFFECT_FONT_KEYS[index];
+        int id = effectId & EffectFontEncoding.EFFECT_ID_MASK;
+
+        return fontKeyCache.computeIfAbsent(id, EffectFontProvider::createFontKey);
+    }
+
+    /**
+     * Creates a font key for the given effect ID.
+     */
+    @NotNull
+    private static Key createFontKey(int effectId) {
+        // For legacy effects 0-7, use the predefined names
+        if (effectId < LEGACY_EFFECT_FONT_KEYS.length) {
+            return LEGACY_EFFECT_FONT_KEYS[effectId];
+        }
+
+        // For effects 8+, use the effect name if available
+        TextEffect.Definition def = TextEffect.getEffect(effectId);
+        String suffix;
+        if (def != null) {
+            // Sanitize name for font key (alphanumeric + underscore only)
+            suffix = def.getName().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9_]", "_");
+        } else {
+            suffix = String.valueOf(effectId);
+        }
+        return Key.key("oraxen", "effect_" + suffix);
     }
 
     /**
      * Returns the font key for a named effect.
      *
      * @param effectName Effect name (e.g., "rainbow", "wave")
-     * @return The font key for this effect, or null if not found
+     * @return The font key for this effect, or the first effect font if not found
      */
     @NotNull
     public static Key getFontKey(@NotNull String effectName) {
         TextEffect.Definition definition = TextEffect.getEffect(effectName);
         if (definition == null) {
-            return EFFECT_FONT_KEYS[0]; // Default to first effect font
+            return LEGACY_EFFECT_FONT_KEYS[0]; // Default to first effect font
         }
         return getFontKey(definition.getId());
     }
@@ -63,7 +104,7 @@ public final class EffectFontProvider {
      * Generates font JSON for an effect font.
      * Each effect font references the full default font (including Oraxen glyphs).
      *
-     * @param effectId Effect type ID (0-7)
+     * @param effectId Effect type ID (0-255)
      * @return JsonObject for the font definition
      */
     @NotNull
@@ -82,17 +123,44 @@ public final class EffectFontProvider {
     }
 
     /**
-     * Returns all effect font keys.
+     * Returns all font keys for enabled effects.
+     * This replaces the old getAllFontKeys() that returned a fixed array.
+     *
+     * @return Collection of font keys for all enabled effects
      */
     @NotNull
-    public static Key[] getAllFontKeys() {
-        return EFFECT_FONT_KEYS.clone();
+    public static Collection<Key> getAllEnabledFontKeys() {
+        return TextEffect.getEnabledEffects().stream()
+                .map(def -> getFontKey(def.getId()))
+                .toList();
     }
 
     /**
-     * Returns the number of effect fonts available.
+     * Returns the legacy effect font keys array.
+     *
+     * @deprecated Use {@link #getAllEnabledFontKeys()} for dynamic font key retrieval.
      */
+    @Deprecated
+    @NotNull
+    public static Key[] getAllFontKeys() {
+        return LEGACY_EFFECT_FONT_KEYS.clone();
+    }
+
+    /**
+     * Returns the number of legacy effect fonts.
+     *
+     * @deprecated Use {@link TextEffect#getEnabledEffects()}.size() for the actual count.
+     */
+    @Deprecated
     public static int getEffectFontCount() {
-        return EFFECT_FONT_KEYS.length;
+        return LEGACY_EFFECT_FONT_KEYS.length;
+    }
+
+    /**
+     * Clears the font key cache.
+     * Should be called when effects are reloaded to ensure fresh keys are generated.
+     */
+    public static void clearCache() {
+        fontKeyCache.clear();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/font/TextEffect.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/TextEffect.java
@@ -324,6 +324,9 @@ public class TextEffect {
      */
     public static void loadConfig(@Nullable ConfigurationSection settingsSection,
                                   @Nullable ConfigurationSection effectsRoot) {
+        // Clear the font key cache to ensure fresh keys are generated for the new effects
+        EffectFontProvider.clearCache();
+
         if (settingsSection == null) {
             globalEnabled = false;
             encoding = new EffectFontEncoding();
@@ -577,7 +580,10 @@ public class TextEffect {
 
     /**
      * Parses trigger_color from config, or generates a default based on effect ID.
-     * Default format: #FDxD00 where x is the effect ID (0-7).
+     * <p>
+     * For effects 0-7: Default format is #FDxD00 where x is the effect ID (legacy compatibility).
+     * For effects 8+: Uses a spread algorithm to generate unique colors across the color space.
+     * <p>
      * This ensures unique, unlikely-to-collide colors for each effect.
      */
     @NotNull
@@ -594,12 +600,8 @@ public class TextEffect {
                 Logs.logWarning("Invalid trigger_color '" + colorStr + "' in text_effects.yml, using default.");
             }
         }
-        // Generate default: R=253 (0xFD), G=(effectId<<4)|0xD, B=0
-        // This produces colors like #FD0D00, #FD1D00, #FD2D00, etc.
-        int r = 0xFD;
-        int g = ((effectId & 0x07) << 4) | 0x0D;
-        int b = 0x00;
-        return TextColor.color(r, g, b);
+        // Delegate to EffectFontEncoding for consistent default color generation
+        return EffectFontEncoding.generateDefaultTriggerColor(effectId);
     }
 
     @NotNull

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -715,7 +715,10 @@ public class ResourcePack {
 
     /**
      * Generates effect font files for text effects.
-     * Each effect type gets a dedicated font that references vanilla glyphs.
+     * Each enabled effect gets a dedicated font that references vanilla glyphs.
+     * <p>
+     * This method now supports unlimited effects (up to 256) by iterating over
+     * all enabled effects rather than a fixed array.
      */
     private void generateEffectFonts() {
         if (!TextEffect.isEnabled() || !TextEffect.hasAnyEffectEnabled()) {
@@ -724,9 +727,10 @@ public class ResourcePack {
 
         EffectFontProvider provider = new EffectFontProvider();
 
-        for (int i = 0; i < EffectFontProvider.getEffectFontCount(); i++) {
-            Key fontKey = EffectFontProvider.EFFECT_FONT_KEYS[i];
-            JsonObject fontJson = provider.generateFontJson(i);
+        // Generate fonts for all enabled effects (supports unlimited effects)
+        for (TextEffect.Definition def : TextEffect.getEnabledEffects()) {
+            Key fontKey = EffectFontProvider.getFontKey(def.getId());
+            JsonObject fontJson = provider.generateFontJson(def.getId());
 
             String path = "assets/" + fontKey.namespace() + "/font";
             String filename = fontKey.value() + ".json";


### PR DESCRIPTION
The shader generation already supported unlimited effects via dynamic arrays. This change removes the artificial 8-effect limit enforced by bit-masking in the encoding layer.

Changes:
- EffectFontEncoding: Changed dataMask from 0x07 to 0xFF (256 effects)
- EffectFontEncoding: Added generateDefaultTriggerColor() for effects 8+
- EffectFontProvider: Dynamic font key generation with caching
- ResourcePack: Iterate enabled effects instead of fixed array

Backward compatible - effects 0-7 retain legacy #FDxD00 trigger colors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Expand text effects to 256 with dynamic fonts and exact-color triggers**
> 
> - Upgrades `EffectFontEncoding` to 8-bit effect IDs (`dataMask 0xFF`), adds `generateDefaultTriggerColor()` for IDs 8+, supports legacy `#FDxD00` (0–7), simplifies `matches()` to R-marker, and decodes both legacy/new formats
> - `EffectFontProvider`: adds dynamic, cached font keys (name-based for 8+), keeps legacy keys, new `getAllEnabledFontKeys()`, and cache clearing
> - `TextEffect`: clears font-key cache on config load; default `trigger_color` delegated to encoding
> - `ResourcePack`: generates effect fonts by iterating enabled effects instead of a fixed array
> 
> _Backward compatible for effects 0–7._
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 054ab0487030ca0108f5d2c11397f170fa8dd9b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->