### PR TITLE
fix: sign glyph formatting

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -158,10 +158,9 @@ public class FontEvents implements Listener {
         if (!Settings.FORMAT_SIGNS.toBool() || manager.useNmsGlyphs()) return;
 
         Player player = event.getPlayer();
-        for (String line : event.getLines()) {
-            line = AdventureUtils.parseLegacyThroughMiniMessage(line);
-            int i = Arrays.stream(event.getLines()).toList().indexOf(line);
-            if (i == -1) continue;
+        String[] lines = event.getLines();
+        for (int i = 0; i < lines.length; i++) {
+            String line = AdventureUtils.parseLegacyThroughMiniMessage(lines[i]);
             for (Character character : manager.getReverseMap().keySet()) {
                 if (!line.contains(String.valueOf(character))) continue;
 
@@ -181,7 +180,7 @@ public class FontEvents implements Listener {
                             : line.replace(entry.getKey(), ChatColor.WHITE + unicode + PapiAliases.setPlaceholders(player, manager.permsChatcolor))
                             .replace(unicode, ChatColor.WHITE + unicode + ChatColor.BLACK);
             }
-            event.setLine(i, AdventureUtils.parseLegacy(line));
+            event.setLine(i, line);
         }
     }
 


### PR DESCRIPTION
## 🟠 Sign Glyph Formatting Fix
- **Summary** - Fixed sign glyph processing so placeholders like `<3` no longer render literal MiniMessage tags (e.g. `<white>...</white>`) on signs.

- **Description** - Sign formatting in `FontEvents#onSignGlyph` was converting the final line back into MiniMessage text before calling `SignChangeEvent#setLine`, which expects plain/legacy sign text. This caused raw MiniMessage tags to appear on placed signs. The handler also used `indexOf(line)` after mutating the line, which could fail to find the correct line index and skip updates. The fix writes the processed legacy line directly and switches to deterministic index-based iteration over sign lines.

- **Changes** - Updated sign handling in `core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java`:
  - Replaced `for (String line : event.getLines())` plus `indexOf(line)` with indexed iteration over `event.getLines()`.
  - Replaced `event.setLine(i, AdventureUtils.parseLegacy(line));` with `event.setLine(i, line);`.
