### PR TITLE
fix: HUD permission checks and spectator mode handling

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/hud/Hud.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hud/Hud.java
@@ -1,5 +1,7 @@
 package io.th0rgal.oraxen.hud;
 
+import org.bukkit.entity.Player;
+
 public record Hud(String displayText,
                   String fontName,
                   String perm,
@@ -20,6 +22,10 @@ public record Hud(String displayText,
         return perm;
     }
 
+    public boolean hasPermission(Player player) {
+        return player == null || perm.isBlank() || player.hasPermission(perm);
+    }
+
     public boolean isEnabledByDefault() {
         return enabledByDefault;
     }
@@ -29,6 +35,6 @@ public record Hud(String displayText,
     }
 
     public boolean enableInSpectatorMode() {
-        return true;
+        return this.enableInSpectatorMode;
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/hud/HudEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hud/HudEvents.java
@@ -31,7 +31,7 @@ public class HudEvents implements Listener {
             }
             return;
         }
-        if (!player.hasPermission(hud.getPerm())) {
+        if (!hud.hasPermission(player)) {
             if (Settings.DEBUG.toBool()) {
                 Logs.logWarning("[HUD] Player " + player.getName() + " doesn't have permission: " + hud.getPerm());
             }

--- a/core/src/main/java/io/th0rgal/oraxen/hud/HudTask.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hud/HudTask.java
@@ -57,7 +57,7 @@ public class HudTask implements Runnable {
         if (hud.disableWhilstInWater() && EntityUtils.isUnderWater(player)) {
             return;
         }
-        if (!player.hasPermission(hud.getPerm())) {
+        if (!hud.hasPermission(player)) {
             if (Settings.DEBUG.toBool()) {
                 Logs.logWarning("[HUD] Player " + player.getName() + " doesn't have permission: " + hud.getPerm());
             }


### PR DESCRIPTION
## 🟠 HUD Permission Fix
- **Summary** - Fixed an Oraxen HUD issue where non-OP players could lose their HUD while OP players kept it.

- **Description** - The HUD system was checking `player.hasPermission(hud.getPerm())` directly. If a HUD permission was blank, Bukkit could treat that as effectively OP-only during repeated HUD updates. The fix makes blank HUD permissions mean "no permission required" and reuses that logic in the join and scheduled update paths. A separate bug was also fixed where `enable_for_spectator_mode` was ignored.

- **Changes** - Added `Hud.hasPermission(Player)` in `core/src/main/java/io/th0rgal/oraxen/hud/Hud.java`, updated permission checks in `core/src/main/java/io/th0rgal/oraxen/hud/HudEvents.java` and `core/src/main/java/io/th0rgal/oraxen/hud/HudTask.java`, and corrected spectator-mode handling in `Hud.java`. Verified with `./gradlew :core:compileJava`.
