### PR TITLE
Fix Furniture Admin Place Null Facing Crash

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -464,6 +464,7 @@ public class FurnitureMechanic extends Mechanic {
         if (checkSpace && this.notEnoughSpace(yaw, location)) return null;
         assert location.getWorld() != null;
         assert location.getWorld() != null;
+        BlockFace resolvedFacing = facing != null ? facing : BlockFace.NORTH;
 
         Class<? extends Entity> entityClass = getFurnitureEntityType().getEntityClass();
         if (entityClass == null) entityClass = ItemFrame.class;
@@ -474,7 +475,7 @@ public class FurnitureMechanic extends Mechanic {
         }
         item.setAmount(1);
 
-        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, facing), entityClass, (e) -> setEntityData(e, yaw, item, facing));
+        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing), entityClass, (e) -> setEntityData(e, yaw, item, resolvedFacing));
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }
@@ -483,6 +484,7 @@ public class FurnitureMechanic extends Mechanic {
     }
 
     private boolean allowWallForLimitedFloor(Location location, BlockFace blockFace) {
+        if (blockFace == null) return false;
         return blockFace.getModY() == 0 && location.getBlock().getRelative(BlockFace.DOWN).isSolid();
     }
 


### PR DESCRIPTION
## 🟠 Fix Furniture Admin Place Null Facing Crash

- **Summary** - Fixed a null pointer crash when placing furniture via `/oraxen admin furniture place ...`.
- **Description** - The admin command passed a `null` `BlockFace` into `FurnitureMechanic.place(...)`, and furniture placement logic dereferenced `facing` in placement helpers. This caused an unhandled exception and aborted placement.

- **Changes** - In `core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java`, added `resolvedFacing` fallback (`BlockFace.NORTH`) when `facing` is null and used it for spawn location/entity data setup. Added a defensive null check in `allowWallForLimitedFloor(...)`.

- **Verification** - Ran `./gradlew :core:compileJava` successfully (warnings only). Ran the `review` skill workflow; no issues found.
