### PR TITLE
feat: add Cross-version shader overlay support for 1.21.4+ compatibility

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
@@ -11,9 +11,37 @@ import io.th0rgal.oraxen.utils.ResourcePackFormatUtil;
  */
 public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion) {
 
+    /** Pack format for 1.21.4/1.21.5 */
+    public static final int PACK_FORMAT_1_21_4 = 46;
+    /** Pack format for 1.21.6+ (first version with new shader format) */
+    public static final int PACK_FORMAT_1_21_6 = 55;
+
     public static TextShaderTarget current() {
         return new TextShaderTarget(ResourcePackFormatUtil.getCurrentResourcePackFormat(),
                 MinecraftVersion.getCurrentVersion());
+    }
+
+    /**
+     * Creates a target for a specific Minecraft version.
+     * Used for generating overlay shaders for different client versions.
+     */
+    public static TextShaderTarget forVersion(String version) {
+        MinecraftVersion mcVersion = new MinecraftVersion(version);
+        int packFormat = getPackFormatForVersion(mcVersion);
+        return new TextShaderTarget(packFormat, mcVersion);
+    }
+
+    private static int getPackFormatForVersion(MinecraftVersion version) {
+        // Map major shader-breaking versions to their pack formats
+        if (version.isAtLeast(new MinecraftVersion("1.21.6"))) return PACK_FORMAT_1_21_6;
+        if (version.isAtLeast(new MinecraftVersion("1.21.4"))) return PACK_FORMAT_1_21_4;
+        if (version.isAtLeast(new MinecraftVersion("1.21.2"))) return 42;
+        if (version.isAtLeast(new MinecraftVersion("1.21"))) return 34;
+        if (version.isAtLeast(new MinecraftVersion("1.20.5"))) return 32;
+        if (version.isAtLeast(new MinecraftVersion("1.20.3"))) return 22;
+        if (version.isAtLeast(new MinecraftVersion("1.20.2"))) return 18;
+        if (version.isAtLeast(new MinecraftVersion("1.20"))) return 15;
+        return 15; // fallback
     }
 
     public boolean isAtLeast(String version) {


### PR DESCRIPTION
## 🟠 Cross-version shader overlay support for 1.21.4+ compatibility

- **Summary** - Adds cross-version shader compatibility for Minecraft 1.21.4+ by generating overlay shaders and updating pack.mcmeta format handling
- **Description** - Implements shader overlay system to support different client versions accessing the same resource pack, addressing breaking changes in Minecraft 1.21.4+ shader format requirements

- **Changes**
  - Added `TextShaderTarget` class for version-specific shader generation with pack format constants
  - Enhanced `ResourcePack.java` with overlay shader generation for cross-version compatibility
  - Updated pack.mcmeta generation to include `supported_formats` and overlay entries
  - Simplified font system by removing configurable default font setting
  - Refactored `GlyphAppearance.fromConfig()` to use standard minecraft:default font
  - Added shader overlay directories (`overlay_1_21_4_5`, `overlay_1_21_6_plus`) for different client versions
  - Fixed shader JSON generation to use fully-qualified core references (`minecraft:core/shader_name`) for 1.21.4+

- **Verification**
  - Resource pack generates correctly for both 1.21.4/1.21.5 and 1.21.6+ server versions
  - Overlay shaders are created in appropriate directories when server version differs from client capabilities
  - pack.mcmeta includes proper supported_formats range and overlay entries
  - Font generation maintains backward compatibility while using simplified default font approach
  - Tested on multiple client and server versions.