### PR TITLE
fix: Merge overlay asset directories in pack packs

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMerger.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMerger.java
@@ -268,8 +268,13 @@ public class PackMerger {
             
             String relativePath = entryPath.substring(root.length());
             
-            // Valid resource pack files: assets/*, pack.mcmeta, pack.png
-            if (relativePath.startsWith("assets/") || 
+            // Valid resource pack files:
+            // - base assets: assets/*
+            // - overlay assets: <overlay_directory>/assets/*
+            // - root metadata/files: pack.mcmeta, pack.png
+            if (relativePath.startsWith("assets/")
+                || isOverlayAssetsPath(relativePath)
+                ||
                 relativePath.equals("pack.mcmeta") || 
                 relativePath.equals("pack.png")) {
                 return relativePath;
@@ -277,6 +282,15 @@ public class PackMerger {
         }
         
         return null;
+    }
+
+    /**
+     * Returns true if a path is an overlay-style assets path:
+     * <overlay_directory>/assets/...
+     */
+    private boolean isOverlayAssetsPath(String relativePath) {
+        int assetsIndex = relativePath.indexOf("/assets/");
+        return assetsIndex > 0;
     }
 
     private String getParentFolder(String path) {

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMergerIntegrationTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMergerIntegrationTest.java
@@ -158,6 +158,23 @@ public class PackMergerIntegrationTest {
         assertTrue(result.isEmpty(), "Should return empty list for invalid pack structure");
     }
 
+    @Test
+    void testOverlayDirectoryAssetsAreMerged() throws IOException {
+        createZipFile(uploadsFolder.resolve("overlay_pack.zip"),
+                "pack.mcmeta", """
+                        {"pack":{"pack_format":34},"overlays":{"entries":[{"directory":"overlay_1_21_6_plus"}]}}
+                        """,
+                "overlay_1_21_6_plus/assets/minecraft/shaders/core/rendertype_text.vsh", "SHADER_DATA",
+                "overlay_1_21_6_plus/assets/minecraft/shaders/core/rendertype_text.json", "{\"vertex\":\"test\"}");
+
+        List<VirtualFile> result = merger.mergeUploadedPacks();
+        List<String> paths = result.stream().map(VirtualFile::getPath).collect(Collectors.toList());
+
+        assertTrue(paths.contains("pack.mcmeta"));
+        assertTrue(paths.contains("overlay_1_21_6_plus/assets/minecraft/shaders/core/rendertype_text.vsh"));
+        assertTrue(paths.contains("overlay_1_21_6_plus/assets/minecraft/shaders/core/rendertype_text.json"));
+    }
+
     private void createZipFile(Path zipPath, String... entries) throws IOException {
         if (entries.length % 2 != 0) {
             throw new IllegalArgumentException("Entries must be path/content pairs");
@@ -363,6 +380,7 @@ public class PackMergerIntegrationTest {
                 String relativePath = entryPath.substring(root.length());
 
                 if (relativePath.startsWith("assets/") ||
+                        isOverlayAssetsPath(relativePath) ||
                         relativePath.equals("pack.mcmeta") ||
                         relativePath.equals("pack.png")) {
                     return relativePath;
@@ -370,6 +388,11 @@ public class PackMergerIntegrationTest {
             }
 
             return null;
+        }
+
+        private boolean isOverlayAssetsPath(String relativePath) {
+            int assetsIndex = relativePath.indexOf("/assets/");
+            return assetsIndex > 0;
         }
 
         private String getParentFolder(String path) {


### PR DESCRIPTION
## 🟠 Overlay Import Preservation
- **Summary** - Fixed Oraxen pack upload merging so overlay directories are no longer dropped from `pack/uploads/*.zip`.

- **Description** - Vanilla overlay packs can include root-level overlay folders like `<overlay_dir>/assets/...` referenced by `pack.mcmeta` overlays entries. Oraxen’s upload merger previously only accepted `assets/...`, `pack.mcmeta`, and `pack.png`, so valid overlay-directory asset paths were ignored during zip merge. The fix extends path acceptance to include overlay-style paths (`<overlay_dir>/assets/...`) while keeping existing pack-root detection and filtering behavior.

- **Changes** - Updated normalization logic in `core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMerger.java` to treat overlay-directory assets as valid imported files. Added integration coverage in `core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMergerIntegrationTest.java` with `testOverlayDirectoryAssetsAreMerged`, and mirrored the same normalization rule in the test harness merger. Verified with `./gradlew :core:test --tests "io.th0rgal.oraxen.pack.generation.PackMergerIntegrationTest" --tests "io.th0rgal.oraxen.pack.generation.PackMergerTest"` and `./gradlew :core:test --tests "io.th0rgal.oraxen.pack.generation.PackMergerIntegrationTest.testOverlayDirectoryAssetsAreMerged"`.
