### PR TITLE
Add disable-noteblock-functionality setting

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -68,6 +68,7 @@ public enum Settings {
     // Custom Blocks
     BLOCK_CORRECTION("CustomBlocks.block_correction"),
     LEGACY_NOTEBLOCKS("CustomBlocks.use_legacy_noteblocks"),
+    DISABLE_NOTE_BLOCK_FUNCTIONALITY("CustomBlocks.disable-noteblock-functionality"),
 
     // ItemUpdater
     UPDATE_ITEMS("ItemUpdater.update_items"),

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.mechanics;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.events.OraxenNativeMechanicsRegisteredEvent;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.mechanics.provided.combat.knockbackstrike.KnockbackStrikeMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.combat.bleeding.BleedingMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.combat.lifeleech.LifeLeechMechanicFactory;
@@ -81,7 +82,8 @@ public class MechanicsManager {
         registerFactory("durability", DurabilityMechanicFactory::new);
         registerFactory("efficiency", EfficiencyMechanicFactory::new);
         registerFactory("block", BlockMechanicFactory::new);
-        registerFactory("noteblock", NoteBlockMechanicFactory::new);
+        if (!Settings.DISABLE_NOTE_BLOCK_FUNCTIONALITY.toBool())
+            registerFactory("noteblock", NoteBlockMechanicFactory::new);
         registerFactory("stringblock", StringBlockMechanicFactory::new);
         registerFactory("chorusblock", ChorusBlockMechanicFactory::new);
         registerFactory("shaped_block", ShapedBlockMechanicFactory::new);

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PaperConfigUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PaperConfigUpdater.java
@@ -60,6 +60,7 @@ public final class PaperConfigUpdater {
             boolean inBlockUpdates = false;
             int blockUpdatesIndent = -1;
 
+            boolean updateNoteblockUpdates = !Settings.DISABLE_NOTE_BLOCK_FUNCTIONALITY.toBool();
             for (int i = 0; i < updatedLines.size(); i++) {
                 String line = updatedLines.get(i);
                 String trimmed = line.trim();
@@ -81,8 +82,11 @@ public final class PaperConfigUpdater {
 
                 // Process settings within block-updates
                 if (inBlockUpdates) {
-                    String updated = tryUpdateSetting(line, "disable-noteblock-updates", updatedSettings);
-                    if (updated != null) { updatedLines.set(i, updated); continue; }
+                    String updated;
+                    if (updateNoteblockUpdates) {
+                        updated = tryUpdateSetting(line, "disable-noteblock-updates", updatedSettings);
+                        if (updated != null) { updatedLines.set(i, updated); continue; }
+                    }
 
                     updated = tryUpdateSetting(line, "disable-tripwire-updates", updatedSettings);
                     if (updated != null) { updatedLines.set(i, updated); continue; }

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -76,6 +76,7 @@ CustomArmor:
 CustomBlocks:
   block_correction: NMS # Valid types are NMS and LEGACY
   use_legacy_noteblocks: true # Setting relevant for future changes, for now leave this to true
+  disable-noteblock-functionality: false # When true, Oraxen will not use note blocks for custom blocks and vanilla note blocks will behave normally (requires restart)
 
 ItemUpdater:
   # Update the items in player inventory to the latest in config when player joins


### PR DESCRIPTION
When `disable-noteblock-functionality: true`, Oraxen won’t use noteblocks for custom blocks and vanilla noteblocks behave normally (restart required).

Reasoning for this PR is because noteblocks can't activate with redstone pulses even when all noteblock-related settings are disabled.