### PR TITLE
feat: Add pre-join pack dispatch with automatic on-join fallback

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -131,6 +131,8 @@ public enum Settings {
     POLYMATH_SERVER("Pack.upload.polymath.server"),
     POLYMATH_SECRET("Pack.upload.polymath.secret"),
 
+    SEND_PRE_JOIN("Pack.dispatch.send_pre_join"),
+    SEND_ON_JOIN("Pack.dispatch.send_on_join"),
     SEND_PACK("Pack.dispatch.send_pack"),
     SEND_ON_RELOAD("Pack.dispatch.send_on_reload"),
     SEND_PACK_DELAY("Pack.dispatch.delay"),

--- a/core/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/UpdatedSettings.java
@@ -15,6 +15,7 @@ public enum UpdatedSettings {
     USE_NMS_GLYPHS2("Plugin.experimental.use_nms_glyphs", "Plugin.experimental.nms.glyphs"),
     SEND_PACK_ADVANCED_MANDATORY("Pack.dispatch.send_pack_advanced.mandatory", "Pack.dispatch.mandatory"),
     SEND_PACK_ADVANCED_MESSAGE("Pack.dispatch.send_pack_advanced.message", "Pack.dispatch.prompt"),
+    SEND_PACK("Pack.dispatch.send_pack", "Pack.dispatch.send_on_join"),
     VERIFY_PACK_FILES("Plugin.experimental.verify_pack_files", "Pack.generation.verify_pack_files"),
     EXCLUDE_MALFORMED_ATLAS("Plugin.experimental.exclude_malformed_from_atlas", "Pack.generation.atlas.exclude_malformed_from_atlas"),
     NMS_GLYPHS("Plugin.experimental.nms.glyphs", "Glyphs.nms_glyphs"),

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -5,6 +5,7 @@ import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -16,6 +17,10 @@ import java.util.Set;
 public interface NMSHandler {
 
     GlyphHandler glyphHandler();
+
+    default Listener packDispatchListener() {
+        return null;
+    }
 
     boolean noteblockUpdatesDisabled();
 

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandlers.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.Bukkit;
+import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -53,6 +54,10 @@ public class NMSHandlers {
                     Logs.logInfo("Oraxen will use the NMSHandler for this version.");
                 }
                 Bukkit.getPluginManager().registerEvents(new NMSListeners(), OraxenPlugin.get());
+                Listener packDispatchListener = handler.packDispatchListener();
+                if (packDispatchListener != null) {
+                    Bukkit.getPluginManager().registerEvents(packDispatchListener, OraxenPlugin.get());
+                }
                 return;
             } catch (ClassNotFoundException | InvocationTargetException | InstantiationException
                     | IllegalAccessException | NoSuchMethodException e) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/BukkitPackSender.java
@@ -39,7 +39,14 @@ public class BukkitPackSender extends PackSender implements Listener {
     public void onPlayerConnect(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         if (Settings.SEND_JOIN_MESSAGE.toBool()) sendWelcomeMessage(player, true);
-        if (!Settings.SEND_PACK.toBool()) return;
+
+        boolean sendOnJoin = PackSender.isSendOnJoinConfigured();
+        boolean sendPreJoin = PackSender.isSendPreJoinConfigured();
+        if (!sendOnJoin && !sendPreJoin) return;
+        boolean preJoinActive = PackSender.isPreJoinDispatchActive();
+        if (preJoinActive) return;
+        if (sendPreJoin) sendOnJoin = true;
+
         int delay = (int) Settings.SEND_PACK_DELAY.getValue();
         if (delay <= 0) sendPack(player);
         else SchedulerUtil.runTaskLaterAsync(delay * 20L, () ->

--- a/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/MultiVersionPackSender.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/MultiVersionPackSender.java
@@ -101,9 +101,12 @@ public class MultiVersionPackSender implements Listener {
             sendWelcomeMessage(player, true);
         }
 
-        if (!Settings.SEND_PACK.toBool()) {
-            return;
-        }
+        boolean sendOnJoin = PackSender.isSendOnJoinConfigured();
+        boolean sendPreJoin = PackSender.isSendPreJoinConfigured();
+        if (!sendOnJoin && !sendPreJoin) return;
+        boolean preJoinActive = PackSender.isPreJoinDispatchActive();
+        if (preJoinActive) return;
+        if (sendPreJoin) sendOnJoin = true;
 
         int delay = (int) Settings.SEND_PACK_DELAY.getValue();
         if (delay <= 0) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/MultiVersionPackSender.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/MultiVersionPackSender.java
@@ -103,10 +103,10 @@ public class MultiVersionPackSender implements Listener {
 
         boolean sendOnJoin = PackSender.isSendOnJoinConfigured();
         boolean sendPreJoin = PackSender.isSendPreJoinConfigured();
-        if (!sendOnJoin && !sendPreJoin) return;
         boolean preJoinActive = PackSender.isPreJoinDispatchActive();
+        boolean effectiveSendOnJoin = sendOnJoin || (sendPreJoin && !preJoinActive);
+        if (!effectiveSendOnJoin) return;
         if (preJoinActive) return;
-        if (sendPreJoin) sendOnJoin = true;
 
         int delay = (int) Settings.SEND_PACK_DELAY.getValue();
         if (delay <= 0) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/PackSender.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/PackSender.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.pack.dispatch;
 
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.pack.receive.PackReceiver;
 import io.th0rgal.oraxen.pack.upload.hosts.HostingProvider;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
@@ -122,6 +123,7 @@ public abstract class PackSender {
         String packUrl = OraxenPlugin.get().getPackURL();
         String hash = OraxenPlugin.get().getPackSHA1();
         if (packUrl == null || hash == null) return null;
+        UUID playerId = connection.getProfile().getId();
 
         byte[] hashBytes = hashArray(hash);
         UUID packUUID = UUID.nameUUIDFromBytes(hashBytes);
@@ -138,7 +140,8 @@ public abstract class PackSender {
                 .replace(true)
                 .prompt(AdventureUtils.MINI_MESSAGE.deserialize(Settings.SEND_PACK_PROMPT.toString()))
                 .packs(info)
-                .callback((uuid, status, audience) -> {
+                .callback((requestId, status, audience) -> {
+                    PackReceiver.handleAdventureStatus(playerId, status);
                     if (!status.intermediate()) {
                         if (future != null) future.complete(null);
                         else connection.completeReconfiguration();

--- a/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/PackSender.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/dispatch/PackSender.java
@@ -6,13 +6,23 @@ import io.th0rgal.oraxen.pack.upload.hosts.HostingProvider;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.papermc.paper.connection.PlayerConfigurationConnection;
+import net.kyori.adventure.resource.ResourcePackInfo;
+import net.kyori.adventure.resource.ResourcePackRequest;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class PackSender {
 
     protected final HostingProvider hostingProvider;
+    private static final Object dispatchNormalizationLock = new Object();
+    private static volatile boolean dispatchModeNormalized = false;
 
 
     protected PackSender(HostingProvider hostingProvider) {
@@ -86,6 +96,111 @@ public abstract class PackSender {
             } else {
                 player.setResourcePack(url, sha1, legacyPrompt, mandatory);
             }
+        }
+    }
+
+    public static boolean isSendPreJoinConfigured() {
+        normalizeDispatchModeForServerSupport();
+        return readSendPreJoinConfigured();
+    }
+
+    public static boolean isSendOnJoinConfigured() {
+        normalizeDispatchModeForServerSupport();
+        return readSendOnJoinConfigured();
+    }
+
+    public static boolean isPreJoinDispatchActive() {
+        return isSendPreJoinConfigured() && VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.21.7");
+    }
+
+    public static boolean isAnyDispatchEnabled() {
+        return isSendOnJoinConfigured() || isSendPreJoinConfigured();
+    }
+
+    @Nullable
+    public static CompletableFuture<Void> sendResourcePack(PlayerConfigurationConnection connection, boolean reconfigure) {
+        String packUrl = OraxenPlugin.get().getPackURL();
+        String hash = OraxenPlugin.get().getPackSHA1();
+        if (packUrl == null || hash == null) return null;
+
+        byte[] hashBytes = hashArray(hash);
+        UUID packUUID = UUID.nameUUIDFromBytes(hashBytes);
+        CompletableFuture<Void> future = reconfigure ? null : new CompletableFuture<>();
+
+        ResourcePackInfo info = ResourcePackInfo.resourcePackInfo()
+                .id(packUUID)
+                .uri(java.net.URI.create(packUrl))
+                .hash(hash)
+                .build();
+
+        ResourcePackRequest request = ResourcePackRequest.resourcePackRequest()
+                .required(Settings.SEND_PACK_MANDATORY.toBool())
+                .replace(true)
+                .prompt(AdventureUtils.MINI_MESSAGE.deserialize(Settings.SEND_PACK_PROMPT.toString()))
+                .packs(info)
+                .callback((uuid, status, audience) -> {
+                    if (!status.intermediate()) {
+                        if (future != null) future.complete(null);
+                        else connection.completeReconfiguration();
+                    }
+                })
+                .build();
+
+        connection.getAudience().sendResourcePacks(request);
+        return future;
+    }
+
+    private static byte[] hashArray(String hash) {
+        int length = hash.length();
+        if (length % 2 != 0) throw new IllegalArgumentException("Hash length must be even");
+
+        byte[] result = new byte[length / 2];
+        for (int i = 0; i < result.length; i++) {
+            int from = i * 2;
+            result[i] = (byte) Integer.parseInt(hash.substring(from, from + 2), 16);
+        }
+        return result;
+    }
+
+    private static boolean getBooleanSetting(String path, @Nullable String legacyPath, boolean fallback) {
+        YamlConfiguration settings = OraxenPlugin.get().getConfigsManager().getSettings();
+        Object value = settings.get(path);
+        if (value instanceof Boolean bool) return bool;
+
+        if (legacyPath != null) {
+            Object legacyValue = settings.get(legacyPath);
+            if (legacyValue instanceof Boolean bool) return bool;
+        }
+
+        return fallback;
+    }
+
+    private static boolean readSendPreJoinConfigured() {
+        return getBooleanSetting("Pack.dispatch.send_pre_join", null, true);
+    }
+
+    private static boolean readSendOnJoinConfigured() {
+        return getBooleanSetting("Pack.dispatch.send_on_join", "Pack.dispatch.send_pack", false);
+    }
+
+    private static void normalizeDispatchModeForServerSupport() {
+        if (dispatchModeNormalized) return;
+
+        synchronized (dispatchNormalizationLock) {
+            if (dispatchModeNormalized) return;
+
+            boolean sendPreJoin = readSendPreJoinConfigured();
+            boolean sendOnJoin = readSendOnJoinConfigured();
+            boolean preJoinSupported = VersionUtil.isPaperServer() && VersionUtil.atOrAbove("1.21.7");
+
+            if (sendPreJoin && !preJoinSupported && !sendOnJoin) {
+                Settings.SEND_ON_JOIN.setValue(true);
+                if (Settings.DEBUG.toBool()) {
+                    Logs.logInfo("Enabled Pack.dispatch.send_on_join because Pack.dispatch.send_pre_join is unsupported on this server.");
+                }
+            }
+
+            dispatchModeNormalized = true;
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/receive/PackReceiver.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/receive/PackReceiver.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.resource.ResourcePackStatus;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.title.Title;
@@ -13,17 +14,84 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class PackReceiver implements Listener {
 
+    private static final ConcurrentMap<UUID, List<PlayerResourcePackStatusEvent.Status>> pendingStatuses = new ConcurrentHashMap<>();
+    private static final Object pendingStatusesLock = new Object();
+
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerUpdatesPackStatus(PlayerResourcePackStatusEvent event) {
-        PlayerResourcePackStatusEvent.Status status = event.getStatus();
-        TagResolver playerResolver = AdventureUtils.tagResolver("player", event.getPlayer().getName());
+        processStatus(event.getPlayer(), event.getStatus());
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        UUID playerId = event.getPlayer().getUniqueId();
+        List<PlayerResourcePackStatusEvent.Status> queuedStatuses;
+        synchronized (pendingStatusesLock) {
+            queuedStatuses = pendingStatuses.remove(playerId);
+        }
+        if (queuedStatuses == null || queuedStatuses.isEmpty()) return;
+
+        for (PlayerResourcePackStatusEvent.Status status : queuedStatuses) {
+            processStatus(event.getPlayer(), status);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        synchronized (pendingStatusesLock) {
+            pendingStatuses.remove(event.getPlayer().getUniqueId());
+        }
+    }
+
+    public static void handleAdventureStatus(@Nullable UUID playerId, @NotNull ResourcePackStatus status) {
+        if (!Settings.RECEIVE_ENABLED.toBool() || playerId == null) return;
+
+        PlayerResourcePackStatusEvent.Status bukkitStatus = toBukkitStatus(status);
+        if (bukkitStatus == null) return;
+
+        Player playerToProcess = null;
+        synchronized (pendingStatusesLock) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                playerToProcess = player;
+            } else {
+                pendingStatuses.compute(playerId, (uuid, statuses) -> {
+                    List<PlayerResourcePackStatusEvent.Status> list = statuses != null ? statuses : new ArrayList<>();
+                    list.add(bukkitStatus);
+                    return list;
+                });
+            }
+        }
+
+        if (playerToProcess != null) {
+            Player scheduledPlayer = playerToProcess;
+            SchedulerUtil.runTask(() -> {
+                if (scheduledPlayer.isOnline()) {
+                    processStatus(scheduledPlayer, bukkitStatus);
+                }
+            });
+        }
+    }
+
+    private static void processStatus(Player player, PlayerResourcePackStatusEvent.Status status) {
+        if (!Settings.RECEIVE_ENABLED.toBool()) return;
+
+        TagResolver playerResolver = AdventureUtils.tagResolver("player", player.getName());
         PackAction packAction = switch (status) {
             case ACCEPTED -> new PackAction(Settings.RECEIVE_ALLOWED_ACTIONS.toConfigSection(), playerResolver);
             case DECLINED -> new PackAction(Settings.RECEIVE_DENIED_ACTIONS.toConfigSection(), playerResolver);
@@ -36,17 +104,26 @@ public class PackReceiver implements Listener {
             case FAILED_RELOAD -> new PackAction(Settings.RECEIVE_FAILED_RELOAD_ACTIONS.toConfigSection(), playerResolver);
             case DISCARDED -> new PackAction(Settings.RECEIVE_DISCARDED_ACTIONS.toConfigSection(), playerResolver);
         };
-        SchedulerUtil.runForEntityLater(event.getPlayer(), packAction.getDelay(), () -> {
+        SchedulerUtil.runForEntityLater(player, packAction.getDelay(), () -> {
             if (packAction.hasMessage())
-                sendMessage(event.getPlayer(), packAction.getMessageType(), packAction.getMessageContent());
+                sendMessage(player, packAction.getMessageType(), packAction.getMessageContent());
             if (packAction.hasSound())
-                packAction.playSound(event.getPlayer(), event.getPlayer().getLocation());
+                packAction.playSound(player, player.getLocation());
 
-            packAction.getCommandsParser().perform(event.getPlayer());
+            packAction.getCommandsParser().perform(player);
         }, () -> {});
     }
 
-    private void sendMessage(Player receiver, String action, Component message) {
+    @Nullable
+    private static PlayerResourcePackStatusEvent.Status toBukkitStatus(ResourcePackStatus status) {
+        try {
+            return PlayerResourcePackStatusEvent.Status.valueOf(status.name());
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private static void sendMessage(Player receiver, String action, Component message) {
         @NotNull Audience audience = OraxenPlugin.get().getAudience().sender(receiver);
         switch (action) {
             case "KICK" -> receiver.kickPlayer(AdventureUtils.LEGACY_SERIALIZER.serialize(message));

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/MultiVersionUploadManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/MultiVersionUploadManager.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.api.events.OraxenPackPreUploadEvent;
 import io.th0rgal.oraxen.api.events.OraxenPackUploadEvent;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.pack.dispatch.MultiVersionPackSender;
+import io.th0rgal.oraxen.pack.dispatch.PackSender;
 import io.th0rgal.oraxen.pack.dispatch.PlayerVersionDetector;
 import io.th0rgal.oraxen.pack.generation.PackVersion;
 import io.th0rgal.oraxen.pack.generation.PackVersionManager;
@@ -102,12 +103,12 @@ public class MultiVersionUploadManager {
         }
         packSender = new MultiVersionPackSender(vm);
 
-        boolean shouldRegister = (Settings.SEND_PACK.toBool() || Settings.SEND_JOIN_MESSAGE.toBool())
+        boolean shouldRegister = (PackSender.isAnyDispatchEnabled() || Settings.SEND_JOIN_MESSAGE.toBool())
                 && !(reload && !Settings.SEND_ON_RELOAD.toBool());
 
         if (shouldRegister) {
             packSender.register();
-            if (sendToPlayers && Settings.SEND_PACK.toBool() && contentChanged) {
+            if (sendToPlayers && PackSender.isAnyDispatchEnabled() && contentChanged) {
                 for (Player player : Bukkit.getOnlinePlayers()) {
                     packSender.sendPack(player);
                 }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/UploadManager.java
@@ -121,7 +121,7 @@ public class UploadManager {
         if (cancelled) return;
         if (isReload && !Settings.SEND_ON_RELOAD.toBool() && packSender != null) {
             packSender.unregister();
-        } else if (Settings.SEND_PACK.toBool() || Settings.SEND_JOIN_MESSAGE.toBool()) {
+        } else if (PackSender.isAnyDispatchEnabled() || Settings.SEND_JOIN_MESSAGE.toBool()) {
             packSender.register();
             if (contentChanged) {
                 for (Player player : Bukkit.getOnlinePlayers())

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -198,7 +198,8 @@ Pack:
       domain: "localhost:8080" # The domain/IP:port that players will use to download the pack (e.g., "my-server.com:8080" or "192.168.1.100:8080")
 
   dispatch:
-    send_pack: true
+    send_pre_join: true # Pre-join dispatch (Paper 1.21.7+). Takes priority over send_on_join when supported.
+    send_on_join: false # Legacy join dispatch (after full join). If send_pre_join is enabled but unsupported, Oraxen auto-enables send_on_join and saves settings.yml.
     send_on_reload: true
     delay: -1
     mandatory: true

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
@@ -73,6 +73,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.components.FoodComponent;
+import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -86,9 +87,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     private final GlyphHandler glyphHandler;
+    private final Listener packDispatchListener;
 
     public NMSHandler() {
         this.glyphHandler = new io.th0rgal.oraxen.nms.v1_21_R6.GlyphHandler();
+        this.packDispatchListener = new PackDispatchListener();
 
         // mineableWith tag handling
         NamespacedKey tagKey = NamespacedKey.fromString("mineable_with_key", OraxenPlugin.get());
@@ -119,6 +122,11 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
     @Override
     public GlyphHandler glyphHandler() {
         return glyphHandler;
+    }
+
+    @Override
+    public Listener packDispatchListener() {
+        return packDispatchListener;
     }
 
     @Override

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/PackDispatchListener.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/PackDispatchListener.java
@@ -1,0 +1,71 @@
+package io.th0rgal.oraxen.nms.v1_21_R6;
+
+import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
+import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent;
+import io.papermc.paper.event.connection.configuration.PlayerConnectionReconfigureEvent;
+import io.th0rgal.oraxen.pack.dispatch.PackSender;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class PackDispatchListener implements Listener {
+
+    private final ConcurrentHashMap<UUID, CompletableFuture<Void>> futures = new ConcurrentHashMap<>();
+
+    @EventHandler
+    public void onInitialConfig(@NotNull AsyncPlayerConnectionConfigureEvent event) {
+        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
+
+        UUID uuid = event.getConnection().getProfile().getId();
+        if (uuid == null) return;
+
+        try {
+            CompletableFuture<Void> previous = futures.remove(uuid);
+            if (previous != null) previous.complete(null);
+        } catch (Exception ignored) {
+        }
+
+        CompletableFuture<Void> future = PackSender.sendResourcePack(event.getConnection(), false);
+        if (future != null) {
+            futures.put(uuid, future);
+            try {
+                future.get(10, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                Logs.logWarning("Timed out while waiting for pre-join resource pack callback for " + uuid);
+                future.cancel(true);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Logs.logWarning("Interrupted while waiting for pre-join resource pack callback for " + uuid);
+                future.cancel(true);
+            } catch (ExecutionException e) {
+                Logs.logWarning("Pre-join resource pack dispatch failed for " + uuid + ": " + e.getMessage());
+                future.cancel(true);
+            } finally {
+                futures.remove(uuid, future);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onReconfig(@NotNull PlayerConnectionReconfigureEvent event) {
+        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
+        PackSender.sendResourcePack(event.getConnection(), true);
+    }
+
+    @EventHandler
+    public void onClose(@NotNull PlayerConnectionCloseEvent event) {
+        try {
+            CompletableFuture<Void> future = futures.remove(event.getPlayerUniqueId());
+            if (future != null) future.complete(null);
+        } catch (Exception ignored) {
+        }
+    }
+}


### PR DESCRIPTION
## 🟠 Pre-Join Pack Dispatch Fallback and Safety
- **Summary** - Added pre-join dispatch support with automatic fallback to on-join dispatch on unsupported servers, and hardened pre-join wait handling.
- **Description** - Oraxen now keeps `send_pre_join` as default, but if the server does not support pre-join dispatch it automatically enables `send_on_join`, persists that in `settings.yml`, and logs this in debug mode. Join-dispatch logic was simplified to remove redundant conditions, and pre-join async waiting now uses a timeout with proper failure handling.

- **Changes** - Implemented dispatch-mode normalization and persistence in `PackSender`; updated join dispatch flow in `BukkitPackSender` and `MultiVersionPackSender`; replaced unbounded `future.join()` with bounded `future.get(..., TimeUnit.SECONDS)` plus timeout/interruption/execution handling and cleanup in `v1_21_R6` `PackDispatchListener`; clarified `settings.yml` comments for `send_pre_join` / `send_on_join`.

## 🟠 Pre-Join Pack Receive Bridge
- **Summary** - Added reliable receive-action execution (including welcome sound) for `send_pre_join` dispatch mode and hardened related concurrency/dispatch logic.
- **Description** - Pre-join pack callbacks now flow into Oraxen’s existing `Pack.receive.*` pipeline, with queued status replay when the player is not yet online, main-thread-safe processing, consistent locking around queued statuses, and clearer on-join effective dispatch evaluation.

- **Changes** - Introduced Adventure status bridging in `PackSender` to `PackReceiver`; added queued pre-join status storage/replay on join and cleanup on quit in `PackReceiver`; made status processing main-thread scheduled when invoked from callback paths; fixed race/locking consistency with `pendingStatusesLock`; removed dead assignment in `MultiVersionPackSender` by using `effectiveSendOnJoin`; added/kept pre-join fallback normalization that auto-enables `send_on_join` when unsupported and persists it in `settings.yml` (with debug log).