### PR TITLE
fix: Remove 256x256 Texture Limit Validation

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -513,11 +513,6 @@ public class ResourcePack {
                         continue;
                     }
 
-                    if (image.getHeight() > 256 || image.getWidth() > 256) {
-                        Logs.logWarning("Found invalid texture at <blue>" + texture.getPath());
-                        Logs.logError("Resolution of textures cannot exceed 256x256");
-                        malformedTextures.add(texture);
-                    }
                 } catch (Exception e) {
                     // Be resilient when validating packs: bad files should not crash pack
                     // generation


### PR DESCRIPTION
## 🟠 fix: Remove 256x256 Texture Limit Validation

- **Summary** - Removed Oraxen’s texture-dimension rejection so textures larger than `256x256` are no longer marked malformed during pack validation.
- **Description** - In `/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java:516`, I removed the block that logged `Resolution of textures cannot exceed 256x256` and added those textures to `malformedTextures`. Readability/path/corruption checks remain unchanged.

- **Changes** - Deleted the `if (image.getHeight() > 256 || image.getWidth() > 256)` validation block in `/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java`.