### PR TITLE
fix: KnockbackStrike 1.21.1 Sound Compatibility + Configurable runServer Version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,12 +173,14 @@ tasks {
         filteringCharset = Charsets.UTF_8.name()
     }
 
+    val runServerVersion = (findProperty("mcVersion") as String?) ?: "1.21.11"
+
     runServer {
         downloadPlugins {
             hangar("ProtocolLib", "5.4.0")
             hangar("CommandAPI", "11.1.0")
         }
-        minecraftVersion("1.21.11")
+        minecraftVersion(runServerVersion)
         jvmArgs("-Dcom.mojang.eula.agree=true")
     }
 
@@ -333,4 +335,3 @@ tasks.register<Exec>("generatePack") {
         println("Generating resource pack for $serverType $mcVersion...")
     }
 }
-

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/knockbackstrike/KnockbackStrikeMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/knockbackstrike/KnockbackStrikeMechanicListener.java
@@ -101,7 +101,7 @@ public class KnockbackStrikeMechanicListener implements Listener {
         spawnParticles(victimLoc, mechanic);
 
         // Play sound at victim location
-        if (mechanic.shouldPlaySound()) {
+        if (mechanic.shouldPlaySound() && mechanic.getSoundType() != null) {
             World world = victimLoc.getWorld();
             if (world != null) {
                 try {


### PR DESCRIPTION
## 🟠 fix: KnockbackStrike 1.21.1 Sound Compatibility + Configurable runServer Version

- **Summary** - Fixed Oraxen startup failure on Minecraft `1.21.1` caused by `KnockbackStrike` sound fallback logic, and added configurable `runServer` MC version support.

- **Description** - The crash came from `IncompatibleClassChangeError` when `KnockbackStrike` called `Sound.values()` on older API behavior. The mechanic now uses safer fallback resolution and disables sound gracefully if no compatible sound is found. `runServer` now reads `-PmcVersion` instead of being hardcoded.

- **Changes** - Updated sound parsing/fallback logic in `/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/knockbackstrike/KnockbackStrikeMechanic.java`, added null-safe sound playback in `/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/combat/knockbackstrike/KnockbackStrikeMechanicListener.java`, and made `runServer` version configurable via `-PmcVersion` in `build.gradle.kts`.