### PR TITLE
feat: add gui_model support for display_context selector

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java
@@ -15,6 +15,7 @@ public class OraxenMeta {
 
     private Integer customModelData;
     private String modelName;
+    private String guiModel;
     private String blockingModel;
     private String blockingTexture;
     private List<String> pullingModels;
@@ -63,6 +64,7 @@ public class OraxenMeta {
     public void setPackInfos(ConfigurationSection section) {
         this.hasPackInfos = true;
         this.modelName = readModelName(section, "model");
+        this.guiModel = readModelName(section, "gui_model");
         this.blockingModel = readModelName(section, "blocking_model");
         this.castModel = readModelName(section, "cast_model");
         this.chargedModel = readModelName(section, "charged_model");
@@ -207,6 +209,14 @@ public class OraxenMeta {
 
     public String getModelName() {
         return modelName;
+    }
+
+    public boolean hasGuiModel() {
+        return guiModel != null;
+    }
+
+    public String getGuiModel() {
+        return guiModel;
     }
 
     public String getModelPath() {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java
@@ -38,6 +38,12 @@ public class ModelDefinitionGenerator {
         
         JsonObject baseModel = createBaseModel();
         JsonObject itemModel = createItemSpecificModel(baseModel);
+        
+        // If gui_model is specified, wrap in display_context selector
+        if (oraxenMeta.hasGuiModel()) {
+            itemModel = createDisplayContextModel(itemModel);
+        }
+        
         root.add("model", itemModel);
         
         addItemModelProperties(root);
@@ -307,6 +313,31 @@ public class ModelDefinitionGenerator {
         conditionModel.add("on_true", createModelObject(oraxenMeta.getBlockingModel()));
         
         return conditionModel;
+    }
+    
+    /**
+     * Creates a display_context selector model that shows different models in GUI vs other contexts.
+     * This wraps the main item model (which could be a bow, crossbow, etc.) with a GUI-specific icon.
+     *
+     * @param fallbackModel The model to use in all contexts except GUI (equipped, in-hand, etc.)
+     * @return A JsonObject representing a minecraft:select type with display_context property
+     */
+    private JsonObject createDisplayContextModel(JsonObject fallbackModel) {
+        JsonObject selectModel = new JsonObject();
+        selectModel.addProperty("type", "minecraft:select");
+        selectModel.addProperty("property", "minecraft:display_context");
+        
+        // Create the GUI case
+        JsonArray cases = new JsonArray();
+        JsonObject guiCase = new JsonObject();
+        guiCase.addProperty("when", "gui");
+        guiCase.add("model", createModelObject(oraxenMeta.getGuiModel()));
+        cases.add(guiCase);
+        
+        selectModel.add("cases", cases);
+        selectModel.add("fallback", fallbackModel);
+        
+        return selectModel;
     }
     
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/utils/schema/SchemaGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/schema/SchemaGenerator.java
@@ -1039,6 +1039,15 @@ public class SchemaGenerator {
         model.addProperty("description", "Path to existing JSON model file (without .json)");
         pack.add("model", model);
 
+        // gui_model
+        JsonObject guiModel = new JsonObject();
+        guiModel.addProperty("type", "string");
+        guiModel.addProperty("description", "Model to display in inventory/GUI (uses display_context selector). " +
+                "When specified, 'model' is shown when held/equipped, and 'gui_model' is shown in inventory. " +
+                "Useful for 3D models that need simpler 2D icons in GUI.");
+        guiModel.addProperty("minecraftVersion", "1.21.2+");
+        pack.add("gui_model", guiModel);
+
         // models - Additional model definitions for multi-state items
         JsonObject models = new JsonObject();
         models.addProperty("type", "object");


### PR DESCRIPTION
## 🟠 Add gui_model pack option

- **Summary** - Added support for a `gui_model` override so items can show a dedicated icon in GUIs while keeping the main 3D model for in-world views.
- **Description** - `OraxenMeta` now reads `gui_model` from configs and exposes getters, the model generator wraps definitions in a `minecraft:display_context` selector when `gui_model` is provided, and the schema documents the new property along with guidance on its purpose and version requirement.

- **Changes** - `core/src/main/java/io/th0rgal/oraxen/items/OraxenMeta.java`, `core/src/main/java/io/th0rgal/oraxen/pack/generation/ModelDefinitionGenerator.java`, `core/src/main/java/io/th0rgal/oraxen/utils/schema/SchemaGenerator.java`.

- **Verification** - Used a simple .sh script and tested in Paper 1.21.11.