### PR TITLE
fix: prevent inventory filtering from crashing on missing OraxenMeta

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java
@@ -179,12 +179,18 @@ public class OraxenItems {
     }
 
     public static List<ItemBuilder> getUnexcludedItems() {
-        return itemStream().filter(item -> !item.getOraxenMeta().isExcludedFromInventory())
+        return itemStream().filter(OraxenItems::shouldShowInInventory)
                 .toList();
     }
 
     public static List<ItemBuilder> getUnexcludedItems(final File file) {
-        return map.get(file).values().stream().filter(item -> !item.getOraxenMeta().isExcludedFromInventory()).toList();
+        Map<String, ItemBuilder> fileItems = map.get(file);
+        if (fileItems == null) return List.of();
+        return fileItems.values().stream().filter(OraxenItems::shouldShowInInventory).toList();
+    }
+
+    private static boolean shouldShowInInventory(@Nullable ItemBuilder item) {
+        return item != null && item.hasOraxenMeta() && !item.getOraxenMeta().isExcludedFromInventory();
     }
 
     public static List<ItemStack> getItemStacksByName(final List<List<String>> lists) {


### PR DESCRIPTION
## 🟠 Inventory NPE Guard
- **Summary** - Prevented `/oraxen inventory` from crashing when an `ItemBuilder` has no `OraxenMeta`.
- **Description** - `OraxenItems.getUnexcludedItems()` now uses a shared null-safe predicate and skips builders without metadata instead of dereferencing `getOraxenMeta()` directly.
- **Changes** - Updated both `getUnexcludedItems()` overloads in `core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java` to guard against `null` `OraxenMeta` and missing file entries.
