### PR TITLE
fix: duplicate text in MiniMessage effect tag rendering

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/font/TextEffectTag.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/TextEffectTag.java
@@ -12,7 +12,6 @@ import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -91,34 +90,13 @@ public class TextEffectTag {
 
         @Override
         public Component apply(@NotNull Component current, int depth) {
-            // Only transform at depth 0 to avoid double-processing
-            if (depth > 0) {
-                return current;
+            // Modifying tags are applied recursively by MiniMessage itself.
+            // Returning a component with existing children would make MiniMessage append
+            // those children again, causing duplicated text.
+            Component transformed = current.font(effectFont).color(triggerColor);
+            if (!current.children().isEmpty()) {
+                transformed = transformed.children(List.of());
             }
-
-            return transformComponent(current);
-        }
-
-        /**
-         * Recursively transforms a component tree, applying effect font/color
-         * while preserving structure, decorations, and events.
-         */
-        private Component transformComponent(Component component) {
-            // Apply effect font and color, preserving other styles
-            // Adventure's style system is additive, so decorations like bold/italic are preserved
-            Component transformed = component.font(effectFont).color(triggerColor);
-
-            // Recursively transform children
-            List<Component> children = component.children();
-            if (!children.isEmpty()) {
-                List<Component> transformedChildren = new ArrayList<>(children.size());
-                for (Component child : children) {
-                    transformedChildren.add(transformComponent(child));
-                }
-                // Build new component with transformed children
-                return transformed.children(transformedChildren);
-            }
-
             return transformed;
         }
     }


### PR DESCRIPTION
## 🟢 Fix Rainbow Effect Text Duplication
- **Summary** - Fixed duplicated text output when using `<effect:...>...</effect>` (e.g. rainbow) in item names/lore.

- **Description** - The custom `Modifying` tag implementation in `TextEffectTag` was recursively transforming and reattaching children, while MiniMessage already handles recursive modifier application. That caused children to be appended twice (`lol` -> `lollol`).

- **Changes** - Updated `core/src/main/java/io/th0rgal/oraxen/font/TextEffectTag.java` to:
  - Remove manual recursive child transformation logic.
  - Apply effect styling only to the current component in `apply(...)`.
  - Clear retained children before returning so MiniMessage can append transformed children exactly once.