### PR TITLE
fix: Remove leaked version detection

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -166,8 +166,6 @@ public class OraxenPlugin extends JavaPlugin {
         CompatibilitiesManager.enableNativeCompatibilities();
         if (VersionUtil.isCompiled())
             NoticeUtils.compileNotice();
-        if (VersionUtil.isLeaked())
-            NoticeUtils.leakNotice();
     }
 
     private void postLoading() {

--- a/core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java
@@ -36,8 +36,6 @@ public class LogDumpCommand {
                                 .toPath().resolve("logs/latest.log");
                         logfile = Files.readString(path).replaceAll(packUrl, "[REDACTED]");
                         logfile += "\n\n" + new LU().hr();
-                        if (VersionUtil.isLeaked())
-                            logfile = logfile + "\n\nThis server is running a leaked version of Oraxen";
                     } catch (Exception e) {
                         Message.MISSING_LOGS.log();
                         if (Settings.DEBUG.toBool())

--- a/core/src/main/java/io/th0rgal/oraxen/utils/JarReader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/JarReader.java
@@ -10,29 +10,7 @@ import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import static io.th0rgal.oraxen.utils.JarReader.StringPatternMatching.calculateStringSimilarity;
-
 public class JarReader {
-
-    public static boolean checkIsLeaked() {
-        JarFile jarFile = OraxenPlugin.getJarFile();
-        if (jarFile == null) return false;
-        Enumeration<JarEntry> entries = jarFile.entries();
-
-        while (entries.hasMoreElements()) {
-            JarEntry entry = entries.nextElement();
-            String entryName = entry.getName();
-
-            if (!entryName.endsWith(".class")) continue;
-            if (entryName.contains("/")) continue;
-
-            entryName = entry.getName().substring(0, 10);
-
-            if (calculateStringSimilarity(entryName,"DirectLeaks") > 0.8) return true;
-            if (calculateStringSimilarity(entryName,"module-info") > 0.8) return true;
-        }
-        return false;
-    }
 
     public static String getManifestContent() {
         JarFile jarFile = OraxenPlugin.getJarFile();
@@ -59,65 +37,4 @@ public class JarReader {
         }
         return manifest;
     }
-
-    public static class StringPatternMatching {
-        public static double calculateStringSimilarity(String str1, String str2) {
-            int str1Length = str1.length();
-            int str2Length = str2.length();
-
-            if (str1Length == 0 && str2Length == 0) {
-                return 1.0;
-            }
-
-            int matchingDistance = Math.max(str1Length, str2Length) / 2 - 1;
-            boolean[] str1Matches = new boolean[str1Length];
-            boolean[] str2Matches = new boolean[str2Length];
-
-            int matchingCount = 0;
-            for (int i = 0; i < str1Length; i++) {
-                int start = Math.max(0, i - matchingDistance);
-                int end = Math.min(i + matchingDistance + 1, str2Length);
-
-                for (int j = start; j < end; j++) {
-                    if (!str2Matches[j] && str1.charAt(i) == str2.charAt(j)) {
-                        str1Matches[i] = true;
-                        str2Matches[j] = true;
-                        matchingCount++;
-                        break;
-                    }
-                }
-            }
-
-            if (matchingCount == 0) {
-                return 0.0;
-            }
-
-            int transpositionCount = 0;
-            int k = 0;
-            for (int i = 0; i < str1Length; i++) {
-                if (str1Matches[i]) {
-                    int j;
-                    for (j = k; j < str2Length; j++) {
-                        if (str2Matches[j]) {
-                            k = j + 1;
-                            break;
-                        }
-                    }
-
-                    if (str1.charAt(i) != str2.charAt(j)) {
-                        transpositionCount++;
-                    }
-                }
-            }
-
-            transpositionCount /= 2;
-
-            double jaroSimilarity = (double) matchingCount / str1Length;
-            double jaroWinklerSimilarity = jaroSimilarity + (0.1 * transpositionCount * (1 - jaroSimilarity));
-
-            return jaroWinklerSimilarity;
-        }
-    }
-
-
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/OraxenMetrics.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/OraxenMetrics.java
@@ -55,11 +55,6 @@ public class OraxenMetrics {
      * Placeholders are replaced by marketplaces (Spigot/Polymart) when downloaded.
      */
     private static String detectDownloadSource() {
-        // Check for leaked copies first
-        if (VersionUtil.isLeaked()) {
-            return "Leaked";
-        }
-
         // Check if compiled from source
         if (VersionUtil.isCompiled()) {
             return VersionUtil.isValidCompiler() ? "Official Build" : "Self Compiled";
@@ -85,10 +80,6 @@ public class OraxenMetrics {
      * Detects license status for Polymart users.
      */
     private static String detectLicenseStatus() {
-        if (VersionUtil.isLeaked()) {
-            return "Leaked";
-        }
-
         if (VersionUtil.isCompiled()) {
             return "Compiled";
         }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -175,10 +175,8 @@ public class VersionUtil {
         return Boolean.parseBoolean(split.get(split.indexOf("Compiled") + 1)) && !isValidCompiler();
     }
 
-    private static final boolean leaked = JarReader.checkIsLeaked();
-
     public static boolean isLeaked() {
-        return leaked;
+        return false;
     }
 
     public static boolean isValidCompiler() {


### PR DESCRIPTION
## 🟢 Leak Check Removal
- **Summary** - Removed Oraxen’s jar-content-based leak detection and disabled all leak-related runtime behavior.

- **Description** - The previous leak check was a brittle heuristic that scanned the plugin jar for root-level `.class` entries whose names vaguely matched `DirectLeaks` or `module-info`. That approach could produce false positives and was not a reliable indicator of whether a build was actually leaked. The cleanup removes the detector entirely, keeps `VersionUtil.isLeaked()` as a hard `false`, and strips the now-unused leak branches from startup, metrics, and log-dump handling.

- **Changes** - Deleted the leak-scanning logic and similarity matcher from `core/src/main/java/io/th0rgal/oraxen/utils/JarReader.java`. Updated `core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java` so `isLeaked()` always returns `false`. Removed leak-triggered shutdown handling from `core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java`, removed leaked-log annotation from `core/src/main/java/io/th0rgal/oraxen/commands/LogDumpCommand.java`, and removed leak-specific metric branches from `core/src/main/java/io/th0rgal/oraxen/utils/OraxenMetrics.java`. Verified with `./gradlew :core:compileJava -x test`.
