### PR TITLE
fix: add enabled check to isOraxenNoteBlock

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java
@@ -129,7 +129,7 @@ public class OraxenBlocks {
      * @return true if the itemID has a NoteBlockMechanic, otherwise false
      */
     public static boolean isOraxenNoteBlock(String itemID) {
-        return !NoteBlockMechanicFactory.getInstance().isNotImplementedIn(itemID);
+        return NoteBlockMechanicFactory.isEnabled() && !NoteBlockMechanicFactory.getInstance().isNotImplementedIn(itemID);
     }
 
     public static boolean isOraxenNoteBlock(ItemStack item) {


### PR DESCRIPTION
## 🟠 add enabled check to isOraxenNoteBlock

- **Summary** - Return safely when the NoteBlock mechanic factory is disabled so integrations like CustomCrops no longer NPE while probing block IDs.
- **Description** - `isOraxenNoteBlock(String)` now checks `NoteBlockMechanicFactory.isEnabled()` before calling `isNotImplementedIn`, which lets callers rely on a clean `false` result rather than a null factory exception.

- **Changes** - Wrapped the existing factory call with `NoteBlockMechanicFactory.isEnabled()` in `core/src/main/java/io/th0rgal/oraxen/api/OraxenBlocks.java`.

<sub>Issue reported by @Xiao-MoMi through @Jonaas13 for CustomCrops.