### PR TITLE
fix: sapling replaceBlocks config key mismatch and inverted water check

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingListener.java
@@ -44,7 +44,7 @@ public class SaplingListener implements Listener {
         SaplingMechanic sapling = mechanic.getSaplingMechanic();
         if (sapling == null || !sapling.hasSchematic()) return;
         if (sapling.requiresLight() && sapling.getMinLightLevel() > block.getLightLevel()) return;
-        if (sapling.requiresWaterSource() && sapling.isUnderWater(block)) return;
+        if (sapling.requiresWaterSource() && !sapling.isUnderWater(block)) return;
         if (!sapling.canGrowFromBoneMeal()) return;
         if (!PluginUtils.isEnabled("WorldEdit")) return;
         if (!sapling.replaceBlocks() && !WrappedWorldEdit.getBlocksInSchematic(loc, sapling.getSchematic()).isEmpty()) return;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/sapling/SaplingMechanic.java
@@ -33,7 +33,7 @@ public class SaplingMechanic {
         minLightLevel = section.getInt("minLightLevel", 0);
         requiresWaterSource = section.getBoolean("requiresWaterSource", false);
         schematicName = section.getString("schematicName", null);
-        shouldReplaceBlocks = section.getBoolean("shouldReplaceBlocks", false);
+        shouldReplaceBlocks = section.getBoolean("replaceBlocks", section.getBoolean("shouldReplaceBlocks", false));
         shouldCopyBiomes = section.getBoolean("shouldCopyBiomes", false);
         shouldCopyEntities = section.getBoolean("shouldCopyEntities", false);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.212.0
+pluginVersion=1.212.1


### PR DESCRIPTION
## Summary
- The sapling mechanic read `shouldReplaceBlocks` from config but users use `replaceBlocks`, so the value always defaulted to `false`  preventing schematic pasting when any non-replaceable block existed in the footprint
- Fixes inverted water check in `SaplingListener` (`SaplingTask` already had the correct logic)
- Bumps version to 1.212.1

## Test plan
- [ ] Configure a stringblock sapling with `replaceBlocks: true` and verify bone meal grows the tree
- [ ] Configure with `replaceBlocks: false` and verify blocks in footprint prevent growth
- [ ] Verify `shouldReplaceBlocks` still works as a key (backward compat)
- [ ] Test `requiresWaterSource: true` with and without water present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfixes to sapling growth gating and config parsing; main impact is behavior change for setups relying on the previously incorrect water check or misread `replaceBlocks` setting.
> 
> **Overview**
> Fixes stringblock sapling growth conditions when using bone meal by correcting the `requiresWaterSource` check (now blocks growth *unless* water is present).
> 
> Updates `SaplingMechanic` config parsing to read `replaceBlocks` (with fallback to legacy `shouldReplaceBlocks`), ensuring schematic pasting respects the intended replace behavior. Bumps plugin version to `1.212.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20519f8678c1d8858372102bdf37665fee52c78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->