### PR TITLE
Add Minecraft 26.1.1 support & ViaVersion Support / Fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,18 @@ val foliaPluginPath = project.findProperty("oraxen_folia_plugin_path")?.toString
 val spigotPluginPath = project.findProperty("oraxen_spigot_plugin_path")?.toString()
 val pluginVersion: String by project
 val runServerVersion = findProperty("mcVersion") as String? ?: "26.1.1"
-val runServerJavaVersion = if (runServerVersion.startsWith("26.")) 25 else 21
+val runServerMajorVersion = Regex("""^\D*(\d+)""")
+    .find(runServerVersion)
+    ?.groupValues
+    ?.get(1)
+    ?.toIntOrNull()
+val configuredRunJavaVersion = project.findProperty("runJavaVersion")?.toString()
+val runServerJavaVersion = if (configuredRunJavaVersion != null) {
+    configuredRunJavaVersion.toIntOrNull()
+        ?: throw GradleException("Invalid runJavaVersion '$configuredRunJavaVersion'. Expected an integer Java language level (e.g., 21, 25).")
+} else {
+    if ((runServerMajorVersion ?: 0) >= 26) 25 else 21
+}
 group = "io.th0rgal"
 version = pluginVersion
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,8 @@ val devPluginPath = project.findProperty("oraxen_dev_plugin_path")?.toString()
 val foliaPluginPath = project.findProperty("oraxen_folia_plugin_path")?.toString()
 val spigotPluginPath = project.findProperty("oraxen_spigot_plugin_path")?.toString()
 val pluginVersion: String by project
+val runServerVersion = findProperty("mcVersion") as String? ?: "26.1.1"
+val runServerJavaVersion = if (runServerVersion.startsWith("26.")) 25 else 21
 group = "io.th0rgal"
 version = pluginVersion
 
@@ -142,7 +144,7 @@ java {
 tasks.withType(xyz.jpenilla.runtask.task.AbstractRun::class) {
     javaLauncher = javaToolchains.launcherFor {
         vendor = JvmVendorSpec.JETBRAINS
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(runServerJavaVersion)
     }
     jvmArgs("-XX:+AllowEnhancedClassRedefinition")
 }
@@ -173,8 +175,6 @@ tasks {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
         filteringCharset = Charsets.UTF_8.name()
     }
-
-    val runServerVersion = findProperty("mcVersion") as String? ?: "26.1.1"
 
     runServer {
         downloadPlugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
     //id("com.github.johnrengelman.shadow") version "8.1.1"
     id("xyz.jpenilla.run-paper") version "2.3.1"
     id("net.minecrell.plugin-yml.bukkit") version "0.6.0" // Generates plugin.yml
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17" apply false
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21" apply false
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 
@@ -19,6 +19,7 @@ class NMSVersion(val nmsVersion: String, val serverVersion: String)
 infix fun String.toNms(that: String): NMSVersion = NMSVersion(this, that)
 val isCI = System.getenv("CI") != null
 val SUPPORTED_VERSIONS: List<NMSVersion> = listOfNotNull(
+    "v1_26_R1" toNms "26.1.1.build.29-alpha",
     "v1_20_R1" toNms "1.20.1-R0.1-SNAPSHOT",
     "v1_20_R2" toNms "1.20.2-R0.1-SNAPSHOT",
     "v1_20_R3" toNms "1.20.4-R0.1-SNAPSHOT",
@@ -173,7 +174,7 @@ tasks {
         filteringCharset = Charsets.UTF_8.name()
     }
 
-    val runServerVersion = (findProperty("mcVersion") as String?) ?: "1.21.11"
+    val runServerVersion = (findProperty("mcVersion") as String?) ?: "26.1.1"
 
     runServer {
         downloadPlugins {
@@ -226,7 +227,7 @@ tasks {
                         )
                     }",
                     "Compiled" to (project.findProperty("oraxen_compiled")?.toString() ?: "true").toBoolean(),
-                    // Tell Paper not to remap this plugin - v1_21_R6 module uses Mojang mappings
+                    // Tell Paper not to remap this plugin - modern NMS modules use Mojang mappings
                     "paperweight-mappings-namespace" to "mojang"
                 )
             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ val foliaPluginPath = project.findProperty("oraxen_folia_plugin_path")?.toString
 val spigotPluginPath = project.findProperty("oraxen_spigot_plugin_path")?.toString()
 val pluginVersion: String by project
 val runServerVersion = findProperty("mcVersion") as String? ?: "26.1.1"
-val runServerMajorVersion = Regex("""^\D*(\d+)""")
+val runServerMajorVersion = Regex("""^\D*(?:1\.)?(\d+)""")
     .find(runServerVersion)
     ?.groupValues
     ?.get(1)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,7 +174,7 @@ tasks {
         filteringCharset = Charsets.UTF_8.name()
     }
 
-    val runServerVersion = (findProperty("mcVersion") as String?) ?: "26.1.1"
+    val runServerVersion = findProperty("mcVersion") as String? ?: "26.1.1"
 
     runServer {
         downloadPlugins {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     testImplementation("net.kyori:adventure-text-minimessage:4.17.0")
     testImplementation("net.kyori:adventure-text-serializer-legacy:4.17.0")
     testImplementation("com.google.guava:guava:33.0.0-jre")
+    testImplementation("com.google.code.gson:gson:2.10.1")
 }
 
 java {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("java")
     //id("io.papermc.paperweight.userdev") version "1.6.0"
     id("maven-publish")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
     id("org.ajoberstar.grgit.service") version "5.2.0"
 }
 
@@ -26,7 +26,7 @@ tasks.register<JavaExec>("runPackMergerDebug") {
     
     // Pass command line args: ./gradlew :core:runPackMergerDebug --args="path/to/pack.zip"
     if (project.hasProperty("packFile")) {
-        args(project.property("packFile"))
+        args(project.property("packFile").toString())
     }
 }
 

--- a/core/src/main/java/io/th0rgal/oraxen/commands/ModelDataCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/ModelDataCommand.java
@@ -19,10 +19,13 @@ public class ModelDataCommand {
                 .executes((sender, args) -> {
                     Map<Material, Integer> itemMap = new HashMap<>();
                     for (ItemBuilder builder : OraxenItems.getItems()) {
-                        int currentModelData = builder.getOraxenMeta().getCustomModelData();
+                        Integer currentModelData = builder.getOraxenMeta().getCustomModelData();
+                        if (currentModelData == null || currentModelData == 0) {
+                            continue;
+                        }
                         Material type = builder.build().getType();
 
-                        if (currentModelData != 0) itemMap.putIfAbsent(type, currentModelData);
+                        itemMap.putIfAbsent(type, currentModelData);
                         if (itemMap.containsKey(type) && itemMap.get(type) < currentModelData) {
                             itemMap.put(type, currentModelData);
                         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackFileCollector.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackFileCollector.java
@@ -223,7 +223,7 @@ class PackFileCollector {
 
     static boolean isCoreShaderPath(String path) {
         return path.startsWith("assets/minecraft/shaders/core/")
-                || path.matches("assets/minecraft/overlays/.*/shaders/core/.*");
+                || path.matches("overlay_[^/]+/assets/minecraft/shaders/core/.*");
     }
 
     private void readFileToVirtuals(final Collection<VirtualFile> output, File file, String newFolder) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.pack.generation;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.th0rgal.oraxen.utils.ResourcePackFormatUtil;
@@ -33,19 +34,26 @@ public class PackMcmetaUtils {
 
         pack.addProperty("pack_format", packFormat);
 
-        if (packFormat >= 18 && minFormat > 0) {
-            // Add supported_formats for 1.20.2+ packs when explicitly requested
-            JsonObject supportedFormats = new JsonObject();
-            supportedFormats.addProperty("min_inclusive", minFormat);
-            supportedFormats.addProperty("max_inclusive", maxFormat);
-            pack.add("supported_formats", supportedFormats);
-        } else {
-            // Remove any stale supported_formats from deep-copied mcmeta.
-            // For pre-1.20.2 packs (packFormat < 18): supported_formats was introduced
-            // in pack_format 18; having it produces contradictory metadata.
-            // For single-pack mode (minFormat == 0): supported_formats would narrow
-            // the declared range; removing it lets any client accept the pack.
+        if (packFormat >= 65) {
+            // 1.21.11+ metadata requires explicit min/max format fields.
+            int min = minFormat > 0 ? minFormat : packFormat;
+            int max = maxFormat > 0 ? maxFormat : packFormat;
+            pack.addProperty("min_format", min);
+            pack.addProperty("max_format", max);
             pack.remove("supported_formats");
+        } else if (packFormat >= 18 && minFormat > 0) {
+            // Legacy range declaration for pack_format 18..64.
+            JsonArray supportedFormats = new JsonArray();
+            supportedFormats.add(minFormat);
+            supportedFormats.add(maxFormat);
+            pack.add("supported_formats", supportedFormats);
+            pack.remove("min_format");
+            pack.remove("max_format");
+        } else {
+            // Pre-1.20.2 packs do not use range metadata.
+            pack.remove("supported_formats");
+            pack.remove("min_format");
+            pack.remove("max_format");
         }
 
         root.add("pack", pack);
@@ -79,9 +87,6 @@ public class PackMcmetaUtils {
 
     /**
      * Updates the pack.mcmeta file for single-pack mode.
-     * Does NOT add supported_formats — single-pack mode targets only
-     * the server's version. Adding supported_formats would narrow the
-     * declared range and cause ViaVersion clients to see it as incompatible.
      */
     public static void updatePackMcmetaFile(Path mcmetaPath) {
         JsonObject existingMcmeta = readExistingMcmeta(mcmetaPath);
@@ -89,7 +94,8 @@ public class PackMcmetaUtils {
         // Use NMS reflection first (accurate for all versions), fall back to hardcoded mapping
         int packFormat = ResourcePackFormatUtil.getCurrentResourcePackFormat();
 
-        // Pass 0 for minFormat to skip supported_formats in single-pack mode
+        // For modern pack formats (>=65), createPackMcmeta will set min/max to packFormat.
+        // For older formats this keeps legacy behavior (no supported range in single-pack mode).
         JsonObject mcmeta = createPackMcmeta(packFormat, 0, 0, existingMcmeta);
 
         writePackMcmeta(mcmetaPath, mcmeta);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
@@ -34,14 +34,14 @@ public class PackMcmetaUtils {
         pack.addProperty("pack_format", packFormat);
 
         if (packFormat >= 65) {
-            // pack_format > 64 requires explicit min/max range fields.
+            // Resource pack format 65+ (introduced in 25w31a / 1.21.9) uses top-level min/max fields.
             int min = minFormat > 0 ? minFormat : packFormat;
             int max = maxFormat > 0 ? maxFormat : packFormat;
             pack.addProperty("min_format", min);
             pack.addProperty("max_format", max);
             pack.remove("supported_formats");
         } else if (packFormat >= 18 && minFormat > 0) {
-            // 1.20.2-1.21.x range declaration.
+            // 1.20.2-1.21.8 range declaration.
             JsonObject supportedFormats = new JsonObject();
             supportedFormats.addProperty("min_inclusive", minFormat);
             supportedFormats.addProperty("max_inclusive", maxFormat);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
@@ -2,7 +2,6 @@ package io.th0rgal.oraxen.pack.generation;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.th0rgal.oraxen.utils.ResourcePackFormatUtil;
@@ -35,17 +34,17 @@ public class PackMcmetaUtils {
         pack.addProperty("pack_format", packFormat);
 
         if (packFormat >= 65) {
-            // 1.21.11+ metadata requires explicit min/max format fields.
+            // pack_format > 64 requires explicit min/max range fields.
             int min = minFormat > 0 ? minFormat : packFormat;
             int max = maxFormat > 0 ? maxFormat : packFormat;
             pack.addProperty("min_format", min);
             pack.addProperty("max_format", max);
             pack.remove("supported_formats");
         } else if (packFormat >= 18 && minFormat > 0) {
-            // Legacy range declaration for pack_format 18..64.
-            JsonArray supportedFormats = new JsonArray();
-            supportedFormats.add(minFormat);
-            supportedFormats.add(maxFormat);
+            // 1.20.2-1.21.x range declaration.
+            JsonObject supportedFormats = new JsonObject();
+            supportedFormats.addProperty("min_inclusive", minFormat);
+            supportedFormats.addProperty("max_inclusive", maxFormat);
             pack.add("supported_formats", supportedFormats);
             pack.remove("min_format");
             pack.remove("max_format");
@@ -94,8 +93,8 @@ public class PackMcmetaUtils {
         // Use NMS reflection first (accurate for all versions), fall back to hardcoded mapping
         int packFormat = ResourcePackFormatUtil.getCurrentResourcePackFormat();
 
-        // For modern pack formats (>=65), createPackMcmeta will set min/max to packFormat.
-        // For older formats this keeps legacy behavior (no supported range in single-pack mode).
+        // For modern formats (>=65), createPackMcmeta sets min/max to packFormat.
+        // Older formats keep legacy behavior (no explicit supported range in single-pack mode).
         JsonObject mcmeta = createPackMcmeta(packFormat, 0, 0, existingMcmeta);
 
         writePackMcmeta(mcmetaPath, mcmeta);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackVersionManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackVersionManager.java
@@ -26,7 +26,9 @@ public class PackVersionManager {
      */
     private static final Object[][] VERSION_DEFINITIONS = {
         // mcVersion, format, minFormat, maxFormat
-        {"1.21.9",  69, 69, 999},  // 1.21.9+ (latest, open-ended)
+        {"26.1",    84, 84, 999},  // 26.1+ (latest, open-ended)
+        {"1.21.11", 75, 75, 83},   // 1.21.11
+        {"1.21.9",  69, 69, 74},   // 1.21.9-1.21.10
         {"1.21.7",  64, 64, 68},   // 1.21.7-1.21.8
         {"1.21.6",  63, 63, 63},   // 1.21.6
         {"1.21.5",  55, 55, 62},   // 1.21.5

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackVersionManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackVersionManager.java
@@ -212,6 +212,23 @@ public class PackVersionManager {
             }
         }
 
+        // Normalize "1.26.x" runtimes to "26.x" namespace.
+        // Some server forks/wrappers report 26.x as "1.26.x"; the VERSION_DEFINITIONS
+        // table uses "26.1" as the canonical key.
+        if (parts.length >= 2) {
+            try {
+                int majorPart = Integer.parseInt(parts[0]);
+                int minorPart = Integer.parseInt(parts[1]);
+                if (majorPart == 1 && minorPart >= 26) {
+                    if (parts.length >= 3) {
+                        candidates.add(minorPart + "." + parts[2]);
+                    }
+                    candidates.add(String.valueOf(minorPart));
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
         for (String candidate : candidates) {
             PackVersion candidateVersion = packVersions.get(candidate);
             if (candidateVersion != null) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ProtocolVersion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ProtocolVersion.java
@@ -16,6 +16,7 @@ import java.util.Optional;
  * Pack format reference: https://minecraft.wiki/w/Pack_format
  */
 public enum ProtocolVersion {
+    MC_26_1_1(775, 84, "26.1.1"),
     MC_1_21_11(774, 75, "1.21.11"),
     MC_1_21_9(773, 69, "1.21.9"),
     MC_1_21_7(772, 64, "1.21.7"),

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -586,11 +586,8 @@ public class ResourcePack {
             }
 
             MinecraftVersion currentVersion = MinecraftVersion.getCurrentVersion();
-            if (currentVersion.isAtLeast(new MinecraftVersion("1.21.4"))) {
-                addShaderOverlayEntries(root, currentVersion);
-            }
+            addShaderOverlayEntries(root, currentVersion);
 
-            // Use Gson with pretty printing for readable output
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             Files.writeString(mcmetaPath, gson.toJson(root), StandardCharsets.UTF_8);
         } catch (Exception e) {
@@ -607,19 +604,18 @@ public class ResourcePack {
      * Minecraft client versions. The client automatically selects the appropriate
      * overlay based on its pack_format.</p>
      *
-     * @param root The root pack.mcmeta JSON object
-     * @param serverVersion The server's Minecraft version
+     * <p>Also expands the base pack's supported format range to cover all overlay
+     * format ranges, so that clients of any supported version see the pack as
+     * compatible.</p>
      */
     private void addShaderOverlayEntries(JsonObject root, MinecraftVersion serverVersion) {
-        // Get existing overlays or create new one
         JsonObject overlays;
         if (root.has("overlays")) {
             overlays = root.getAsJsonObject("overlays");
         } else {
             overlays = new JsonObject();
         }
-        
-        // Get existing entries array or create new one
+
         JsonArray entries;
         if (overlays.has("entries")) {
             entries = overlays.getAsJsonArray("entries");
@@ -629,25 +625,13 @@ public class ResourcePack {
 
         int initialSize = entries.size();
 
-        if (serverVersion.isAtLeast(new MinecraftVersion("1.21.6"))) {
-            // Server is 1.21.6+, base shaders are 1.21.6 format
-            // Add overlay for 1.21.4/1.21.5 clients (pack_format 46-54)
+        for (ShaderOverlay overlay : textShaderGenerator.getGeneratedOverlays()) {
             JsonObject entry = new JsonObject();
             JsonObject formats = new JsonObject();
-            formats.addProperty("min_inclusive", TextShaderTarget.PACK_FORMAT_1_21_4);
-            formats.addProperty("max_inclusive", TextShaderTarget.PACK_FORMAT_1_21_6 - 1);
+            formats.addProperty("min_inclusive", overlay.minFormat());
+            formats.addProperty("max_inclusive", overlay.maxFormat());
             entry.add("formats", formats);
-            entry.addProperty("directory", textShaderGenerator.getOverlay12145Name());
-            entries.add(entry);
-        } else if (serverVersion.isAtLeast(new MinecraftVersion("1.21.4"))) {
-            // Server is 1.21.4/1.21.5, base shaders are 1.21.4 format
-            // Add overlay for 1.21.6+ clients (pack_format 55+)
-            JsonObject entry = new JsonObject();
-            JsonObject formats = new JsonObject();
-            formats.addProperty("min_inclusive", TextShaderTarget.PACK_FORMAT_1_21_6);
-            formats.addProperty("max_inclusive", 999); // Support future versions
-            entry.add("formats", formats);
-            entry.addProperty("directory", textShaderGenerator.getOverlay1216PlusName());
+            entry.addProperty("directory", overlay.directory());
             entries.add(entry);
         }
 
@@ -655,10 +639,57 @@ public class ResourcePack {
         if (newEntriesAdded > 0) {
             overlays.add("entries", entries);
             root.add("overlays", overlays);
+
+            expandSupportedFormatsRange(root, serverVersion);
+
             if (Settings.DEBUG.toBool()) {
                 Logs.logInfo("Added " + newEntriesAdded + " shader overlay entries to pack.mcmeta");
             }
         }
+    }
+
+    /**
+     * Expands the base pack's supported_formats / min_format / max_format range
+     * to cover all overlay format ranges, ensuring that clients of any supported
+     * version see the pack as compatible.
+     *
+     * <p>For servers on 1.21.9+ (format 65+), also adds the legacy
+     * {@code supported_formats} field so that pre-1.21.9 clients can read the
+     * format range (they don't understand {@code min_format}/{@code max_format}).</p>
+     */
+    private void expandSupportedFormatsRange(JsonObject root, MinecraftVersion serverVersion) {
+        List<ShaderOverlay> overlayList = textShaderGenerator.getGeneratedOverlays();
+        if (overlayList.isEmpty()) return;
+
+        int minOverlayFormat = overlayList.stream()
+                .mapToInt(ShaderOverlay::minFormat).min().orElse(Integer.MAX_VALUE);
+        int maxOverlayFormat = overlayList.stream()
+                .mapToInt(ShaderOverlay::maxFormat).max().orElse(0);
+
+        JsonObject pack = root.has("pack") && root.get("pack").isJsonObject()
+                ? root.getAsJsonObject("pack") : new JsonObject();
+
+        int serverFormat = ResourcePackFormatUtil.getCurrentResourcePackFormat();
+        int effectiveMin = Math.min(serverFormat, minOverlayFormat);
+        int effectiveMax = Math.max(serverFormat, maxOverlayFormat);
+
+        if (serverFormat >= 65) {
+            pack.addProperty("min_format", effectiveMin);
+            pack.addProperty("max_format", effectiveMax);
+            JsonObject supportedFormats = new JsonObject();
+            supportedFormats.addProperty("min_inclusive", effectiveMin);
+            supportedFormats.addProperty("max_inclusive", effectiveMax);
+            pack.add("supported_formats", supportedFormats);
+        } else if (serverFormat >= 18) {
+            JsonObject supportedFormats = new JsonObject();
+            supportedFormats.addProperty("min_inclusive", effectiveMin);
+            supportedFormats.addProperty("max_inclusive", effectiveMax);
+            pack.add("supported_formats", supportedFormats);
+            pack.remove("min_format");
+            pack.remove("max_format");
+        }
+
+        root.add("pack", pack);
     }
 
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -623,6 +623,24 @@ public class ResourcePack {
             entries = new JsonArray();
         }
 
+        Set<String> generatedDirectories = textShaderGenerator.getGeneratedOverlays().stream()
+                .map(ShaderOverlay::directory)
+                .collect(java.util.stream.Collectors.toSet());
+        JsonArray filteredEntries = new JsonArray();
+        for (JsonElement element : entries) {
+            if (!element.isJsonObject()) {
+                filteredEntries.add(element);
+                continue;
+            }
+
+            JsonObject existingEntry = element.getAsJsonObject();
+            String directory = existingEntry.has("directory") ? existingEntry.get("directory").getAsString() : null;
+            if (directory == null || !generatedDirectories.contains(directory)) {
+                filteredEntries.add(existingEntry);
+            }
+        }
+        entries = filteredEntries;
+
         int initialSize = entries.size();
 
         for (ShaderOverlay overlay : textShaderGenerator.getGeneratedOverlays()) {
@@ -632,6 +650,10 @@ public class ResourcePack {
             formats.addProperty("max_inclusive", overlay.maxFormat());
             entry.add("formats", formats);
             entry.addProperty("directory", overlay.directory());
+            if (overlay.minFormat() > 64 || overlay.maxFormat() > 64) {
+                entry.addProperty("min_format", overlay.minFormat());
+                entry.addProperty("max_format", overlay.maxFormat());
+            }
             entries.add(entry);
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ShaderOverlay.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ShaderOverlay.java
@@ -4,8 +4,7 @@ public enum ShaderOverlay {
 
     V1_20_2("overlay_1_20_2", 18, 45, "1.20.2"),
     V1_21_4("overlay_1_21_4", 46, 62, "1.21.4"),
-    V1_21_6("overlay_1_21_6", 63, 68, "1.21.6"),
-    V1_21_9("overlay_1_21_9", 69, 83, "1.21.9"),
+    V1_21_6("overlay_1_21_6", 63, 83, "1.21.6"),
     V26("overlay_26", 84, 999, "26");
 
     private final String directory;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ShaderOverlay.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ShaderOverlay.java
@@ -1,0 +1,38 @@
+package io.th0rgal.oraxen.pack.generation;
+
+public enum ShaderOverlay {
+
+    V1_20_2("overlay_1_20_2", 18, 45, "1.20.2"),
+    V1_21_4("overlay_1_21_4", 46, 62, "1.21.4"),
+    V1_21_6("overlay_1_21_6", 63, 68, "1.21.6"),
+    V1_21_9("overlay_1_21_9", 69, 83, "1.21.9"),
+    V26("overlay_26", 84, 999, "26");
+
+    private final String directory;
+    private final int minFormat;
+    private final int maxFormat;
+    private final String representativeVersion;
+
+    ShaderOverlay(String directory, int minFormat, int maxFormat, String representativeVersion) {
+        this.directory = directory;
+        this.minFormat = minFormat;
+        this.maxFormat = maxFormat;
+        this.representativeVersion = representativeVersion;
+    }
+
+    public String directory() { return directory; }
+    public int minFormat() { return minFormat; }
+    public int maxFormat() { return maxFormat; }
+    public String representativeVersion() { return representativeVersion; }
+
+    public boolean containsFormat(int format) {
+        return format >= minFormat && format <= maxFormat;
+    }
+
+    public static ShaderOverlay forPackFormat(int packFormat) {
+        for (ShaderOverlay overlay : values()) {
+            if (overlay.containsFormat(packFormat)) return overlay;
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -210,7 +210,7 @@ class TextShaderGenerator {
 
     private void generateTextShadersForTarget(TextShaderTarget target, TextShaderFeatures features, String pathPrefix) {
         boolean modernShaderFormat = target.isAtLeast("1.21.6");
-        boolean shouldWriteJson = !modernShaderFormat || !pathPrefix.isEmpty();
+        boolean shouldWriteJson = !modernShaderFormat;
 
         // Generate shaders (see-through uses a different vertex format on 1.21.6+)
         String vshContent = getAnimationVertexShader(target, features, false);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -210,24 +210,24 @@ class TextShaderGenerator {
 
     private void generateTextShadersForTarget(TextShaderTarget target, TextShaderFeatures features, String pathPrefix) {
         boolean modernShaderFormat = target.isAtLeast("1.21.6");
+        boolean shouldWriteJson = !modernShaderFormat || !pathPrefix.isEmpty();
 
         // Generate shaders (see-through uses a different vertex format on 1.21.6+)
         String vshContent = getAnimationVertexShader(target, features, false);
         String fshContent = getAnimationFragmentShader(target, false);
-        String jsonContent = modernShaderFormat ? null : getAnimationShaderJson(target, false);
+        String jsonContent = shouldWriteJson ? getAnimationShaderJson(target, false) : null;
 
         String vshSeeThrough = getAnimationVertexShader(target, features, true);
         String fshSeeThrough = getAnimationFragmentShader(target, true);
-        String jsonSeeThrough = modernShaderFormat ? null : getAnimationShaderJson(target, true);
+        String jsonSeeThrough = shouldWriteJson ? getAnimationShaderJson(target, true) : null;
 
         String vshIntensity = getAnimationVertexShader(target, features, false);
         String fshIntensity = getAnimationFragmentShader(target, false, true);
-        String jsonIntensity = modernShaderFormat ? null : getAnimationShaderJson(target, "rendertype_text_intensity", false);
+        String jsonIntensity = shouldWriteJson ? getAnimationShaderJson(target, "rendertype_text_intensity", false) : null;
 
         String vshIntensitySeeThrough = getAnimationVertexShader(target, features, true);
         String fshIntensitySeeThrough = getAnimationFragmentShader(target, true, true);
-        String jsonIntensitySeeThrough = modernShaderFormat ? null
-                : getAnimationShaderJson(target, "rendertype_text_intensity_see_through", true);
+        String jsonIntensitySeeThrough = shouldWriteJson ? getAnimationShaderJson(target, "rendertype_text_intensity_see_through", true) : null;
 
         String shaderPath = pathPrefix + "assets/minecraft/shaders/core";
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -114,24 +114,22 @@ class TextShaderGenerator {
                 && VersionUtil.atOrAbove("1.20.3")) {
             OraxenPlugin.get().getPacketAdapter().registerScoreboardListener();
         } else { // Pre 1.20.3 rely on shaders
-            // Check if text shaders were already generated - need to combine them
-            if (textShadersGenerated) {
-                // Use combined shaders that support both text features and scoreboard hiding
-                TextShaderTarget target = TextShaderTarget.current();
+            TextShaderTarget target = TextShaderTarget.current();
+            if (target.isAtLeast("26")) {
+                Logs.logWarning("Shader-based scoreboard number hiding is not supported on 26.x+.");
+                Logs.logWarning("Use a packet adapter (ProtocolLib or PacketEvents) on Paper 1.20.3+ instead.");
+            } else if (textShadersGenerated) {
                 boolean hasAnimatedGlyphs = !OraxenPlugin.get().getFontManager().getAnimatedGlyphs().isEmpty();
                 TextShaderFeatures features = textShaderFeatures != null
                         ? textShaderFeatures
                         : resolveTextShaderFeatures(hasAnimatedGlyphs);
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh",
                         getCombinedVertexShader(target, features));
-                if (!target.isAtLeast("26"))
-                    ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json",
-                            getCombinedShaderJson(target));
+                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json",
+                        getCombinedShaderJson(target));
                 Logs.logInfo("Using combined text + scoreboard hiding shaders");
             } else {
-                TextShaderTarget target = TextShaderTarget.current();
-                if (!target.isAtLeast("26"))
-                    ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
+                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh", getScoreboardVsh());
             }
         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -209,41 +209,48 @@ class TextShaderGenerator {
     }
 
     private void generateTextShadersForTarget(TextShaderTarget target, TextShaderFeatures features, String pathPrefix) {
+        boolean modernShaderFormat = target.isAtLeast("1.21.6");
+
         // Generate shaders (see-through uses a different vertex format on 1.21.6+)
         String vshContent = getAnimationVertexShader(target, features, false);
         String fshContent = getAnimationFragmentShader(target, false);
-        String jsonContent = getAnimationShaderJson(target, false);
+        String jsonContent = modernShaderFormat ? null : getAnimationShaderJson(target, false);
 
         String vshSeeThrough = getAnimationVertexShader(target, features, true);
         String fshSeeThrough = getAnimationFragmentShader(target, true);
-        String jsonSeeThrough = getAnimationShaderJson(target, true);
+        String jsonSeeThrough = modernShaderFormat ? null : getAnimationShaderJson(target, true);
 
         String vshIntensity = getAnimationVertexShader(target, features, false);
         String fshIntensity = getAnimationFragmentShader(target, false, true);
-        String jsonIntensity = getAnimationShaderJson(target, "rendertype_text_intensity", false);
+        String jsonIntensity = modernShaderFormat ? null : getAnimationShaderJson(target, "rendertype_text_intensity", false);
 
         String vshIntensitySeeThrough = getAnimationVertexShader(target, features, true);
         String fshIntensitySeeThrough = getAnimationFragmentShader(target, true, true);
-        String jsonIntensitySeeThrough = getAnimationShaderJson(target, "rendertype_text_intensity_see_through", true);
+        String jsonIntensitySeeThrough = modernShaderFormat ? null
+                : getAnimationShaderJson(target, "rendertype_text_intensity_see_through", true);
 
         String shaderPath = pathPrefix + "assets/minecraft/shaders/core";
 
         // Write shaders for both rendertype_text and rendertype_text_see_through
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text.vsh", vshContent);
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text.fsh", fshContent);
-        ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text.json", jsonContent);
+        if (jsonContent != null)
+            ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text.json", jsonContent);
 
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_see_through.vsh", vshSeeThrough);
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_see_through.fsh", fshSeeThrough);
-        ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_see_through.json", jsonSeeThrough);
+        if (jsonSeeThrough != null)
+            ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_see_through.json", jsonSeeThrough);
 
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity.vsh", vshIntensity);
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity.fsh", fshIntensity);
-        ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity.json", jsonIntensity);
+        if (jsonIntensity != null)
+            ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity.json", jsonIntensity);
 
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity_see_through.vsh", vshIntensitySeeThrough);
         ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity_see_through.fsh", fshIntensitySeeThrough);
-        ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity_see_through.json", jsonIntensitySeeThrough);
+        if (jsonIntensitySeeThrough != null)
+            ResourcePack.writeStringToVirtual(shaderPath, "rendertype_text_intensity_see_through.json", jsonIntensitySeeThrough);
 
         Logs.logSuccess("Generated text shaders for " + target.displayName()
                 + " (shader " + getShaderVersion(target) + ")" + (pathPrefix.isEmpty() ? "" : " [overlay]"));
@@ -546,6 +553,7 @@ class TextShaderGenerator {
                 #moj_import <minecraft:fog.glsl>
                 #moj_import <minecraft:dynamictransforms.glsl>
                 #moj_import <minecraft:projection.glsl>
+                #moj_import <minecraft:sample_lightmap.glsl>
                 #moj_import <minecraft:globals.glsl>
 
                 in vec3 Position;
@@ -631,8 +639,8 @@ class TextShaderGenerator {
                 return new VertexShaderConfig(
                         "sphericalVertexDistance = fog_spherical_distance(pos);\n                        cylindricalVertexDistance = fog_cylindrical_distance(pos);",
                         "sphericalVertexDistance = fog_spherical_distance(pos);\n                            cylindricalVertexDistance = fog_cylindrical_distance(pos);",
-                        "Color * texelFetch(Sampler2, UV2 / 16, 0)",
-                        "vec4(1.0, 1.0, 1.0, visible) * texelFetch(Sampler2, UV2 / 16, 0)",
+                        "Color * sample_lightmap(Sampler2, UV2)",
+                        "vec4(1.0, 1.0, 1.0, visible) * sample_lightmap(Sampler2, UV2)",
                         "(rawFrame % totalFrames)"
                 );
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -124,13 +124,13 @@ class TextShaderGenerator {
                         : resolveTextShaderFeatures(hasAnimatedGlyphs);
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh",
                         getCombinedVertexShader(target, features));
-                if (!target.isAtLeast("26.1"))
+                if (!target.isAtLeast("26"))
                     ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json",
                             getCombinedShaderJson(target));
                 Logs.logInfo("Using combined text + scoreboard hiding shaders");
             } else {
                 TextShaderTarget target = TextShaderTarget.current();
-                if (!target.isAtLeast("26.1"))
+                if (!target.isAtLeast("26"))
                     ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh", getScoreboardVsh());
             }
@@ -213,7 +213,7 @@ class TextShaderGenerator {
     private void generateTextShadersForTarget(TextShaderTarget target, TextShaderFeatures features, String pathPrefix) {
         // 1.21.x still expects explicit shader json files in packs.
         // 26.x moved to generated pipeline metadata and should not be overridden.
-        boolean shouldWriteJson = !target.isAtLeast("26.1");
+        boolean shouldWriteJson = !target.isAtLeast("26");
 
         // Generate shaders (see-through uses a different vertex format on 1.21.6+)
         String vshContent = getAnimationVertexShader(target, features, false);
@@ -524,7 +524,7 @@ class TextShaderGenerator {
 
     private String getAnimationVertexShader(TextShaderTarget target, TextShaderFeatures features, boolean seeThrough) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
-        boolean is26Plus = target.isAtLeast("26.1");
+        boolean is26Plus = target.isAtLeast("26");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
@@ -931,7 +931,7 @@ class TextShaderGenerator {
 
     private String getCombinedVertexShader(TextShaderTarget target, TextShaderFeatures features) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
-        boolean is26Plus = target.isAtLeast("26.1");
+        boolean is26Plus = target.isAtLeast("26");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -124,12 +124,14 @@ class TextShaderGenerator {
                         : resolveTextShaderFeatures(hasAnimatedGlyphs);
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh",
                         getCombinedVertexShader(target, features));
-                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json",
-                        getCombinedShaderJson(target));
-                // Fragment shader stays the same (text shader uses vertex shader for scoreboard hiding)
+                if (!target.isAtLeast("26.1"))
+                    ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json",
+                            getCombinedShaderJson(target));
                 Logs.logInfo("Using combined text + scoreboard hiding shaders");
             } else {
-                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
+                TextShaderTarget target = TextShaderTarget.current();
+                if (!target.isAtLeast("26.1"))
+                    ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh", getScoreboardVsh());
             }
         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -209,8 +209,9 @@ class TextShaderGenerator {
     }
 
     private void generateTextShadersForTarget(TextShaderTarget target, TextShaderFeatures features, String pathPrefix) {
-        boolean modernShaderFormat = target.isAtLeast("1.21.6");
-        boolean shouldWriteJson = !modernShaderFormat;
+        // 1.21.x still expects explicit shader json files in packs.
+        // 26.x moved to generated pipeline metadata and should not be overridden.
+        boolean shouldWriteJson = !target.isAtLeast("26.1");
 
         // Generate shaders (see-through uses a different vertex format on 1.21.6+)
         String vshContent = getAnimationVertexShader(target, features, false);
@@ -521,12 +522,13 @@ class TextShaderGenerator {
 
     private String getAnimationVertexShader(TextShaderTarget target, TextShaderFeatures features, boolean seeThrough) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
+        boolean is26Plus = target.isAtLeast("26.1");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
         String vertexEffects = snippets.vertexEffects();
 
-        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, seeThrough);
+        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is26Plus, seeThrough);
         String mainBody = getVertexShaderMainBody(config, vertexEffects, false);
 
         if (is1_21_6Plus) {
@@ -547,7 +549,7 @@ class TextShaderGenerator {
                 %s
                 %s
 
-""" : """
+""" : (is26Plus ? """
                 #version 330
 
                 #moj_import <minecraft:fog.glsl>
@@ -571,7 +573,30 @@ class TextShaderGenerator {
                 %s
                 %s
 
-""";
+""" : """
+                #version 330
+
+                #moj_import <minecraft:fog.glsl>
+                #moj_import <minecraft:dynamictransforms.glsl>
+                #moj_import <minecraft:projection.glsl>
+                #moj_import <minecraft:globals.glsl>
+
+                in vec3 Position;
+                in vec4 Color;
+                in vec2 UV0;
+                in ivec2 UV2;
+
+                uniform sampler2D Sampler2;
+
+                out float sphericalVertexDistance;
+                out float cylindricalVertexDistance;
+                out vec4 vertexColor;
+                out vec2 texCoord0;
+                out vec4 effectData;
+                %s
+                %s
+
+""");
             return header.formatted(textShaderConstants, vertexPrelude) + mainBody;
         } else {
             // Pre-1.21.6: use traditional uniform declarations
@@ -625,7 +650,7 @@ class TextShaderGenerator {
         }
     }
 
-    private VertexShaderConfig createVertexShaderConfig(boolean is1_21_6Plus, boolean seeThrough) {
+    private VertexShaderConfig createVertexShaderConfig(boolean is1_21_6Plus, boolean is26Plus, boolean seeThrough) {
         if (is1_21_6Plus) {
             if (seeThrough) {
                 return new VertexShaderConfig(
@@ -636,11 +661,17 @@ class TextShaderGenerator {
                         "(rawFrame % totalFrames)"
                 );
             } else {
+                String litColor = is26Plus
+                        ? "Color * sample_lightmap(Sampler2, UV2)"
+                        : "Color * texelFetch(Sampler2, UV2 / 16, 0)";
+                String animatedLitColor = is26Plus
+                        ? "vec4(1.0, 1.0, 1.0, visible) * sample_lightmap(Sampler2, UV2)"
+                        : "vec4(1.0, 1.0, 1.0, visible) * texelFetch(Sampler2, UV2 / 16, 0)";
                 return new VertexShaderConfig(
                         "sphericalVertexDistance = fog_spherical_distance(pos);\n                        cylindricalVertexDistance = fog_cylindrical_distance(pos);",
                         "sphericalVertexDistance = fog_spherical_distance(pos);\n                            cylindricalVertexDistance = fog_cylindrical_distance(pos);",
-                        "Color * sample_lightmap(Sampler2, UV2)",
-                        "vec4(1.0, 1.0, 1.0, visible) * sample_lightmap(Sampler2, UV2)",
+                        litColor,
+                        animatedLitColor,
                         "(rawFrame % totalFrames)"
                 );
             }
@@ -898,17 +929,43 @@ class TextShaderGenerator {
 
     private String getCombinedVertexShader(TextShaderTarget target, TextShaderFeatures features) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
+        boolean is26Plus = target.isAtLeast("26.1");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
         String vertexEffects = snippets.vertexEffects();
 
         // Combined shader always uses non-seeThrough config (has Sampler2, fog) with scoreboard hiding
-        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, false);
+        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is26Plus, false);
         String mainBody = getVertexShaderMainBody(config, vertexEffects, true);
 
         if (is1_21_6Plus) {
-            String header = """
+            String header = is26Plus ? """
+                #version 330
+
+                #moj_import <minecraft:fog.glsl>
+                #moj_import <minecraft:dynamictransforms.glsl>
+                #moj_import <minecraft:projection.glsl>
+                #moj_import <minecraft:sample_lightmap.glsl>
+                #moj_import <minecraft:globals.glsl>
+
+                in vec3 Position;
+                in vec4 Color;
+                in vec2 UV0;
+                in ivec2 UV2;
+
+                uniform sampler2D Sampler2;
+                uniform vec2 ScreenSize;
+
+                out float sphericalVertexDistance;
+                out float cylindricalVertexDistance;
+                out vec4 vertexColor;
+                out vec2 texCoord0;
+                out vec4 effectData;
+                %s
+                %s
+
+""" : """
                 #version 330
 
                 #moj_import <minecraft:fog.glsl>

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -261,7 +261,6 @@ class TextShaderGenerator {
 
     private String getShaderVersion(TextShaderTarget target) {
         if (target.isAtLeast("26")) return "26";
-        if (target.isAtLeast("1.21.9")) return "1.21.9";
         if (target.isAtLeast("1.21.6")) return "1.21.6";
         if (target.isAtLeast("1.21.4")) return "1.21.4";
         if (target.isAtLeast("1.21")) return "1.21";
@@ -521,14 +520,13 @@ class TextShaderGenerator {
 
     private String getAnimationVertexShader(TextShaderTarget target, TextShaderFeatures features, boolean seeThrough) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
-        boolean is1_21_9Plus = target.isAtLeast("1.21.9");
         boolean is26Plus = target.isAtLeast("26");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
         String vertexEffects = snippets.vertexEffects();
 
-        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is1_21_9Plus, seeThrough);
+        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is26Plus, seeThrough);
         String mainBody = getVertexShaderMainBody(config, vertexEffects, false);
 
         if (is1_21_6Plus) {
@@ -549,7 +547,7 @@ class TextShaderGenerator {
                 %s
                 %s
 
-""" : (is1_21_9Plus ? """
+""" : (is26Plus ? """
                 #version 330
 
                 #moj_import <minecraft:fog.glsl>
@@ -650,12 +648,12 @@ class TextShaderGenerator {
         }
     }
 
-    private VertexShaderConfig createVertexShaderConfig(boolean is1_21_6Plus, boolean is1_21_9Plus, boolean seeThrough) {
+    private VertexShaderConfig createVertexShaderConfig(boolean is1_21_6Plus, boolean is26Plus, boolean seeThrough) {
         if (is1_21_6Plus) {
-            String litColor = is1_21_9Plus
+            String litColor = is26Plus
                     ? "Color * sample_lightmap(Sampler2, UV2)"
                     : "Color * texelFetch(Sampler2, UV2 / 16, 0)";
-            String animatedLitColor = is1_21_9Plus
+            String animatedLitColor = is26Plus
                     ? "vec4(1.0, 1.0, 1.0, visible) * sample_lightmap(Sampler2, UV2)"
                     : "vec4(1.0, 1.0, 1.0, visible) * texelFetch(Sampler2, UV2 / 16, 0)";
             if (seeThrough) {
@@ -929,17 +927,17 @@ class TextShaderGenerator {
 
     private String getCombinedVertexShader(TextShaderTarget target, TextShaderFeatures features) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
-        boolean is1_21_9Plus = target.isAtLeast("1.21.9");
+        boolean is26Plus = target.isAtLeast("26");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
         String vertexEffects = snippets.vertexEffects();
 
-        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is1_21_9Plus, false);
+        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is26Plus, false);
         String mainBody = getVertexShaderMainBody(config, vertexEffects, true);
 
         if (is1_21_6Plus) {
-            String header = is1_21_9Plus ? """
+            String header = is26Plus ? """
                 #version 330
 
                 #moj_import <minecraft:fog.glsl>

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -7,6 +7,7 @@ import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -46,11 +47,7 @@ class TextShaderGenerator {
     private TextShaderFeatures textShaderFeatures = null;
     private TextEffectSnippets textEffectSnippets = null;
     private TextShaderTarget textEffectSnippetsTarget = null;
-
-    /** Directory name for 1.21.6+ shader overlay */
-    private static final String OVERLAY_1_21_6_PLUS = "overlay_1_21_6_plus";
-    /** Directory name for 1.21.4/1.21.5 shader overlay */
-    private static final String OVERLAY_1_21_4_5 = "overlay_1_21_4_5";
+    private final List<ShaderOverlay> generatedOverlays = new ArrayList<>();
 
     // Common uniform definitions for shader JSON
     private static final String UNIFORM_MATRIX = """
@@ -75,6 +72,7 @@ class TextShaderGenerator {
         textShaderFeatures = null;
         textEffectSnippets = null;
         textEffectSnippetsTarget = null;
+        generatedOverlays.clear();
     }
 
     boolean wereTextShadersGenerated() {
@@ -90,11 +88,15 @@ class TextShaderGenerator {
     }
 
     String getOverlay1216PlusName() {
-        return OVERLAY_1_21_6_PLUS;
+        return ShaderOverlay.V1_21_6.directory();
     }
 
     String getOverlay12145Name() {
-        return OVERLAY_1_21_4_5;
+        return ShaderOverlay.V1_21_4.directory();
+    }
+
+    List<ShaderOverlay> getGeneratedOverlays() {
+        return List.copyOf(generatedOverlays);
     }
 
     void maybeGenerateTextShaders(boolean hasAnimatedGlyphs) {
@@ -188,23 +190,23 @@ class TextShaderGenerator {
     }
 
     private void generateTextShaders(TextShaderTarget target, TextShaderFeatures features) {
-        // Generate base shaders for the current server version
+        ShaderOverlay serverOverlay = ShaderOverlay.forPackFormat(target.packFormat());
+
         generateTextShadersForTarget(target, features, "");
 
-        // Generate overlay shaders for cross-version compatibility
-        // If server is 1.21.4/1.21.5, also generate 1.21.6+ shaders in overlay directory
-        if (target.isAtLeast("1.21.4") && !target.isAtLeast("1.21.6")) {
-            TextShaderTarget overlayTarget = TextShaderTarget.forVersion("1.21.6");
-            generateTextShadersForTarget(overlayTarget, features, OVERLAY_1_21_6_PLUS + "/");
-            shaderOverlaysGenerated = true;
-            Logs.logSuccess("Generated shader overlay for 1.21.6+ clients");
+        if (serverOverlay == null) return;
+
+        for (ShaderOverlay overlay : ShaderOverlay.values()) {
+            if (overlay == serverOverlay) continue;
+            TextShaderTarget overlayTarget = TextShaderTarget.forVersion(overlay.representativeVersion());
+            generateTextShadersForTarget(overlayTarget, features, overlay.directory() + "/");
+            generatedOverlays.add(overlay);
         }
-        // If server is 1.21.6+, also generate 1.21.4/1.21.5 shaders in overlay directory
-        else if (target.isAtLeast("1.21.6")) {
-            TextShaderTarget overlayTarget = TextShaderTarget.forVersion("1.21.4");
-            generateTextShadersForTarget(overlayTarget, features, OVERLAY_1_21_4_5 + "/");
+
+        if (!generatedOverlays.isEmpty()) {
             shaderOverlaysGenerated = true;
-            Logs.logSuccess("Generated shader overlay for 1.21.4/1.21.5 clients");
+            Logs.logSuccess("Generated shader overlays for " + generatedOverlays.size()
+                    + " additional format groups (" + serverOverlay.directory() + " is the base)");
         }
     }
 
@@ -258,15 +260,12 @@ class TextShaderGenerator {
     }
 
     private String getShaderVersion(TextShaderTarget target) {
-        if (target.isAtLeast("1.21.6")) {
-            return "1.21.6";
-        } else if (target.isAtLeast("1.21.4")) {
-            return "1.21.4";
-        } else if (target.isAtLeast("1.21")) {
-            return "1.21";
-        } else {
-            return "1.20";
-        }
+        if (target.isAtLeast("26")) return "26";
+        if (target.isAtLeast("1.21.9")) return "1.21.9";
+        if (target.isAtLeast("1.21.6")) return "1.21.6";
+        if (target.isAtLeast("1.21.4")) return "1.21.4";
+        if (target.isAtLeast("1.21")) return "1.21";
+        return "1.20";
     }
 
     private String getTextShaderConstants(TextShaderTarget target, TextShaderFeatures features) {
@@ -522,13 +521,14 @@ class TextShaderGenerator {
 
     private String getAnimationVertexShader(TextShaderTarget target, TextShaderFeatures features, boolean seeThrough) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
+        boolean is1_21_9Plus = target.isAtLeast("1.21.9");
         boolean is26Plus = target.isAtLeast("26");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
         String vertexEffects = snippets.vertexEffects();
 
-        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is26Plus, seeThrough);
+        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is1_21_9Plus, seeThrough);
         String mainBody = getVertexShaderMainBody(config, vertexEffects, false);
 
         if (is1_21_6Plus) {
@@ -549,7 +549,7 @@ class TextShaderGenerator {
                 %s
                 %s
 
-""" : (is26Plus ? """
+""" : (is1_21_9Plus ? """
                 #version 330
 
                 #moj_import <minecraft:fog.glsl>
@@ -650,8 +650,14 @@ class TextShaderGenerator {
         }
     }
 
-    private VertexShaderConfig createVertexShaderConfig(boolean is1_21_6Plus, boolean is26Plus, boolean seeThrough) {
+    private VertexShaderConfig createVertexShaderConfig(boolean is1_21_6Plus, boolean is1_21_9Plus, boolean seeThrough) {
         if (is1_21_6Plus) {
+            String litColor = is1_21_9Plus
+                    ? "Color * sample_lightmap(Sampler2, UV2)"
+                    : "Color * texelFetch(Sampler2, UV2 / 16, 0)";
+            String animatedLitColor = is1_21_9Plus
+                    ? "vec4(1.0, 1.0, 1.0, visible) * sample_lightmap(Sampler2, UV2)"
+                    : "vec4(1.0, 1.0, 1.0, visible) * texelFetch(Sampler2, UV2 / 16, 0)";
             if (seeThrough) {
                 return new VertexShaderConfig(
                         "",
@@ -661,12 +667,6 @@ class TextShaderGenerator {
                         "(rawFrame % totalFrames)"
                 );
             } else {
-                String litColor = is26Plus
-                        ? "Color * sample_lightmap(Sampler2, UV2)"
-                        : "Color * texelFetch(Sampler2, UV2 / 16, 0)";
-                String animatedLitColor = is26Plus
-                        ? "vec4(1.0, 1.0, 1.0, visible) * sample_lightmap(Sampler2, UV2)"
-                        : "vec4(1.0, 1.0, 1.0, visible) * texelFetch(Sampler2, UV2 / 16, 0)";
                 return new VertexShaderConfig(
                         "sphericalVertexDistance = fog_spherical_distance(pos);\n                        cylindricalVertexDistance = fog_cylindrical_distance(pos);",
                         "sphericalVertexDistance = fog_spherical_distance(pos);\n                            cylindricalVertexDistance = fog_cylindrical_distance(pos);",
@@ -929,18 +929,17 @@ class TextShaderGenerator {
 
     private String getCombinedVertexShader(TextShaderTarget target, TextShaderFeatures features) {
         boolean is1_21_6Plus = target.isAtLeast("1.21.6");
-        boolean is26Plus = target.isAtLeast("26");
+        boolean is1_21_9Plus = target.isAtLeast("1.21.9");
         String textShaderConstants = getTextShaderConstants(target, features);
         TextEffectSnippets snippets = getTextEffectSnippets(target);
         String vertexPrelude = snippets.vertexPrelude();
         String vertexEffects = snippets.vertexEffects();
 
-        // Combined shader always uses non-seeThrough config (has Sampler2, fog) with scoreboard hiding
-        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is26Plus, false);
+        VertexShaderConfig config = createVertexShaderConfig(is1_21_6Plus, is1_21_9Plus, false);
         String mainBody = getVertexShaderMainBody(config, vertexEffects, true);
 
         if (is1_21_6Plus) {
-            String header = is26Plus ? """
+            String header = is1_21_9Plus ? """
                 #version 330
 
                 #moj_import <minecraft:fog.glsl>

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
@@ -11,10 +11,14 @@ import io.th0rgal.oraxen.utils.ResourcePackFormatUtil;
  */
 public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion) {
 
-    /** Pack format for 1.21.4/1.21.5 */
+    /** Pack format for 1.21.4 (format range 46-62 includes 1.21.5) */
     public static final int PACK_FORMAT_1_21_4 = 46;
-    /** Pack format for 1.21.6+ (first version with new shader format) */
-    public static final int PACK_FORMAT_1_21_6 = 55;
+    /** Pack format for 1.21.6 (first version with GLSL 330 + namespaced imports) */
+    public static final int PACK_FORMAT_1_21_6 = 63;
+    /** Pack format for 1.21.9 (first version with sample_lightmap) */
+    public static final int PACK_FORMAT_1_21_9 = 69;
+    /** Pack format for 26.x */
+    public static final int PACK_FORMAT_26 = 84;
 
     public static TextShaderTarget current() {
         return new TextShaderTarget(ResourcePackFormatUtil.getCurrentResourcePackFormat(),
@@ -32,7 +36,8 @@ public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion
     }
 
     private static int getPackFormatForVersion(MinecraftVersion version) {
-        // Map major shader-breaking versions to their pack formats
+        if (version.isAtLeast(new MinecraftVersion("26"))) return PACK_FORMAT_26;
+        if (version.isAtLeast(new MinecraftVersion("1.21.9"))) return PACK_FORMAT_1_21_9;
         if (version.isAtLeast(new MinecraftVersion("1.21.6"))) return PACK_FORMAT_1_21_6;
         if (version.isAtLeast(new MinecraftVersion("1.21.4"))) return PACK_FORMAT_1_21_4;
         if (version.isAtLeast(new MinecraftVersion("1.21.2"))) return 42;
@@ -41,7 +46,7 @@ public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion
         if (version.isAtLeast(new MinecraftVersion("1.20.3"))) return 22;
         if (version.isAtLeast(new MinecraftVersion("1.20.2"))) return 18;
         if (version.isAtLeast(new MinecraftVersion("1.20"))) return 15;
-        return 15; // fallback
+        return 15;
     }
 
     public boolean isAtLeast(String version) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
@@ -13,11 +13,9 @@ public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion
 
     /** Pack format for 1.21.4 (format range 46-62 includes 1.21.5) */
     public static final int PACK_FORMAT_1_21_4 = 46;
-    /** Pack format for 1.21.6 (first version with GLSL 330 + namespaced imports) */
+    /** Pack format for 1.21.6 (format range 63-83; 1.21.6-1.21.11 share the same shader format with texelFetch) */
     public static final int PACK_FORMAT_1_21_6 = 63;
-    /** Pack format for 1.21.9 (first version with sample_lightmap) */
-    public static final int PACK_FORMAT_1_21_9 = 69;
-    /** Pack format for 26.x */
+    /** Pack format for 26.x (first version with sample_lightmap replacing texelFetch) */
     public static final int PACK_FORMAT_26 = 84;
 
     public static TextShaderTarget current() {
@@ -37,7 +35,6 @@ public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion
 
     private static int getPackFormatForVersion(MinecraftVersion version) {
         if (version.isAtLeast(new MinecraftVersion("26"))) return PACK_FORMAT_26;
-        if (version.isAtLeast(new MinecraftVersion("1.21.9"))) return PACK_FORMAT_1_21_9;
         if (version.isAtLeast(new MinecraftVersion("1.21.6"))) return PACK_FORMAT_1_21_6;
         if (version.isAtLeast(new MinecraftVersion("1.21.4"))) return PACK_FORMAT_1_21_4;
         if (version.isAtLeast(new MinecraftVersion("1.21.2"))) return 42;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderTarget.java
@@ -45,7 +45,16 @@ public record TextShaderTarget(int packFormat, MinecraftVersion minecraftVersion
     }
 
     public boolean isAtLeast(String version) {
-        return minecraftVersion.isAtLeast(new MinecraftVersion(version));
+        MinecraftVersion threshold = new MinecraftVersion(version);
+        if (minecraftVersion.isAtLeast(threshold)) return true;
+        // Handle runtimes reporting "1.26.x" instead of "26.x":
+        // normalize by comparing without the legacy "1." prefix.
+        if (threshold.getMajor() >= 26 && minecraftVersion.getMajor() == 1 && minecraftVersion.getMinor() >= 26) {
+            MinecraftVersion normalized = new MinecraftVersion(
+                    minecraftVersion.getMinor(), minecraftVersion.getBuild(), 0);
+            return normalized.isAtLeast(threshold);
+        }
+        return false;
     }
 
     public String displayName() {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ResourcePackFormatUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ResourcePackFormatUtil.java
@@ -14,6 +14,25 @@ import java.lang.reflect.Method;
 public final class ResourcePackFormatUtil {
 
     private static volatile Integer cached;
+    private static final PackFormatThreshold[] PACK_FORMAT_THRESHOLDS = {
+            new PackFormatThreshold("26.1", 84),
+            new PackFormatThreshold("1.21.11", 75),
+            new PackFormatThreshold("1.21.9", 69),
+            new PackFormatThreshold("1.21.7", 64),
+            new PackFormatThreshold("1.21.6", 63),
+            new PackFormatThreshold("1.21.5", 55),
+            new PackFormatThreshold("1.21.4", 46),
+            new PackFormatThreshold("1.21.2", 42),
+            new PackFormatThreshold("1.21", 34),
+            new PackFormatThreshold("1.20.5", 32),
+            new PackFormatThreshold("1.20.3", 22),
+            new PackFormatThreshold("1.20.2", 18),
+            new PackFormatThreshold("1.20", 15),
+            new PackFormatThreshold("1.19.4", 13),
+            new PackFormatThreshold("1.19.3", 12),
+            new PackFormatThreshold("1.19", 9),
+            new PackFormatThreshold("1.18", 8)
+    };
 
     private ResourcePackFormatUtil() {
     }
@@ -42,28 +61,20 @@ public final class ResourcePackFormatUtil {
      * @return Pack format number
      */
     public static int getPackFormatForVersion(MinecraftVersion version) {
-        // Best-effort mapping for modern versions.
-        // NOTE: For modern versions, pack formats vary significantly between patches
-        if (version.isAtLeast(new MinecraftVersion("26.1"))) return 84; // 26.1+
-        if (version.isAtLeast(new MinecraftVersion("1.21.11"))) return 75; // 1.21.11
-        if (version.isAtLeast(new MinecraftVersion("1.21.9"))) return 69; // 1.21.9-1.21.10
-        if (version.isAtLeast(new MinecraftVersion("1.21.7"))) return 64; // 1.21.7-1.21.8
-        if (version.isAtLeast(new MinecraftVersion("1.21.6"))) return 63; // 1.21.6
-        if (version.isAtLeast(new MinecraftVersion("1.21.5"))) return 55; // 1.21.5
-        if (version.isAtLeast(new MinecraftVersion("1.21.4"))) return 46; // 1.21.4
-        if (version.isAtLeast(new MinecraftVersion("1.21.2"))) return 42; // 1.21.2-1.21.3
-        if (version.isAtLeast(new MinecraftVersion("1.21"))) return 34; // 1.21-1.21.1
-        if (version.isAtLeast(new MinecraftVersion("1.20.5"))) return 32;
-        if (version.isAtLeast(new MinecraftVersion("1.20.3"))) return 22;
-        if (version.isAtLeast(new MinecraftVersion("1.20.2"))) return 18;
-        if (version.isAtLeast(new MinecraftVersion("1.20"))) return 15;
-        if (version.isAtLeast(new MinecraftVersion("1.19.4"))) return 13;
-        if (version.isAtLeast(new MinecraftVersion("1.19.3"))) return 12;
-        if (version.isAtLeast(new MinecraftVersion("1.19"))) return 9;
-        if (version.isAtLeast(new MinecraftVersion("1.18"))) return 8;
+        for (PackFormatThreshold threshold : PACK_FORMAT_THRESHOLDS) {
+            if (version.isAtLeast(threshold.minimumVersion)) {
+                return threshold.packFormat;
+            }
+        }
 
         // Very old / unknown
         return 6;
+    }
+
+    private record PackFormatThreshold(MinecraftVersion minimumVersion, int packFormat) {
+        private PackFormatThreshold(String minimumVersion, int packFormat) {
+            this(new MinecraftVersion(minimumVersion), packFormat);
+        }
     }
 
     @Nullable

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ResourcePackFormatUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ResourcePackFormatUtil.java
@@ -43,10 +43,13 @@ public final class ResourcePackFormatUtil {
      */
     public static int getPackFormatForVersion(MinecraftVersion version) {
         // Best-effort mapping for modern versions.
-        // NOTE: For 1.21.x versions, pack formats vary significantly between patches
-        if (version.isAtLeast(new MinecraftVersion("1.21.11"))) return 61; // 1.21.11+
-        if (version.isAtLeast(new MinecraftVersion("1.21.6"))) return 55; // 1.21.6-1.21.10
-        if (version.isAtLeast(new MinecraftVersion("1.21.5"))) return 48; // 1.21.5
+        // NOTE: For modern versions, pack formats vary significantly between patches
+        if (version.isAtLeast(new MinecraftVersion("26.1"))) return 84; // 26.1+
+        if (version.isAtLeast(new MinecraftVersion("1.21.11"))) return 75; // 1.21.11
+        if (version.isAtLeast(new MinecraftVersion("1.21.9"))) return 69; // 1.21.9-1.21.10
+        if (version.isAtLeast(new MinecraftVersion("1.21.7"))) return 64; // 1.21.7-1.21.8
+        if (version.isAtLeast(new MinecraftVersion("1.21.6"))) return 63; // 1.21.6
+        if (version.isAtLeast(new MinecraftVersion("1.21.5"))) return 55; // 1.21.5
         if (version.isAtLeast(new MinecraftVersion("1.21.4"))) return 46; // 1.21.4
         if (version.isAtLeast(new MinecraftVersion("1.21.2"))) return 42; // 1.21.2-1.21.3
         if (version.isAtLeast(new MinecraftVersion("1.21"))) return 34; // 1.21-1.21.1
@@ -141,4 +144,3 @@ public final class ResourcePackFormatUtil {
         return (result instanceof Integer) ? (Integer) result : ((Number) result).intValue();
     }
 }
-

--- a/core/src/main/java/io/th0rgal/oraxen/utils/ResourcePackFormatUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/ResourcePackFormatUtil.java
@@ -16,6 +16,7 @@ public final class ResourcePackFormatUtil {
     private static volatile Integer cached;
     private static final PackFormatThreshold[] PACK_FORMAT_THRESHOLDS = {
             new PackFormatThreshold("26.1", 84),
+            new PackFormatThreshold("1.26.1", 84),
             new PackFormatThreshold("1.21.11", 75),
             new PackFormatThreshold("1.21.9", 69),
             new PackFormatThreshold("1.21.7", 64),

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -76,7 +76,12 @@ public class VersionUtil {
         spigotVariants.put(NMSVersion.v1_20_R4, NMSVersion.v1_20_R4_spigot);
 
         versionMap.put(NMSVersion.v1_26_R1,
-                Map.of(27, new MinecraftVersion("26.1"), 28, new MinecraftVersion("26.1.1")));
+                Map.of(
+                        27, new MinecraftVersion("26.1"),
+                        28, new MinecraftVersion("26.1.1"),
+                        // Defensive aliases for non-standard "1.26.x" reporting in forks/wrappers
+                        29, new MinecraftVersion("1.26.1"),
+                        30, new MinecraftVersion("1.26.1.1")));
         versionMap.put(NMSVersion.v1_21_R6,
                 Map.of(26, new MinecraftVersion("1.21.11")));
         versionMap.put(NMSVersion.v1_21_R6_old,

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -44,6 +44,12 @@ public class VersionUtil {
             if (version == UNKNOWN) return false;
             NMSVersion serverVersion = getNMSVersion(MinecraftVersion.getCurrentVersion());
 
+            // 26.x currently only has a Paper (Mojang-mapped) handler module.
+            // Prevent loading it on Spigot-mapped runtimes.
+            if (!isPaperServer() && serverVersion == v1_26_R1) {
+                return false;
+            }
+
             // For 1.20.5+ (v1_20_R4 and later), choose between Paper and Spigot variants
             NMSVersion spigotVariant = spigotVariants.get(serverVersion);
             if (spigotVariant != null) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/VersionUtil.java
@@ -13,6 +13,7 @@ public class VersionUtil {
 
     public enum NMSVersion {
         // Paper 1.20.5+ uses Mojang mappings at runtime, Spigot uses Spigot mappings
+        v1_26_R1,              // Paper 26.1-26.1.1 (Mojang-mapped)
         v1_21_R6,              // Paper 1.21.11 (Mojang-mapped)
         v1_21_R6_spigot,       // Spigot 1.21.11 (Spigot-mapped)
         v1_21_R6_old,          // Paper 1.21.9-1.21.10 (Mojang-mapped)
@@ -68,6 +69,8 @@ public class VersionUtil {
         spigotVariants.put(NMSVersion.v1_21_R1, NMSVersion.v1_21_R1_spigot);
         spigotVariants.put(NMSVersion.v1_20_R4, NMSVersion.v1_20_R4_spigot);
 
+        versionMap.put(NMSVersion.v1_26_R1,
+                Map.of(27, new MinecraftVersion("26.1"), 28, new MinecraftVersion("26.1.1")));
         versionMap.put(NMSVersion.v1_21_R6,
                 Map.of(26, new MinecraftVersion("1.21.11")));
         versionMap.put(NMSVersion.v1_21_R6_old,

--- a/core/src/test/java/io/th0rgal/oraxen/pack/dispatch/PlayerVersionDetectorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/dispatch/PlayerVersionDetectorTest.java
@@ -8,11 +8,11 @@ class PlayerVersionDetectorTest {
 
     @Test
     void testProtocolToVersionString_1_21_4_andLater() {
+        assertEquals("26.1.1", PlayerVersionDetector.protocolToVersionString(775));
+        assertEquals("26.1.1+", PlayerVersionDetector.protocolToVersionString(800));
         assertEquals("1.21.4", PlayerVersionDetector.protocolToVersionString(769));
         assertEquals("1.21.5", PlayerVersionDetector.protocolToVersionString(770));
         assertEquals("1.21.11", PlayerVersionDetector.protocolToVersionString(774));
-        assertEquals("1.21.11+", PlayerVersionDetector.protocolToVersionString(775));
-        assertEquals("1.21.11+", PlayerVersionDetector.protocolToVersionString(800));
     }
 
     @Test

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtilsTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtilsTest.java
@@ -98,7 +98,7 @@ class PackMcmetaUtilsTest {
         assertNotNull(highest);
         assertEquals(999, highest.getMaxFormatInclusive(),
             "Highest pack version should have max_inclusive 999");
-        assertEquals("1.21.9", highest.getMinecraftVersion());
+        assertEquals("26.1", highest.getMinecraftVersion());
     }
 
     @Test
@@ -156,10 +156,22 @@ class PackMcmetaUtilsTest {
         assertEquals(55, v1215.getMinFormatInclusive());
         assertEquals(62, v1215.getMaxFormatInclusive());
 
-        // 1.21.9: format 69, range [69, 999]
+        // 1.21.9: format 69, range [69, 74]
         PackVersion v1219 = manager.getVersion("1.21.9");
         assertNotNull(v1219);
         assertEquals(69, v1219.getMinFormatInclusive());
-        assertEquals(999, v1219.getMaxFormatInclusive());
+        assertEquals(74, v1219.getMaxFormatInclusive());
+
+        // 1.21.11: format 75, range [75, 83]
+        PackVersion v12111 = manager.getVersion("1.21.11");
+        assertNotNull(v12111);
+        assertEquals(75, v12111.getMinFormatInclusive());
+        assertEquals(83, v12111.getMaxFormatInclusive());
+
+        // 26.1: format 84, range [84, 999]
+        PackVersion v261 = manager.getVersion("26.1");
+        assertNotNull(v261);
+        assertEquals(84, v261.getMinFormatInclusive());
+        assertEquals(999, v261.getMaxFormatInclusive());
     }
 }

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtilsTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtilsTest.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.pack.generation;
 
+import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -173,5 +174,29 @@ class PackMcmetaUtilsTest {
         assertNotNull(v261);
         assertEquals(84, v261.getMinFormatInclusive());
         assertEquals(999, v261.getMaxFormatInclusive());
+    }
+
+    @Test
+    void testPackFormat65PlusUsesMinAndMaxFormat() {
+        JsonObject mcmeta = PackMcmetaUtils.createPackMcmeta(75, 0, 0, null);
+        JsonObject pack = mcmeta.getAsJsonObject("pack");
+
+        assertEquals(75, pack.get("pack_format").getAsInt());
+        assertEquals(75, pack.get("min_format").getAsInt());
+        assertEquals(75, pack.get("max_format").getAsInt());
+        assertFalse(pack.has("supported_formats"));
+    }
+
+    @Test
+    void testPackFormat18To64UsesSupportedFormatsArray() {
+        JsonObject mcmeta = PackMcmetaUtils.createPackMcmeta(50, 50, 64, null);
+        JsonObject pack = mcmeta.getAsJsonObject("pack");
+
+        assertEquals(50, pack.get("pack_format").getAsInt());
+        assertTrue(pack.has("supported_formats"));
+        assertEquals(50, pack.getAsJsonArray("supported_formats").get(0).getAsInt());
+        assertEquals(64, pack.getAsJsonArray("supported_formats").get(1).getAsInt());
+        assertFalse(pack.has("min_format"));
+        assertFalse(pack.has("max_format"));
     }
 }

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtilsTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtilsTest.java
@@ -188,14 +188,15 @@ class PackMcmetaUtilsTest {
     }
 
     @Test
-    void testPackFormat18To64UsesSupportedFormatsArray() {
+    void testPackFormat18To64UsesSupportedFormatsObject() {
         JsonObject mcmeta = PackMcmetaUtils.createPackMcmeta(50, 50, 64, null);
         JsonObject pack = mcmeta.getAsJsonObject("pack");
 
         assertEquals(50, pack.get("pack_format").getAsInt());
         assertTrue(pack.has("supported_formats"));
-        assertEquals(50, pack.getAsJsonArray("supported_formats").get(0).getAsInt());
-        assertEquals(64, pack.getAsJsonArray("supported_formats").get(1).getAsInt());
+        JsonObject supportedFormats = pack.getAsJsonObject("supported_formats");
+        assertEquals(50, supportedFormats.get("min_inclusive").getAsInt());
+        assertEquals(64, supportedFormats.get("max_inclusive").getAsInt());
         assertFalse(pack.has("min_format"));
         assertFalse(pack.has("max_format"));
     }

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackVersionManagerTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackVersionManagerTest.java
@@ -61,7 +61,7 @@ class PackVersionManagerTest {
         assertNotNull(version);
         assertEquals(55, version.getPackFormat());
 
-        // Unknown high format should match 1.21.9 pack (open-ended)
+        // Unknown high format should match latest pack (open-ended)
         version = manager.findBestVersionForFormat(999);
         assertNotNull(version); // Should return highest format pack
     }
@@ -166,8 +166,8 @@ class PackVersionManagerTest {
             .orElse(null);
 
         assertNotNull(highest);
-        assertEquals(69, highest.getPackFormat(), "max() should return highest pack format (69 for 1.21.9)");
-        assertEquals("1.21.9", highest.getMinecraftVersion());
+        assertEquals(84, highest.getPackFormat(), "max() should return highest pack format (84 for 26.1)");
+        assertEquals("26.1", highest.getMinecraftVersion());
     }
 
     @Test

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackVersionTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackVersionTest.java
@@ -121,7 +121,9 @@ class PackVersionTest {
     void testProtocolToPackFormatMappings() {
         File packFile = tempDir.resolve("pack.zip").toFile();
 
-        PackVersion v1_21_5 = new PackVersion("1.21.5", 48, 48, 999, packFile);
+        PackVersion v26_1 = new PackVersion("26.1", 84, 84, 999, packFile);
+        PackVersion v1_21_11 = new PackVersion("1.21.11", 75, 75, 83, packFile);
+        PackVersion v1_21_5 = new PackVersion("1.21.5", 55, 55, 62, packFile);
         PackVersion v1_21_4 = new PackVersion("1.21.4", 46, 46, 47, packFile);
         PackVersion v1_21_2 = new PackVersion("1.21.2", 42, 42, 45, packFile);
         PackVersion v1_21 = new PackVersion("1.21", 34, 34, 41, packFile);
@@ -130,11 +132,14 @@ class PackVersionTest {
         PackVersion v1_20_2 = new PackVersion("1.20.2", 18, 18, 21, packFile);
         PackVersion v1_20 = new PackVersion("1.20", 15, 15, 17, packFile);
 
-        // Protocol 774 (1.21.11) should map to format 61, which is supported by v1_21_5 (range 48-999)
-        assertTrue(v1_21_5.supportsProtocol(774), "Protocol 774 (1.21.11) should match format 61, supported by v1_21_5");
+        // Protocol 775 (26.1.1) should map to format 84.
+        assertTrue(v26_1.supportsProtocol(775), "Protocol 775 (26.1.1) should match format 84");
+
+        // Protocol 774 (1.21.11) should map to format 75.
+        assertTrue(v1_21_11.supportsProtocol(774), "Protocol 774 (1.21.11) should match format 75");
         
-        // Protocol 770 (1.21.5) should map to format 48
-        assertTrue(v1_21_5.supportsProtocol(770), "Protocol 770 (1.21.5) should match format 48");
+        // Protocol 770 (1.21.5) should map to format 55
+        assertTrue(v1_21_5.supportsProtocol(770), "Protocol 770 (1.21.5) should match format 55");
 
         assertTrue(v1_21_4.supportsProtocol(769), "Protocol 769 (1.21.4) should match format 46");
 

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/ProtocolVersionTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/ProtocolVersionTest.java
@@ -10,6 +10,7 @@ class ProtocolVersionTest {
 
     @Test
     void testFromProtocol_ExactMatch() {
+        assertEquals(ProtocolVersion.MC_26_1_1, ProtocolVersion.fromProtocol(775));
         assertEquals(ProtocolVersion.MC_1_21_11, ProtocolVersion.fromProtocol(774));
         assertEquals(ProtocolVersion.MC_1_21_5, ProtocolVersion.fromProtocol(770));
         assertEquals(ProtocolVersion.MC_1_21_4, ProtocolVersion.fromProtocol(769));
@@ -22,13 +23,14 @@ class ProtocolVersionTest {
 
     @Test
     void testFromProtocol_BestMatch() {
+        assertEquals(ProtocolVersion.MC_26_1_1, ProtocolVersion.fromProtocol(775));
+        assertEquals(ProtocolVersion.MC_26_1_1, ProtocolVersion.fromProtocol(776));
+        assertEquals(ProtocolVersion.MC_26_1_1, ProtocolVersion.fromProtocol(800));
         assertEquals(ProtocolVersion.MC_1_21_5, ProtocolVersion.fromProtocol(770));
         assertEquals(ProtocolVersion.MC_1_21_6, ProtocolVersion.fromProtocol(771));
         assertEquals(ProtocolVersion.MC_1_21_7, ProtocolVersion.fromProtocol(772));
         assertEquals(ProtocolVersion.MC_1_21_9, ProtocolVersion.fromProtocol(773));
         assertEquals(ProtocolVersion.MC_1_21_11, ProtocolVersion.fromProtocol(774));
-        assertEquals(ProtocolVersion.MC_1_21_11, ProtocolVersion.fromProtocol(775));
-        assertEquals(ProtocolVersion.MC_1_21_11, ProtocolVersion.fromProtocol(800));
         assertEquals(ProtocolVersion.MC_1_21_4, ProtocolVersion.fromProtocol(769));
         assertEquals(ProtocolVersion.MC_1_21_2, ProtocolVersion.fromProtocol(768));
         assertEquals(ProtocolVersion.MC_1_20_5, ProtocolVersion.fromProtocol(766));
@@ -50,6 +52,7 @@ class ProtocolVersionTest {
 
     @Test
     void testGetPackFormatForProtocol() {
+        assertEquals(84, ProtocolVersion.getPackFormatForProtocol(775));
         assertEquals(75, ProtocolVersion.getPackFormatForProtocol(774));
         assertEquals(55, ProtocolVersion.getPackFormatForProtocol(770));
         assertEquals(63, ProtocolVersion.getPackFormatForProtocol(771));
@@ -74,6 +77,7 @@ class ProtocolVersionTest {
 
     @Test
     void testGetVersionStringForProtocol() {
+        assertEquals("26.1.1", ProtocolVersion.getVersionStringForProtocol(775));
         assertEquals("1.21.11", ProtocolVersion.getVersionStringForProtocol(774));
         assertEquals("1.21.5", ProtocolVersion.getVersionStringForProtocol(770));
         assertEquals("1.21.4", ProtocolVersion.getVersionStringForProtocol(769));
@@ -87,9 +91,8 @@ class ProtocolVersionTest {
 
     @Test
     void testGetVersionStringForProtocol_FutureVersion() {
-        assertEquals("1.21.11+", ProtocolVersion.getVersionStringForProtocol(775));
-        assertEquals("1.21.11+", ProtocolVersion.getVersionStringForProtocol(776));
-        assertEquals("1.21.11+", ProtocolVersion.getVersionStringForProtocol(800));
+        assertEquals("26.1.1+", ProtocolVersion.getVersionStringForProtocol(776));
+        assertEquals("26.1.1+", ProtocolVersion.getVersionStringForProtocol(800));
         assertEquals("1.21.6", ProtocolVersion.getVersionStringForProtocol(771));
         assertEquals("1.21.7", ProtocolVersion.getVersionStringForProtocol(772));
         assertEquals("1.21.9", ProtocolVersion.getVersionStringForProtocol(773));
@@ -106,6 +109,10 @@ class ProtocolVersionTest {
 
     @Test
     void testEnumProperties() {
+        assertEquals(775, ProtocolVersion.MC_26_1_1.getProtocol());
+        assertEquals(84, ProtocolVersion.MC_26_1_1.getPackFormat());
+        assertEquals("26.1.1", ProtocolVersion.MC_26_1_1.getVersionString());
+
         assertEquals(774, ProtocolVersion.MC_1_21_11.getProtocol());
         assertEquals(75, ProtocolVersion.MC_1_21_11.getPackFormat());
         assertEquals("1.21.11", ProtocolVersion.MC_1_21_11.getVersionString());
@@ -125,6 +132,7 @@ class ProtocolVersionTest {
 
     @Test
     void testIsKnown() {
+        assertTrue(ProtocolVersion.MC_26_1_1.isKnown());
         assertTrue(ProtocolVersion.MC_1_21_11.isKnown());
         assertTrue(ProtocolVersion.MC_1_21_5.isKnown());
         assertTrue(ProtocolVersion.MC_1_21_4.isKnown());

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ dependencyResolutionManagement {
 // Core and Paper NMS modules (always included)
 include(
     "core",
+    "v1_26_R1",
     "v1_20_R1",
     "v1_20_R2",
     "v1_20_R3",

--- a/v1_20_R1/build.gradle.kts
+++ b/v1_20_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 dependencies {

--- a/v1_20_R2/build.gradle.kts
+++ b/v1_20_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 dependencies {

--- a/v1_20_R3/build.gradle.kts
+++ b/v1_20_R3/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 dependencies {

--- a/v1_20_R4/build.gradle.kts
+++ b/v1_20_R4/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.20.5+ uses Mojang mappings at runtime, so we ship Mojang-mapped code

--- a/v1_20_R4_spigot/build.gradle.kts
+++ b/v1_20_R4_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.20.6 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R1/build.gradle.kts
+++ b/v1_21_R1/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.20.5+ uses Mojang mappings at runtime, so we ship Mojang-mapped code

--- a/v1_21_R1_spigot/build.gradle.kts
+++ b/v1_21_R1_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.1 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R2/build.gradle.kts
+++ b/v1_21_R2/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.20.5+ uses Mojang mappings at runtime, so we ship Mojang-mapped code

--- a/v1_21_R2_spigot/build.gradle.kts
+++ b/v1_21_R2_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.3 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R3/build.gradle.kts
+++ b/v1_21_R3/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.20.5+ uses Mojang mappings at runtime, so we ship Mojang-mapped code

--- a/v1_21_R3_spigot/build.gradle.kts
+++ b/v1_21_R3_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.4 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R4/build.gradle.kts
+++ b/v1_21_R4/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.20.5+ uses Mojang mappings at runtime, so we ship Mojang-mapped code

--- a/v1_21_R4_spigot/build.gradle.kts
+++ b/v1_21_R4_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.5 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R5/build.gradle.kts
+++ b/v1_21_R5/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.20.5+ uses Mojang mappings at runtime, so we ship Mojang-mapped code

--- a/v1_21_R5_spigot/build.gradle.kts
+++ b/v1_21_R5_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.8 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/PackDispatchListener.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/PackDispatchListener.java
@@ -64,7 +64,10 @@ public final class PackDispatchListener implements Listener {
 
     @EventHandler
     public void onReconfig(@NotNull PlayerConnectionReconfigureEvent event) {
-        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
+        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) {
+            event.getConnection().completeReconfiguration();
+            return;
+        }
         CompletableFuture<Void> future = sendResourcePack(event.getConnection(), true);
         if (future == null) {
             event.getConnection().completeReconfiguration();

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/PackDispatchListener.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/PackDispatchListener.java
@@ -65,7 +65,10 @@ public final class PackDispatchListener implements Listener {
     @EventHandler
     public void onReconfig(@NotNull PlayerConnectionReconfigureEvent event) {
         if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
-        sendResourcePack(event.getConnection(), true);
+        CompletableFuture<Void> future = sendResourcePack(event.getConnection(), true);
+        if (future == null) {
+            event.getConnection().completeReconfiguration();
+        }
     }
 
     @EventHandler
@@ -83,10 +86,11 @@ public final class PackDispatchListener implements Listener {
         String hash = OraxenPlugin.get().getPackSHA1();
         if (packUrl == null || hash == null) return null;
         UUID playerId = connection.getProfile().getId();
+        if (playerId == null) return null;
 
         byte[] hashBytes = hashArray(hash);
         UUID packUUID = UUID.nameUUIDFromBytes(hashBytes);
-        CompletableFuture<Void> future = reconfigure ? null : new CompletableFuture<>();
+        CompletableFuture<Void> future = new CompletableFuture<>();
 
         ResourcePackInfo info = ResourcePackInfo.resourcePackInfo()
                 .id(packUUID)
@@ -102,8 +106,8 @@ public final class PackDispatchListener implements Listener {
                 .callback((requestId, status, audience) -> {
                     PackReceiver.handleAdventureStatus(playerId, status);
                     if (!status.intermediate()) {
-                        if (future != null) future.complete(null);
-                        else connection.completeReconfiguration();
+                        future.complete(null);
+                        if (reconfigure) connection.completeReconfiguration();
                     }
                 })
                 .build();

--- a/v1_21_R6_old/build.gradle.kts
+++ b/v1_21_R6_old/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Paper 1.21.10 dev bundle for v1_21_R6_old NMS module

--- a/v1_21_R6_old_spigot/build.gradle.kts
+++ b/v1_21_R6_old_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.10 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_21_R6_spigot/build.gradle.kts
+++ b/v1_21_R6_spigot/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("io.github.goooler.shadow") version "8.1.8"
+    id("com.gradleup.shadow") version "9.4.1"
 }
 
 // Spigot 1.21.11 NMS module - uses Spigot mappings (obfuscated)

--- a/v1_26_R1/build.gradle.kts
+++ b/v1_26_R1/build.gradle.kts
@@ -4,13 +4,12 @@ plugins {
     id("com.gradleup.shadow") version "9.4.1"
 }
 
-// Paper 1.21.11 dev bundle for v1_21_R6 NMS module
-// Note: 1.21.11 uses Identifier instead of ResourceLocation (handled by ResourceLocationHelper)
-// Note: 1.21.11 dev bundle doesn't provide reobf mappings, so we ship Mojang-mapped
+// Paper 26.1.1 dev bundle for v1_26_R1 NMS module
+// Note: modern Paper dev bundles don't provide reobf mappings, so we ship Mojang-mapped
 
 dependencies {
     compileOnly(project(":core"))
-    paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("26.1.1.build.29-alpha")
 }
 
 tasks {
@@ -18,8 +17,8 @@ tasks {
         options.encoding = Charsets.UTF_8.name()
     }
 
-    // Disable reobfJar - 1.21.11 dev bundle doesn't provide reobf mappings
-    // and Paper 1.21.11 runs with Mojang mappings anyway
+    // Disable reobfJar - modern dev bundles don't provide reobf mappings
+    // and Paper runs with Mojang mappings anyway
     matching { it.name == "reobfJar" }.configureEach {
         enabled = false
     }
@@ -33,7 +32,5 @@ configurations.named("reobf") {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
 }
-
-

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphHandler.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphHandler.java
@@ -101,9 +101,15 @@ public class GlyphHandler implements io.th0rgal.oraxen.nms.GlyphHandler {
                 .filter(f -> Object2IntMap.class.isAssignableFrom(f.getType())).findFirst().orElseThrow();
         Field getById = Arrays.stream(IdDispatchCodec.class.getDeclaredFields())
                 .filter(f -> List.class.isAssignableFrom(f.getType())).findFirst().orElseThrow();
-        Class<?> entryClass = IdDispatchCodec.class.getDeclaredClasses()[0];
-        Field getCodec = entryClass.getDeclaredFields()[0];
-        Field getType = entryClass.getDeclaredFields()[1];
+        Class<?> entryClass = Arrays.stream(IdDispatchCodec.class.getDeclaredClasses())
+                .filter(c -> !c.isInterface() && !c.isEnum())
+                .findFirst().orElseThrow(() -> new IllegalStateException("No inner class found in IdDispatchCodec"));
+        Field getCodec = Arrays.stream(entryClass.getDeclaredFields())
+                .filter(f -> StreamCodec.class.isAssignableFrom(f.getType()))
+                .findFirst().orElseThrow(() -> new IllegalStateException("No StreamCodec field in " + entryClass.getName()));
+        Field getType = Arrays.stream(entryClass.getDeclaredFields())
+                .filter(f -> !StreamCodec.class.isAssignableFrom(f.getType()))
+                .findFirst().orElseThrow(() -> new IllegalStateException("No type field in " + entryClass.getName()));
 
         getToId.setAccessible(true);
         getById.setAccessible(true);

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphHandler.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphHandler.java
@@ -515,34 +515,35 @@ public class GlyphHandler implements io.th0rgal.oraxen.nms.GlyphHandler {
 
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws IOException {
-            final ByteBuf bufferCopy = buffer.copy();
-            try {
-                if (buffer.readableBytes() == 0)
-                    return;
+            if (buffer.readableBytes() == 0)
+                return;
 
-                CustomDataSerializer dataSerializer = new CustomDataSerializer(player, buffer);
-                int packetID = dataSerializer.readVarInt();
-                Attribute<ConnectionCodec> attribute = ctx.channel().attr(CODEC_ATTRIBUTE_KEY);
-                ConnectionCodec codec = attribute.get();
-                if (codec == null) {
-                    throw new IOException("Missing codec mapping for channel " + ctx.channel());
-                }
-                Packet<?> packet = codec.codec.decode(dataSerializer);
+            int savedReaderIndex = buffer.readerIndex();
+            CustomDataSerializer dataSerializer = new CustomDataSerializer(player, buffer);
+            int packetID = dataSerializer.readVarInt();
+            Attribute<ConnectionCodec> attribute = ctx.channel().attr(CODEC_ATTRIBUTE_KEY);
+            ConnectionCodec codec = attribute.get();
+            if (codec == null) {
+                throw new IOException("Missing codec mapping for channel " + ctx.channel());
+            }
+            Packet<?> packet = codec.codec.decode(dataSerializer);
 
-                if (dataSerializer.readableBytes() > 0) {
-                    throw new IOException("Packet " + packetID + " " + packet + " was larger than expected, found "
-                            + dataSerializer.readableBytes() + " bytes extra whilst reading the packet " + packetID);
-                } else if (packet instanceof ServerboundChatPacket) {
+            if (dataSerializer.readableBytes() > 0) {
+                throw new IOException("Packet " + packetID + " " + packet + " was larger than expected, found "
+                        + dataSerializer.readableBytes() + " bytes extra whilst reading the packet " + packetID);
+            } else if (packet instanceof ServerboundChatPacket) {
+                ByteBuf bufferCopy = buffer.copy(savedReaderIndex, buffer.readerIndex() - savedReaderIndex);
+                try {
                     FriendlyByteBuf baseSerializer = new FriendlyByteBuf(bufferCopy);
                     baseSerializer.readVarInt();
                     packet = codec.codec.decode(baseSerializer);
+                } finally {
+                    bufferCopy.release();
                 }
-
-                out.add(packet);
-                swapProtocolIfNeeded(attribute, packet);
-            } finally {
-                bufferCopy.release();
             }
+
+            out.add(packet);
+            swapProtocolIfNeeded(attribute, packet);
         }
     }
 }

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphHandler.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphHandler.java
@@ -1,0 +1,542 @@
+package io.th0rgal.oraxen.nms.v1_26_R1;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.*;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.nms.GlyphHandlers;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.kyori.adventure.text.Component;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.*;
+import net.minecraft.network.codec.IdDispatchCodec;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.PacketType;
+import net.minecraft.network.protocol.configuration.ConfigurationPacketTypes;
+import net.minecraft.network.protocol.configuration.ConfigurationProtocols;
+import net.minecraft.network.protocol.game.GamePacketTypes;
+import net.minecraft.network.protocol.game.GameProtocols;
+import net.minecraft.network.protocol.game.ServerboundChatPacket;
+import net.minecraft.network.protocol.handshake.HandshakeProtocols;
+import net.minecraft.network.protocol.login.LoginPacketTypes;
+import net.minecraft.network.protocol.login.LoginProtocols;
+import net.minecraft.network.protocol.status.StatusPacketTypes;
+import net.minecraft.network.protocol.status.StatusProtocols;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerConnectionListener;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.function.Function;
+
+public class GlyphHandler implements io.th0rgal.oraxen.nms.GlyphHandler {
+
+    private final Map<Channel, ChannelHandler> encoder = Collections.synchronizedMap(new WeakHashMap<>());
+    private final Map<Channel, ChannelHandler> decoder = Collections.synchronizedMap(new WeakHashMap<>());
+
+    private static final Map<PacketType<?>, ConnectionCodec> CODEC_MAP = new HashMap<>();
+    private static final Map<PacketType<?>, Integer> ID_MAP = new HashMap<>();
+
+    private record ConnectionCodec(StreamCodec<ByteBuf, Packet<?>> codec, ProtocolInfo<?> protocol) {
+    }
+
+    private static final GameProtocols.Context CONTEXT = new GameProtocols.Context() {
+        @Override
+        public boolean hasInfiniteMaterials() {
+            return true;
+        }
+    };
+
+    private static class PacketProtocol {
+        private final ProtocolInfo<?> clientboundInfo;
+        private final ProtocolInfo<?> serverboundInfo;
+
+        private final List<PacketType<?>> clientbounds = new ArrayList<>();
+        private final List<PacketType<?>> serverbounds = new ArrayList<>();
+
+        public PacketProtocol(ProtocolInfo<?> clientbound, ProtocolInfo<?> serverbound, Class<?> clazz) {
+            clientboundInfo = clientbound;
+            serverboundInfo = serverbound;
+            for (Field field : clazz.getFields()) {
+                try {
+                    PacketType<?> type = (PacketType<?>) field.get(null);
+                    switch (type.flow()) {
+                        case CLIENTBOUND -> clientbounds.add(type);
+                        case SERVERBOUND -> serverbounds.add(type);
+                    }
+                } catch (Exception e) {
+                    if (!(e instanceof ClassCastException)) {
+                        Logs.logWarning("Failed reading packet type field " + field.getName() + " in " + clazz.getSimpleName());
+                    }
+                }
+            }
+        }
+    }
+
+    static {
+        Field getToId = Arrays.stream(IdDispatchCodec.class.getDeclaredFields())
+                .filter(f -> Object2IntMap.class.isAssignableFrom(f.getType())).findFirst().orElseThrow();
+        Field getById = Arrays.stream(IdDispatchCodec.class.getDeclaredFields())
+                .filter(f -> List.class.isAssignableFrom(f.getType())).findFirst().orElseThrow();
+        Class<?> entryClass = IdDispatchCodec.class.getDeclaredClasses()[0];
+        Field getCodec = entryClass.getDeclaredFields()[0];
+        Field getType = entryClass.getDeclaredFields()[1];
+
+        getToId.setAccessible(true);
+        getById.setAccessible(true);
+        getCodec.setAccessible(true);
+        getType.setAccessible(true);
+        for (PacketProtocol packetProtocol : List.of(
+                new PacketProtocol(
+                        GameProtocols.CLIENTBOUND_TEMPLATE
+                                .bind(RegistryFriendlyByteBuf.decorator(RegistryAccess.EMPTY)),
+                        GameProtocols.SERVERBOUND_TEMPLATE
+                                .bind(RegistryFriendlyByteBuf.decorator(RegistryAccess.EMPTY), CONTEXT),
+                        GamePacketTypes.class),
+                new PacketProtocol(StatusProtocols.CLIENTBOUND, StatusProtocols.SERVERBOUND, StatusPacketTypes.class),
+                new PacketProtocol(LoginProtocols.CLIENTBOUND, LoginProtocols.SERVERBOUND, LoginPacketTypes.class),
+                new PacketProtocol(ConfigurationProtocols.CLIENTBOUND, ConfigurationProtocols.SERVERBOUND,
+                        ConfigurationPacketTypes.class),
+                new PacketProtocol(null, HandshakeProtocols.SERVERBOUND, HandshakeProtocols.class))) {
+            for (PacketType<?> clientbound : packetProtocol.clientbounds) {
+                if (packetProtocol.clientboundInfo == null)
+                    break;
+                IdDispatchCodec<ByteBuf, ?, ?> codec = (IdDispatchCodec<ByteBuf, ?, ?>) packetProtocol.clientboundInfo
+                        .codec();
+                try {
+                    Object2IntMap<?> object2IntMap = (Object2IntMap<?>) getToId.get(codec);
+                    List<?> objects = (List<?>) getById.get(codec);
+                    for (Object object : objects) {
+                        if (getType.get(object).equals(clientbound)) {
+                            CODEC_MAP.put(clientbound,
+                                    new ConnectionCodec((StreamCodec<ByteBuf, Packet<?>>) getCodec.get(object),
+                                            packetProtocol.clientboundInfo));
+                            ID_MAP.put(clientbound, object2IntMap.getInt(clientbound));
+                        }
+                    }
+                } catch (Exception e) {
+                    Logs.logWarning("Failed mapping clientbound packet codec for " + clientbound + ": " + e.getMessage());
+                }
+            }
+            for (PacketType<?> serverbound : packetProtocol.serverbounds) {
+                if (packetProtocol.serverboundInfo == null)
+                    break;
+                IdDispatchCodec<ByteBuf, ?, ?> codec = (IdDispatchCodec<ByteBuf, ?, ?>) packetProtocol.serverboundInfo
+                        .codec();
+                try {
+                    Object2IntMap<?> object2IntMap = (Object2IntMap<?>) getToId.get(codec);
+                    List<?> objects = (List<?>) getById.get(codec);
+                    for (Object object : objects) {
+                        if (getType.get(object).equals(serverbound)) {
+                            CODEC_MAP.put(serverbound,
+                                    new ConnectionCodec((StreamCodec<ByteBuf, Packet<?>>) getCodec.get(object),
+                                            packetProtocol.serverboundInfo));
+                            ID_MAP.put(serverbound, object2IntMap.getInt(serverbound));
+                        }
+                    }
+                } catch (Exception e) {
+                    Logs.logWarning("Failed mapping serverbound packet codec for " + serverbound + ": " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void setupNmsGlyphs() {
+        if (!GlyphHandlers.isNms())
+            return;
+        List<Connection> networkManagers = MinecraftServer.getServer().getConnection().getConnections();
+        List<ChannelFuture> channelFutures = resolveServerChannelFutures();
+
+        final List<ChannelFuture> futures = channelFutures;
+
+        // Handle connected channels
+        ChannelInitializer<Channel> endInitProtocol = new ChannelInitializer<>() {
+            @Override
+            protected void initChannel(@NotNull Channel channel) {
+                try {
+                    // This can take a while, so we need to stop the main thread from interfering
+                    synchronized (networkManagers) {
+                        // Stop injecting channels
+                        channel.eventLoop().submit(() -> inject(channel, null));
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        // This is executed before Minecraft's channel handler
+        ChannelInitializer<Channel> beginInitProtocol = new ChannelInitializer<>() {
+            @Override
+            protected void initChannel(Channel channel) throws Exception {
+                ChannelHandler handler = null;
+                for (Map.Entry<String, ChannelHandler> entry : channel.pipeline()) {
+                    if (entry.getValue().getClass().getName()
+                            .equals("com.viaversion.viaversion.bukkit.handlers.BukkitChannelInitializer")) {
+                        handler = entry.getValue();
+                    }
+                }
+
+                if (handler == null) {
+                    channel.pipeline().addLast(endInitProtocol);
+                } else {
+                    Class<?> clazz = handler.getClass();
+                    Method initChannel = ChannelInitializer.class.getDeclaredMethod("initChannel", Channel.class);
+                    initChannel.setAccessible(true);
+                    Field original = clazz.getDeclaredField("original");
+                    original.setAccessible(true);
+                    ChannelInitializer<Channel> initializer = (ChannelInitializer<Channel>) original.get(handler);
+                    ChannelInitializer<Channel> miniInit = new ChannelInitializer<>() {
+                        @Override
+                        protected void initChannel(@NotNull Channel ch) throws Exception {
+                            initChannel.invoke(initializer, ch);
+                            ch.eventLoop().submit(() -> inject(ch, null));
+                        }
+                    };
+                    original.set(handler, miniInit);
+                }
+            }
+        };
+
+        ChannelInboundHandlerAdapter serverChannelHandler = new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, @NotNull Object msg) {
+                // Prepare to initialize ths channel
+                ((Channel) msg).pipeline().addFirst(beginInitProtocol);
+                ctx.fireChannelRead(msg);
+            }
+        };
+
+        try {
+            bind(futures, serverChannelHandler);
+        } catch (IllegalArgumentException ex) {
+            SchedulerUtil.runTask(() -> bind(futures, serverChannelHandler));
+        }
+
+        if (VersionUtil.isPaperServer())
+            Bukkit.getPluginManager().registerEvents(new GlyphListener(), OraxenPlugin.get());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ChannelFuture> resolveServerChannelFutures() {
+        try {
+            ServerConnectionListener connectionListener = MinecraftServer.getServer().getConnection();
+            for (Field field : ServerConnectionListener.class.getDeclaredFields()) {
+                if (!List.class.isAssignableFrom(field.getType())) continue;
+
+                boolean matchesChannelFutureList = false;
+                Type genericType = field.getGenericType();
+                if (genericType instanceof ParameterizedType parameterizedType) {
+                    Type[] args = parameterizedType.getActualTypeArguments();
+                    if (args.length == 1 && args[0].getTypeName().endsWith("ChannelFuture")) {
+                        matchesChannelFutureList = true;
+                    }
+                }
+
+                if (!matchesChannelFutureList && !field.getName().equals("f")) continue;
+                if (!matchesChannelFutureList && field.getName().equals("f")) {
+                    Logs.logWarning("Falling back to obfuscated ServerConnectionListener field 'f' for channel futures");
+                }
+                field.setAccessible(true);
+                Object value = field.get(connectionListener);
+                if (value instanceof List<?> list) {
+                    return (List<ChannelFuture>) list;
+                }
+            }
+        } catch (Exception e) {
+            Logs.logError("Failed to resolve server channel futures: " + e.getMessage());
+            if (VersionUtil.atOrAbove("26.1")) {
+                e.printStackTrace();
+            }
+        }
+        Logs.logWarning("Could not resolve server channel futures; glyph network injection may be incomplete.");
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void inject(Player player) {
+        if (player == null || !GlyphHandlers.isNms())
+            return;
+        Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
+
+        channel.eventLoop().submit(() -> inject(channel, player));
+    }
+
+    @Override
+    public void uninject(Player player) {
+        if (player == null || !GlyphHandlers.isNms())
+            return;
+        Channel channel = ((CraftPlayer) player).getHandle().connection.connection.channel;
+
+        uninject(channel);
+    }
+
+    private void uninject(Channel channel) {
+        if (encoder.containsKey(channel)) {
+            // Replace our custom packet encoder with the default one that the player had
+            ChannelHandler previousHandler = encoder.remove(channel);
+            if (previousHandler instanceof PacketEncoder) {
+                // PacketEncoder is not shareable, so we can't re-add it back. Instead, we'll
+                // have to create a new instance
+                channel.pipeline().replace("encoder", "encoder", new PacketEncoder<>(GameProtocols.CLIENTBOUND_TEMPLATE
+                        .bind(RegistryFriendlyByteBuf.decorator(RegistryAccess.EMPTY))));
+            } else
+                channel.pipeline().replace("encoder", "encoder", previousHandler);
+        }
+
+        if (decoder.containsKey(channel)) {
+            ChannelHandler previousHandler = decoder.remove(channel);
+            if (previousHandler instanceof PacketDecoder) {
+                channel.pipeline().replace("decoder", "decoder", new PacketDecoder<>(GameProtocols.SERVERBOUND_TEMPLATE
+                        .bind(RegistryFriendlyByteBuf.decorator(RegistryAccess.EMPTY), CONTEXT)));
+            } else {
+                channel.pipeline().replace("decoder", "decoder", previousHandler);
+            }
+        }
+    }
+
+    private void inject(Channel channel, @Nullable Player player) {
+        // Replace the vanilla PacketEncoder with our own
+        if (!(channel.pipeline().get("encoder") instanceof CustomPacketEncoder))
+            encoder.putIfAbsent(channel,
+                    channel.pipeline().replace("encoder", "encoder", new CustomPacketEncoder(player, channel)));
+
+        // Replace the vanilla PacketDecoder with our own
+        if (!(channel.pipeline().get("decoder") instanceof CustomPacketDecoder))
+            decoder.putIfAbsent(channel,
+                    channel.pipeline().replace("decoder", "decoder", new CustomPacketDecoder(player)));
+    }
+
+    private void bind(List<ChannelFuture> channelFutures, ChannelInboundHandlerAdapter serverChannelHandler) {
+        for (ChannelFuture future : channelFutures) {
+            future.channel().pipeline().addFirst(serverChannelHandler);
+        }
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            inject(player);
+        }
+    }
+
+    private static class CustomDataSerializer extends FriendlyByteBuf {
+        @Nullable
+        private final Player player;
+
+        public CustomDataSerializer(@Nullable Player player, ByteBuf bytebuf) {
+            super(bytebuf);
+            this.player = player;
+        }
+
+        @Override
+        public @NotNull FriendlyByteBuf writeUtf(@NotNull String string, int maxLength) {
+            try {
+                JsonElement element = JsonParser.parseString(string);
+                if (element.isJsonObject())
+                    return super.writeUtf(GlyphHandlers.formatJsonString(element.getAsJsonObject(), null), maxLength);
+            } catch (Exception ignored) {
+            }
+
+            return super.writeUtf(string, maxLength);
+        }
+
+        @Override
+        public @NotNull String readUtf(int i) {
+            String value = super.readUtf(i);
+            try {
+                Component component = AdventureUtils.MINI_MESSAGE_EMPTY.deserialize(value);
+                return AdventureUtils.MINI_MESSAGE_EMPTY.serialize(GlyphHandlers.transform(component, player, true));
+            } catch (Exception e) {
+                return value;
+            }
+        }
+
+        @NotNull
+        @Override
+        public FriendlyByteBuf writeNbt(@Nullable Tag tag) {
+            if (tag instanceof CompoundTag compoundTag)
+                transform(compoundTag, GlyphHandlers.transformer(null));
+            return super.writeNbt(tag);
+        }
+
+        @Override
+        public @Nullable CompoundTag readNbt() {
+            CompoundTag compound = super.readNbt();
+            if (compound != null)
+                transform(compound, GlyphHandlers.transformer(player));
+
+            return compound;
+        }
+
+        private void transform(CompoundTag compound, Function<String, String> transformer) {
+            for (String key : compound.keySet()) {
+                Tag base = compound.get(key);
+                if (base instanceof CompoundTag tag)
+                    transform(tag, transformer);
+                else if (base instanceof ListTag listTag)
+                    transform(listTag, transformer);
+                else if (base instanceof StringTag)
+                    base.asString().ifPresent(value ->
+                            compound.put(key, StringTag.valueOf(transformer.apply(value))));
+            }
+        }
+
+        private void transform(ListTag list, Function<String, String> transformer) {
+            List<Tag> listCopy = List.copyOf(list);
+            for (int i = 0; i < listCopy.size(); i++) {
+                Tag base = listCopy.get(i);
+                final int index = i;
+                if (base instanceof CompoundTag tag)
+                    transform(tag, transformer);
+                else if (base instanceof ListTag listTag)
+                    transform(listTag, transformer);
+                else if (base instanceof StringTag) {
+                    base.asString().ifPresent(value ->
+                            list.set(index, StringTag.valueOf(transformer.apply(value))));
+                }
+            }
+        }
+    }
+
+    private static final AttributeKey<ConnectionCodec> CODEC_ATTRIBUTE_KEY = AttributeKey
+            .newInstance("oraxen.codec.key");
+
+    private static class CustomPacketEncoder extends MessageToByteEncoder<Packet<?>> {
+        @Nullable
+        private final Player player;
+        private final Channel channel;
+
+        private CustomPacketEncoder(@Nullable Player player, @NotNull Channel channel) {
+            super();
+            this.player = player;
+            this.channel = channel;
+        }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof Packet<?> packet) {
+                ConnectionCodec codec = CODEC_MAP.get(packet.type());
+                if (codec != null)
+                    channel.attr(CODEC_ATTRIBUTE_KEY).set(codec);
+            }
+            super.write(ctx, msg, promise);
+        }
+
+        @Override
+        public void encode(ChannelHandlerContext ctx, Packet<?> packet, ByteBuf byteBuf) {
+            Channel ctxChannel = ctx.channel();
+            if (ctxChannel == null) {
+                throw new IllegalStateException("Channel is null");
+            }
+
+            ConnectionCodec connectionCodec = CODEC_MAP.get(packet.type());
+            if (connectionCodec == null) {
+                throw new IllegalArgumentException("Unknown packet type: " + packet.type());
+            }
+            Integer packetId = ID_MAP.get(packet.type());
+            if (packetId == null) {
+                throw new IllegalArgumentException("Unknown packet id for packet type: " + packet.type());
+            }
+            StreamCodec<ByteBuf, Packet<?>> codec = connectionCodec.codec;
+
+            FriendlyByteBuf packetDataSerializer = new CustomDataSerializer(player, byteBuf);
+            packetDataSerializer.writeVarInt(packetId);
+
+            try {
+                int integer2 = packetDataSerializer.writerIndex();
+                codec.encode(packetDataSerializer, packet);
+                int integer3 = packetDataSerializer.writerIndex() - integer2;
+                if (integer3 > 8388608) {
+                    throw new IllegalArgumentException(
+                            "Packet too big (is " + integer3 + ", should be less than 8388608): " + packet);
+                }
+            } catch (Exception e) {
+                if (packet.isSkippable())
+                    throw new SkipPacketEncoderException(e);
+                throw e;
+            }
+            swapProtocolIfNeeded(ctxChannel.attr(CODEC_ATTRIBUTE_KEY), packet);
+        }
+
+    }
+
+    private static void swapProtocolIfNeeded(Attribute<ConnectionCodec> protocolAttribute, Packet<?> packet) {
+        ConnectionCodec mappedCodec = CODEC_MAP.get(packet.type());
+        if (mappedCodec == null) return;
+        ProtocolInfo<?> connectionProtocol = mappedCodec.protocol;
+        if (connectionProtocol != null) {
+            ConnectionCodec codecData = protocolAttribute.get();
+            if (codecData == null) return;
+            ProtocolInfo<?> connectionProtocol2 = codecData.protocol;
+            if (connectionProtocol.id() != connectionProtocol2.id()) {
+                @SuppressWarnings("unchecked")
+                StreamCodec<ByteBuf, Packet<?>> codecData2 = (StreamCodec) connectionProtocol.codec();
+                protocolAttribute.set(new ConnectionCodec(codecData2, connectionProtocol));
+            }
+        }
+
+    }
+
+    private static class CustomPacketDecoder extends ByteToMessageDecoder {
+        @Nullable
+        private final Player player;
+
+        private CustomPacketDecoder(@Nullable Player player) {
+            this.player = player;
+        }
+
+        @Override
+        protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws IOException {
+            final ByteBuf bufferCopy = buffer.copy();
+            try {
+                if (buffer.readableBytes() == 0)
+                    return;
+
+                CustomDataSerializer dataSerializer = new CustomDataSerializer(player, buffer);
+                int packetID = dataSerializer.readVarInt();
+                Attribute<ConnectionCodec> attribute = ctx.channel().attr(CODEC_ATTRIBUTE_KEY);
+                ConnectionCodec codec = attribute.get();
+                if (codec == null) {
+                    throw new IOException("Missing codec mapping for channel " + ctx.channel());
+                }
+                Packet<?> packet = codec.codec.decode(dataSerializer);
+
+                if (dataSerializer.readableBytes() > 0) {
+                    throw new IOException("Packet " + packetID + " " + packet + " was larger than expected, found "
+                            + dataSerializer.readableBytes() + " bytes extra whilst reading the packet " + packetID);
+                } else if (packet instanceof ServerboundChatPacket) {
+                    FriendlyByteBuf baseSerializer = new FriendlyByteBuf(bufferCopy);
+                    baseSerializer.readVarInt();
+                    packet = codec.codec.decode(baseSerializer);
+                }
+
+                out.add(packet);
+                swapProtocolIfNeeded(attribute, packet);
+            } finally {
+                bufferCopy.release();
+            }
+        }
+    }
+}

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphListener.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/GlyphListener.java
@@ -1,0 +1,15 @@
+package io.th0rgal.oraxen.nms.v1_26_R1;
+
+import io.papermc.paper.event.player.AsyncChatDecorateEvent;
+import io.th0rgal.oraxen.nms.GlyphHandlers;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class GlyphListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onDecorate(AsyncChatDecorateEvent event) {
+        event.result(GlyphHandlers.transform(event.result(), event.player(), true));
+    }
+}

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/NMSHandler.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/NMSHandler.java
@@ -254,8 +254,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         return null;
     }
 
-    // Use Object as key type to support both ResourceLocation (1.21.10) and
-    // Identifier (1.21.11)
+    // Use Object as key type to support both ResourceLocation and Identifier
+    // (renamed across mapping generations before/into 26.x).
     private final Map<Object, IntList> tagRegistryMap = createTagRegistryMap();
 
     private Map<Object, IntList> createTagRegistryMap() {

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/NMSHandler.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/NMSHandler.java
@@ -1,0 +1,895 @@
+package io.th0rgal.oraxen.nms.v1_26_R1;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.papermc.paper.configuration.GlobalConfiguration;
+import io.papermc.paper.network.ChannelInitializeListenerHolder;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.items.ItemBuilder;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanicFactory;
+import io.th0rgal.oraxen.nms.GlyphHandler;
+import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.Connection;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.ClientboundUpdateTagsPacket;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.PositionMoveRotation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.tags.TagNetworkSerialization;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemUseAnimation;
+import net.minecraft.world.item.JukeboxSong;
+import net.minecraft.world.item.component.Consumable;
+import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.consume_effects.*;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.context.DirectionalPlaceContext;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.LevelEvent;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import org.apache.commons.lang3.EnumUtils;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.SoundCategory;
+import org.bukkit.SoundGroup;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.components.FoodComponent;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
+
+    private final GlyphHandler glyphHandler;
+    private final Listener packDispatchListener;
+
+    public NMSHandler() {
+        this.glyphHandler = new io.th0rgal.oraxen.nms.v1_26_R1.GlyphHandler();
+        this.packDispatchListener = new PackDispatchListener();
+
+        // mineableWith tag handling
+        NamespacedKey tagKey = NamespacedKey.fromString("mineable_with_key", OraxenPlugin.get());
+        if (!VersionUtil.isPaperServer())
+            return;
+        if (ChannelInitializeListenerHolder.hasListener(tagKey))
+            return;
+        ChannelInitializeListenerHolder.addListener(tagKey, (channel -> channel.pipeline().addBefore("packet_handler",
+                tagKey.asString(), new ChannelDuplexHandler() {
+                    TagNetworkSerialization.NetworkPayload payload = createPayload();
+
+                    @Override
+                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                        if (msg instanceof ClientboundUpdateTagsPacket updateTagsPacket) {
+                            Map<ResourceKey<? extends Registry<?>>, TagNetworkSerialization.NetworkPayload> tags = new HashMap<>(updateTagsPacket.getTags());
+                            if (payload != null
+                                    && NoteBlockMechanicFactory.isEnabled()
+                                    && NoteBlockMechanicFactory.getInstance().removeMineableTag())
+                                tags.put(Registries.BLOCK, payload);
+                            msg = new ClientboundUpdateTagsPacket(tags);
+                        }
+                        ctx.write(msg, promise);
+                    }
+                })));
+    }
+
+    @Override
+    public GlyphHandler glyphHandler() {
+        return glyphHandler;
+    }
+
+    @Override
+    public Listener packDispatchListener() {
+        return packDispatchListener;
+    }
+
+    @Override
+    public boolean tripwireUpdatesDisabled() {
+        return VersionUtil.isPaperServer() && GlobalConfiguration.get().blockUpdates.disableTripwireUpdates;
+    }
+
+    @Override
+    public boolean noteblockUpdatesDisabled() {
+        return VersionUtil.isPaperServer() && GlobalConfiguration.get().blockUpdates.disableNoteblockUpdates;
+    }
+
+    @Override
+    public boolean chorusPlantUpdatesDisabled() {
+        return VersionUtil.isPaperServer() && GlobalConfiguration.get().blockUpdates.disableChorusPlantUpdates;
+    }
+
+    @Override
+    /* This method copies custom NBT data from one item to another */
+    public ItemStack copyItemNBTTags(@NotNull ItemStack oldItem, @NotNull ItemStack newItem) {
+        net.minecraft.world.item.ItemStack newNmsItem = CraftItemStack.asNMSCopy(newItem);
+        net.minecraft.world.item.ItemStack oldItemStack = CraftItemStack.asNMSCopy(oldItem);
+        // Gets data component's nbt data.
+        DataComponentType<CustomData> type = DataComponents.CUSTOM_DATA;
+        CustomData oldData = oldItemStack.getComponents().get(type);
+        CustomData newData = newNmsItem.getComponents().get(type);
+
+        // Cancels if null.
+        if (oldData == null || newData == null)
+            return newItem;
+        // Creates new nbt compound.
+        CompoundTag oldTag = oldData.copyTag();
+        CompoundTag newTag = newData.copyTag();
+
+        for (String key : oldTag.keySet()) {
+            if (vanillaKeys.contains(key))
+                continue;
+            Tag value = oldTag.get(key);
+            if (value != null)
+                newTag.put(key, value);
+            else
+                newTag.remove(key);
+        }
+
+        newNmsItem.set(type, CustomData.of(newTag));
+        return CraftItemStack.asBukkitCopy(newNmsItem);
+    }
+
+    @Override
+    @Nullable
+    public BlockData correctBlockStates(Player player, EquipmentSlot slot, ItemStack itemStack) {
+        InteractionHand hand = slot == EquipmentSlot.HAND ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND;
+        net.minecraft.world.item.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
+        ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
+        BlockHitResult hitResult = getPlayerPOVHitResult(serverPlayer.level(), serverPlayer, ClipContext.Fluid.NONE);
+        BlockPlaceContext placeContext = new BlockPlaceContext(new UseOnContext(serverPlayer, hand, hitResult));
+
+        if (!(nmsStack.getItem() instanceof BlockItem blockItem)) {
+            nmsStack.getItem().useOn(new UseOnContext(serverPlayer, hand, hitResult));
+            if (!player.isSneaking())
+                serverPlayer.gameMode.useItem(serverPlayer, serverPlayer.level(), nmsStack, hand);
+            return null;
+        }
+
+        // Shulker-Boxes are DirectionalPlace based unlike other directional-blocks
+        if (org.bukkit.Tag.SHULKER_BOXES.isTagged(itemStack.getType())) {
+            placeContext = new DirectionalPlaceContext(serverPlayer.level(), hitResult.getBlockPos(),
+                    hitResult.getDirection(), nmsStack, hitResult.getDirection().getOpposite());
+        }
+
+        InteractionResult result = blockItem.place(placeContext);
+        if (result == InteractionResult.FAIL)
+            return null;
+        if (placeContext instanceof DirectionalPlaceContext && player.getGameMode() != org.bukkit.GameMode.CREATIVE)
+            itemStack.setAmount(itemStack.getAmount() - 1);
+        World world = player.getWorld();
+        BlockPos placedPos = placeContext.getClickedPos();
+
+        if (!player.isSneaking()) {
+            Block block = world.getBlockAt(placedPos.getX(), placedPos.getY(), placedPos.getZ());
+            SoundGroup sound = block.getBlockData().getSoundGroup();
+
+            world.playSound(
+                    BlockHelpers.toCenterBlockLocation(block.getLocation()), sound.getPlaceSound(),
+                    SoundCategory.BLOCKS, (sound.getVolume() + 1.0F) / 2.0F, sound.getPitch() * 0.8F);
+        }
+
+        return world.getBlockAt(placedPos.getX(), placedPos.getY(), placedPos.getZ()).getBlockData();
+    }
+
+    public BlockHitResult getPlayerPOVHitResult(Level world, net.minecraft.world.entity.player.Player player,
+            ClipContext.Fluid fluidHandling) {
+        float f = player.getXRot();
+        float g = player.getYRot();
+        Vec3 vec3 = player.getEyePosition();
+        float h = Mth.cos(-g * ((float) Math.PI / 180F) - (float) Math.PI);
+        float i = Mth.sin(-g * ((float) Math.PI / 180F) - (float) Math.PI);
+        float j = -Mth.cos(-f * ((float) Math.PI / 180F));
+        float k = Mth.sin(-f * ((float) Math.PI / 180F));
+        float l = i * j;
+        float n = h * j;
+        double d = 5.0D;
+        Vec3 vec32 = vec3.add((double) l * d, (double) k * d, (double) n * d);
+        return world.clip(new ClipContext(vec3, vec32, ClipContext.Block.OUTLINE, fluidHandling, player));
+    }
+
+    @Override
+    public void customBlockDefaultTools(Player player) {
+
+    }
+
+    private TagNetworkSerialization.NetworkPayload createPayload() {
+        Constructor<?> constructor = Arrays
+                .stream(TagNetworkSerialization.NetworkPayload.class.getDeclaredConstructors()).findFirst()
+                .orElse(null);
+        if (constructor == null)
+            return null;
+        constructor.setAccessible(true);
+        try {
+            return (TagNetworkSerialization.NetworkPayload) constructor.newInstance(tagRegistryMap);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    // Use Object as key type to support both ResourceLocation (1.21.10) and
+    // Identifier (1.21.11)
+    private final Map<Object, IntList> tagRegistryMap = createTagRegistryMap();
+
+    private Map<Object, IntList> createTagRegistryMap() {
+        return BuiltInRegistries.BLOCK.getTags().map(named -> {
+            IntArrayList list = new IntArrayList(named.size());
+            if (named.key().location().equals(BlockTags.MINEABLE_WITH_AXE.location())) {
+                named.stream()
+                        .filter(block -> !block.value().getDescriptionId().endsWith("note_block"))
+                        .forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
+            } else {
+                named.forEach(block -> list.add(BuiltInRegistries.BLOCK.getId(block.value())));
+            }
+            return Map.of((Object) named.key().location(), (IntList) list);
+        }).collect(HashMap::new, Map::putAll, Map::putAll);
+    }
+
+    @Override
+    public boolean getSupported() {
+        return true;
+    }
+
+    /**
+     * Sets a component on an item using the DataComponents registry
+     * 
+     * @param item         The ItemBuilder to modify
+     * @param componentKey The component key (e.g. "food", "tool", etc.)
+     * @param component    The component object
+     * @return true if the component was successfully set
+     */
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public boolean setComponent(ItemBuilder item, String componentKey, Object component) {
+        try {
+            Object componentLocation = ResourceLocationHelper.parse("minecraft:" + componentKey.toLowerCase());
+            if (componentLocation == null)
+                return false;
+
+            net.minecraft.core.component.DataComponentType<?> componentType = getDataComponentType(componentLocation);
+            if (componentType == null)
+                return false;
+
+            if (component instanceof ConfigurationSection config) {
+                net.minecraft.nbt.CompoundTag nbt = new net.minecraft.nbt.CompoundTag();
+                convertConfigToNBT(config, nbt);
+
+                // Use Codec-based deserialization (works for all components including records)
+                com.mojang.serialization.Codec<?> codec = componentType.codecOrThrow();
+                var registryAccess = ((org.bukkit.craftbukkit.CraftServer) org.bukkit.Bukkit.getServer())
+                        .getServer().registryAccess();
+                var ops = net.minecraft.resources.RegistryOps.create(
+                        net.minecraft.nbt.NbtOps.INSTANCE, registryAccess);
+                var result = codec.parse(ops, nbt);
+
+                var parsedOptional = result.result();
+                if (parsedOptional.isPresent()) {
+                    item.setComponent(componentKey, parsedOptional.get());
+                    return true;
+                } else {
+                    Logs.logWarning("Failed to parse component '" + componentKey + "': " +
+                            result.error().map(e -> e.message()).orElse("unknown error"));
+                    return false;
+                }
+            } else {
+                item.setComponent(componentKey, component);
+                return true;
+            }
+        } catch (Exception e) {
+            Logs.logWarning("Failed to set component " + componentKey);
+            if (io.th0rgal.oraxen.config.Settings.DEBUG.toBool())
+                e.printStackTrace();
+            return false;
+        }
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public ItemStack applyGenericComponents(ItemStack itemStack, java.util.Map<String, Object> components) {
+        if (components.isEmpty()) return itemStack;
+
+        net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+        for (var entry : components.entrySet()) {
+            try {
+                Object location = ResourceLocationHelper.parse("minecraft:" + entry.getKey().toLowerCase());
+                if (location == null) continue;
+
+                DataComponentType componentType = getDataComponentType(location);
+                if (componentType == null) continue;
+
+                nmsItem.set(componentType, entry.getValue());
+            } catch (Exception e) {
+                Logs.logWarning("Failed to apply component '" + entry.getKey() + "'");
+                if (io.th0rgal.oraxen.config.Settings.DEBUG.toBool())
+                    e.printStackTrace();
+            }
+        }
+        return CraftItemStack.asBukkitCopy(nmsItem);
+    }
+
+    private void convertConfigToNBT(ConfigurationSection config, net.minecraft.nbt.CompoundTag nbt) {
+        for (String key : config.getKeys(false)) {
+            Object value = config.get(key);
+            if (value instanceof ConfigurationSection section) {
+                handleConfigSectionValue(nbt, key, section);
+            } else if (value instanceof Number number) {
+                handleNumberValue(nbt, key, number);
+            } else if (value instanceof Boolean boolValue) {
+                nbt.putBoolean(key, boolValue);
+            } else if (value instanceof String stringValue) {
+                nbt.putString(key, stringValue);
+            } else if (value instanceof List<?> list) {
+                handleListValue(nbt, key, list);
+            }
+        }
+    }
+
+    private void handleConfigSectionValue(net.minecraft.nbt.CompoundTag nbt, String key, ConfigurationSection section) {
+        net.minecraft.nbt.CompoundTag compound = new net.minecraft.nbt.CompoundTag();
+        convertConfigToNBT(section, compound);
+        nbt.put(key, compound);
+    }
+
+    private void handleNumberValue(net.minecraft.nbt.CompoundTag nbt, String key, Number number) {
+        if (number instanceof Integer)
+            nbt.putInt(key, number.intValue());
+        else if (number instanceof Double)
+            nbt.putDouble(key, number.doubleValue());
+        else if (number instanceof Float)
+            nbt.putFloat(key, number.floatValue());
+        else if (number instanceof Long)
+            nbt.putLong(key, number.longValue());
+        else if (number instanceof Byte)
+            nbt.putByte(key, number.byteValue());
+        else if (number instanceof Short)
+            nbt.putShort(key, number.shortValue());
+    }
+
+    private void handleListValue(net.minecraft.nbt.CompoundTag nbt, String key, List<?> list) {
+        if (list.isEmpty()) {
+            return;
+        }
+
+        Object first = list.get(0);
+        if (first instanceof String) {
+            net.minecraft.nbt.ListTag stringList = new net.minecraft.nbt.ListTag();
+            for (Object s : list) {
+                stringList.add(net.minecraft.nbt.StringTag.valueOf(s.toString()));
+            }
+            nbt.put(key, stringList);
+        } else if (first instanceof Number) {
+            if (list.stream().anyMatch(element -> !(element instanceof Number))) {
+                Logs.logWarning("Mixed-type numeric list in NBT config for key: " + key);
+                return;
+            }
+
+            List<? extends Number> numbers = list.stream()
+                    .map(element -> (Number) element)
+                    .toList();
+            boolean hasFractional = numbers.stream()
+                    .anyMatch(number -> number instanceof Float || number instanceof Double);
+
+            if (hasFractional) {
+                net.minecraft.nbt.ListTag decimalList = new net.minecraft.nbt.ListTag();
+                numbers.forEach(number -> decimalList.add(net.minecraft.nbt.DoubleTag.valueOf(number.doubleValue())));
+                nbt.put(key, decimalList);
+                return;
+            }
+
+            boolean requiresLong = numbers.stream()
+                    .anyMatch(number -> number.longValue() > Integer.MAX_VALUE || number.longValue() < Integer.MIN_VALUE);
+            if (requiresLong) {
+                nbt.putLongArray(key, numbers.stream().mapToLong(Number::longValue).toArray());
+            } else {
+                nbt.putIntArray(key, numbers.stream().mapToInt(Number::intValue).toArray());
+            }
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public void foodComponent(ItemBuilder item, ConfigurationSection foodSection) {
+        FoodComponent foodComponent = new ItemStack(item.getType()).getItemMeta().getFood();
+
+        // Ensure nutrition is non-negative
+        int nutrition = Math.max(foodSection.getInt("nutrition"), 0);
+        foodComponent.setNutrition(nutrition);
+
+        // Ensure saturation is non-negative
+        float saturation = Math.max((float) foodSection.getDouble("saturation", 0.0), 0f);
+        foodComponent.setSaturation(saturation);
+
+        foodComponent.setCanAlwaysEat(foodSection.getBoolean("can_always_eat", false));
+
+        item.setFoodComponent(foodComponent);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public void consumableComponent(ItemBuilder item, ConfigurationSection section) {
+        Consumable.Builder consumable = Consumable.builder();
+        Consumable template = Optional.ofNullable(CraftItemStack.asNMSCopy(new ItemStack(item.getType()))
+                .getComponents().get(DataComponents.CONSUMABLE))
+                .orElse(Consumable.builder().build());
+
+        // Basic properties
+        consumable.consumeSeconds((float) section.getDouble("consume_seconds", template.consumeSeconds()));
+        consumable.animation(Optional.ofNullable(EnumUtils.getEnum(ItemUseAnimation.class,
+                section.getString("animation", "").toUpperCase()))
+                .orElse(template.animation()));
+        consumable.hasConsumeParticles(section.getBoolean("has_consume_particles", template.hasConsumeParticles()));
+
+        // Sound handling
+        String soundId = section.getString("sound");
+        if (soundId != null) {
+            SoundEvent soundEvent = getSoundEventFromId(soundId);
+            if (soundEvent != null) {
+                consumable.sound(Holder.direct(soundEvent));
+            } else {
+                consumable.sound(template.sound());
+            }
+        } else {
+            consumable.sound(template.sound());
+        }
+
+        // Effects handling
+        List<Map<?, ?>> effectsMap = section.getMapList("on_consume_effects");
+        if (effectsMap.isEmpty()) {
+            template.onConsumeEffects().forEach(consumable::onConsume);
+        } else {
+            for (Map<?, ?> effectSection : effectsMap) {
+                String type = Optional.ofNullable(effectSection.get("type"))
+                        .map(Object::toString)
+                        .orElse("");
+
+                switch (type.toLowerCase()) {
+                    case "apply_effects" -> handleApplyEffects(consumable, effectSection);
+                    case "remove_effects" -> handleRemoveEffects(consumable, effectSection);
+                    case "clear_all_effects" -> consumable.onConsume(new ClearAllStatusEffectsConsumeEffect());
+                    case "teleport_randomly" -> {
+                        float diameter = Optional.ofNullable(effectSection.get("diameter"))
+                                .map(d -> Float.parseFloat(d.toString()))
+                                .orElse(16f);
+                        consumable.onConsume(new TeleportRandomlyConsumeEffect(diameter));
+                    }
+                    case "play_sound" -> handlePlaySound(consumable, effectSection, template);
+                    default -> Logs.logWarning("Invalid ConsumeEffect-Type " + type);
+                }
+            }
+        }
+
+        item.setConsumableComponent(consumable.build());
+    }
+
+    private void handleApplyEffects(Consumable.Builder consumable, Map<?, ?> effectSection) {
+        if (!(effectSection.get("effects") instanceof Map<?, ?> effects))
+            return;
+
+        float probability = parseFloatValue(effectSection.get("probability"), 1.0f, "probability");
+
+        for (Map.Entry<?, ?> entry : effects.entrySet()) {
+            String effectId = entry.getKey().toString();
+            if (!(entry.getValue() instanceof Map<?, ?> rawMap)) {
+                Logs.logWarning("Invalid effect data for " + effectId + ": expected map");
+                continue;
+            }
+            Map<String, Object> effectData = new HashMap<>();
+            for (Map.Entry<?, ?> effectEntry : rawMap.entrySet()) {
+                effectData.put(String.valueOf(effectEntry.getKey()), effectEntry.getValue());
+            }
+
+            getMobEffectOptional(effectId)
+                    .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+                    .ifPresent(effect -> {
+                        int duration = Optional.ofNullable(effectData.get("duration"))
+                                .map(d -> parseIntegerValue(d, 1, "duration", effectId) * 20)
+                                .orElse(20);
+                        int amplifier = Optional.ofNullable(effectData.get("amplifier"))
+                                .map(a -> parseIntegerValue(a, 0, "amplifier", effectId))
+                                .orElse(0);
+                        boolean ambient = Optional.ofNullable(effectData.get("ambient"))
+                                .map(a -> Boolean.parseBoolean(a.toString()))
+                                .orElse(false);
+                        boolean particles = Optional.ofNullable(effectData.get("show_particles"))
+                                .map(p -> Boolean.parseBoolean(p.toString()))
+                                .orElse(true);
+                        boolean icon = Optional.ofNullable(effectData.get("show_icon"))
+                                .map(i -> Boolean.parseBoolean(i.toString()))
+                                .orElse(true);
+
+                        MobEffectInstance instance = new MobEffectInstance(
+                                effect, duration, amplifier, ambient, particles, icon);
+                        consumable.onConsume(new ApplyStatusEffectsConsumeEffect(instance, probability));
+                    });
+        }
+    }
+
+    private float parseFloatValue(Object value, float fallback, String fieldName) {
+        if (value == null) return fallback;
+        try {
+            return Float.parseFloat(value.toString());
+        } catch (NumberFormatException exception) {
+            Logs.logWarning("Invalid float value for " + fieldName + ": " + value + ", using " + fallback);
+            return fallback;
+        }
+    }
+
+    private int parseIntegerValue(Object value, int fallback, String fieldName, String effectId) {
+        if (value == null) return fallback;
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException exception) {
+            Logs.logWarning("Invalid integer value for " + fieldName + " in effect " + effectId + ": " + value + ", using " + fallback);
+            return fallback;
+        }
+    }
+
+    private void handleRemoveEffects(Consumable.Builder consumable, Map<?, ?> effectSection) {
+        if (!(effectSection.get("effects") instanceof List<?> effects))
+            return;
+
+        List<Holder<MobEffect>> mobEffects = effects.stream()
+                .map(Object::toString)
+                .map(this::getMobEffectOptional)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(BuiltInRegistries.MOB_EFFECT::wrapAsHolder)
+                .toList();
+
+        if (!mobEffects.isEmpty()) {
+            consumable.onConsume(new RemoveStatusEffectsConsumeEffect(HolderSet.direct(mobEffects)));
+        }
+    }
+
+    private void handlePlaySound(Consumable.Builder consumable, Map<?, ?> effectSection, Consumable template) {
+        String soundIdStr = Optional.ofNullable(effectSection.get("sound"))
+                .map(Object::toString)
+                .orElse(null);
+
+        if (soundIdStr != null) {
+            getSoundEventOptional(soundIdStr)
+                    .map(BuiltInRegistries.SOUND_EVENT::wrapAsHolder)
+                    .map(PlaySoundConsumeEffect::new)
+                    .ifPresent(consumable::onConsume);
+        } else {
+            // Use template sound
+            consumable.onConsume(new PlaySoundConsumeEffect(template.sound()));
+        }
+    }
+
+    // ============ Reflection helpers for ResourceLocation/Identifier compatibility
+    // ============
+
+    /**
+     * Get DataComponentType by looking up the component location via reflection.
+     */
+    @SuppressWarnings("unchecked")
+    private net.minecraft.core.component.DataComponentType<?> getDataComponentType(Object location) {
+        try {
+            java.lang.reflect.Method getOptional = BuiltInRegistries.DATA_COMPONENT_TYPE.getClass()
+                    .getMethod("getOptional", ResourceLocationHelper.getResourceLocationClass());
+            Optional<net.minecraft.core.component.DataComponentType<?>> result = (Optional<net.minecraft.core.component.DataComponentType<?>>) getOptional
+                    .invoke(
+                            BuiltInRegistries.DATA_COMPONENT_TYPE, location);
+            return result.orElse(null);
+        } catch (Exception e) {
+            Logs.logWarning("Failed to get data component type: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Get MobEffect optional by effect ID string.
+     */
+    @SuppressWarnings("unchecked")
+    private Optional<MobEffect> getMobEffectOptional(String effectId) {
+        try {
+            Object location = ResourceLocationHelper.parse(effectId);
+            java.lang.reflect.Method getOptional = BuiltInRegistries.MOB_EFFECT.getClass()
+                    .getMethod("getOptional", ResourceLocationHelper.getResourceLocationClass());
+            return (Optional<MobEffect>) getOptional.invoke(BuiltInRegistries.MOB_EFFECT, location);
+        } catch (Exception e) {
+            Logs.logWarning("Failed to get mob effect: " + effectId);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get SoundEvent optional by sound ID string.
+     */
+    @SuppressWarnings("unchecked")
+    private Optional<SoundEvent> getSoundEventOptional(String soundId) {
+        try {
+            Object location = ResourceLocationHelper.parse(soundId);
+            java.lang.reflect.Method getOptional = BuiltInRegistries.SOUND_EVENT.getClass()
+                    .getMethod("getOptional", ResourceLocationHelper.getResourceLocationClass());
+            return (Optional<SoundEvent>) getOptional.invoke(BuiltInRegistries.SOUND_EVENT, location);
+        } catch (Exception e) {
+            Logs.logWarning("Failed to get sound event: " + soundId);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Create a SoundEvent from a sound ID string.
+     */
+    private SoundEvent getSoundEventFromId(String soundId) {
+        try {
+            Object location = ResourceLocationHelper.parse(soundId);
+            // SoundEvent constructor takes the location - use reflection since type differs
+            java.lang.reflect.Constructor<?> constructor = SoundEvent.class.getConstructor(
+                    ResourceLocationHelper.getResourceLocationClass(), Optional.class);
+            return (SoundEvent) constructor.newInstance(location, Optional.empty());
+        } catch (Exception e) {
+            Logs.logWarning("Failed to create sound event: " + soundId);
+            return null;
+        }
+    }
+
+    @Override
+    @Nullable
+    public Object consumableComponent(final ItemStack itemStack) {
+        if (itemStack == null)
+            return null;
+        try {
+            net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+            return nmsItem.get(DataComponents.CONSUMABLE);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public ItemStack consumableComponent(final ItemStack itemStack, @Nullable Object consumable) {
+        if (consumable == null)
+            return itemStack;
+        try {
+            net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+            nmsItem.set(DataComponents.CONSUMABLE, (Consumable) consumable);
+            return CraftItemStack.asBukkitCopy(nmsItem);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return itemStack;
+    }
+
+    @Override
+    public boolean supportsJukeboxPlaying() {
+        return true;
+    }
+
+    @Override
+    public void playJukeBoxSong(Location location, ItemStack itemStack) {
+        if (location == null || location.getWorld() == null) return;
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(itemStack);
+        Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(nmsItem);
+        if (!optional.isPresent())
+            return; // should never happen if the itemstack has the jukeboxPlayable component
+        int id = level.registryAccess().lookupOrThrow(Registries.JUKEBOX_SONG).getId(optional.get().value());
+        level.levelEvent(null, LevelEvent.SOUND_PLAY_JUKEBOX_SONG,
+                new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), id);
+    }
+
+    @Override
+    public void stopJukeBox(Location location) {
+        if (location == null || location.getWorld() == null) return;
+        ServerLevel level = ((CraftWorld) location.getWorld()).getHandle().getLevel();
+        level.levelEvent(null, LevelEvent.SOUND_STOP_JUKEBOX_SONG,
+                new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), 0);
+    }
+
+    // ============ Backpack Cosmetic Packet Methods ============
+
+    private static final AtomicInteger ENTITY_ID_COUNTER = new AtomicInteger(Integer.MAX_VALUE / 2);
+
+    @Override
+    public int getNextEntityId() {
+        return ENTITY_ID_COUNTER.decrementAndGet();
+    }
+
+    @Override
+    public void spawnBackpackArmorStand(Player viewer, int entityId, Location location, ItemStack displayItem, boolean small) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+
+        // Debug: Logs.logSuccess("[Backpack] Spawning armor stand for " + viewer.getName() + " at " + location + " (entityId: " + entityId + ")");
+
+        // Create spawn packet for armor stand
+        UUID uuid = UUID.randomUUID();
+        double x = location.getX();
+        double y = location.getY();
+        double z = location.getZ();
+        float yaw = location.getYaw();
+        float pitch = location.getPitch();
+
+        // Spawn entity packet
+        ClientboundAddEntityPacket spawnPacket = new ClientboundAddEntityPacket(
+                entityId,
+                uuid,
+                x, y, z,
+                pitch, yaw,
+                EntityType.ARMOR_STAND,
+                0, // data
+                Vec3.ZERO,
+                0.0 // head yaw
+        );
+        connection.send(spawnPacket);
+
+        // Set entity metadata (invisible, small - NO marker flag so equipment renders)
+        List<SynchedEntityData.DataValue<?>> metadata = new ArrayList<>();
+
+        // Byte flags at index 0: 0x20 = invisible (armor stand body invisible, equipment still renders)
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(0, EntityDataSerializers.BYTE),
+                (byte) 0x20  // Invisible - only equipment renders
+        ));
+
+        // Armor stand flags at index 15: 0x01 = small (NO marker flag - marker prevents equipment rendering)
+        byte armorStandFlags = (byte) (small ? 0x01 : 0x00);
+        // Don't set marker flag (0x10) - it prevents equipment from rendering
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(15, EntityDataSerializers.BYTE),
+                armorStandFlags
+        ));
+
+        ClientboundSetEntityDataPacket metadataPacket = new ClientboundSetEntityDataPacket(entityId, metadata);
+        connection.send(metadataPacket);
+
+        // Set equipment - use HEAD slot to display the item as a head decoration
+        // This renders the item model on top of the armor stand
+        if (displayItem != null && !displayItem.getType().isAir()) {
+            net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(displayItem);
+            List<com.mojang.datafixers.util.Pair<net.minecraft.world.entity.EquipmentSlot, net.minecraft.world.item.ItemStack>> equipment = new ArrayList<>();
+            // Set item in head slot - renders as a floating item on the armor stand
+            equipment.add(new com.mojang.datafixers.util.Pair<>(
+                    net.minecraft.world.entity.EquipmentSlot.HEAD,
+                    nmsItem
+            ));
+            ClientboundSetEquipmentPacket equipmentPacket = new ClientboundSetEquipmentPacket(entityId, equipment);
+            connection.send(equipmentPacket);
+            // Debug: Logs.logSuccess("[Backpack] Sent equipment packet with item in HEAD slot: " + displayItem.getType());
+        }
+    }
+
+    @Override
+    public void sendEntityTeleport(Player viewer, int entityId, Location location) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+
+        // Create position/rotation data
+        PositionMoveRotation positionData = new PositionMoveRotation(
+                new Vec3(location.getX(), location.getY(), location.getZ()),
+                Vec3.ZERO, // delta movement
+                location.getYaw(),
+                location.getPitch()
+        );
+
+        ClientboundEntityPositionSyncPacket teleportPacket = new ClientboundEntityPositionSyncPacket(
+                entityId,
+                positionData,
+                false // on ground
+        );
+        connection.send(teleportPacket);
+    }
+
+    @Override
+    public void sendEntityHeadRotation(Player viewer, int entityId, float yaw) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+
+        // Following HMCCosmetics approach: send BOTH rotation packets for proper rotation
+        // "First person backpacks need both packets to rotate properly, otherwise they look off"
+
+        // Convert yaw to protocol format (256 steps per rotation)
+        byte protocolYaw = (byte) ((int) (yaw * 256.0F / 360.0F));
+
+        // 1. Send entity body rotation packet (ClientboundMoveEntityPacket.Rot)
+        connection.send(new ClientboundMoveEntityPacket.Rot(entityId, protocolYaw, (byte) 0, false));
+
+        // 2. Send entity head rotation packet - write manually since we have a fake entity
+        // Packet format: VarInt entityId, Byte headYaw
+        io.netty.buffer.ByteBuf byteBuf = io.netty.buffer.Unpooled.buffer();
+        try {
+            FriendlyByteBuf buf = new FriendlyByteBuf(byteBuf);
+            buf.writeVarInt(entityId);
+            buf.writeByte(protocolYaw);
+
+            // Create and send the packet using the registry
+            ClientboundRotateHeadPacket headPacket = ClientboundRotateHeadPacket.STREAM_CODEC.decode(buf);
+            connection.send(headPacket);
+        } finally {
+            byteBuf.release();
+        }
+    }
+
+    @Override
+    public void sendEntityDestroy(Player viewer, int... entityIds) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+
+        ClientboundRemoveEntitiesPacket destroyPacket = new ClientboundRemoveEntitiesPacket(entityIds);
+        connection.send(destroyPacket);
+    }
+
+    @Override
+    public void sendMountPacket(Player viewer, int vehicleId, int... passengerIds) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+
+        // Create mount packet by writing to a buffer
+        io.netty.buffer.ByteBuf byteBuf = io.netty.buffer.Unpooled.buffer();
+        try {
+            net.minecraft.network.FriendlyByteBuf buf = new net.minecraft.network.FriendlyByteBuf(byteBuf);
+
+            // Write vehicle entity ID as VarInt
+            buf.writeVarInt(vehicleId);
+
+            // Write passenger count as VarInt
+            buf.writeVarInt(passengerIds.length);
+
+            // Write each passenger ID as VarInt
+            for (int passengerId : passengerIds) {
+                buf.writeVarInt(passengerId);
+            }
+
+            // Create packet using the buffer constructor
+            ClientboundSetPassengersPacket mountPacket = ClientboundSetPassengersPacket.STREAM_CODEC.decode(buf);
+            connection.send(mountPacket);
+        } catch (Exception e) {
+            Logs.logWarning("Failed to send mount packet: " + e.getMessage());
+            e.printStackTrace();
+        } finally {
+            byteBuf.release();
+        }
+    }
+
+}

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/NMSHandler.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/NMSHandler.java
@@ -155,12 +155,10 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         CustomData oldData = oldItemStack.getComponents().get(type);
         CustomData newData = newNmsItem.getComponents().get(type);
 
-        // Cancels if null.
-        if (oldData == null || newData == null)
+        if (oldData == null)
             return newItem;
-        // Creates new nbt compound.
         CompoundTag oldTag = oldData.copyTag();
-        CompoundTag newTag = newData.copyTag();
+        CompoundTag newTag = newData != null ? newData.copyTag() : new CompoundTag();
 
         for (String key : oldTag.keySet()) {
             if (vanillaKeys.contains(key))

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
@@ -1,0 +1,150 @@
+package io.th0rgal.oraxen.nms.v1_26_R1;
+
+import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent;
+import io.papermc.paper.connection.PlayerConfigurationConnection;
+import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent;
+import io.papermc.paper.event.connection.configuration.PlayerConnectionReconfigureEvent;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.pack.dispatch.PackSender;
+import io.th0rgal.oraxen.pack.receive.PackReceiver;
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import net.kyori.adventure.resource.ResourcePackInfo;
+import net.kyori.adventure.resource.ResourcePackRequest;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class PackDispatchListener implements Listener {
+
+    private final ConcurrentHashMap<UUID, CompletableFuture<Void>> futures = new ConcurrentHashMap<>();
+
+    @EventHandler
+    public void onInitialConfig(@NotNull AsyncPlayerConnectionConfigureEvent event) {
+        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
+
+        UUID uuid = event.getConnection().getProfile().getId();
+        if (uuid == null) return;
+
+        try {
+            CompletableFuture<Void> previous = futures.remove(uuid);
+            if (previous != null) previous.complete(null);
+        } catch (Exception ignored) {
+        }
+
+        CompletableFuture<Void> future = sendResourcePack(event.getConnection(), false);
+        if (future != null) {
+            futures.put(uuid, future);
+            try {
+                future.get(10, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                Logs.logWarning("Timed out while waiting for pre-join resource pack callback for " + uuid);
+                future.cancel(true);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Logs.logWarning("Interrupted while waiting for pre-join resource pack callback for " + uuid);
+                future.cancel(true);
+            } catch (ExecutionException e) {
+                Logs.logWarning("Pre-join resource pack dispatch failed for " + uuid + ": " + e.getMessage());
+                future.cancel(true);
+            } finally {
+                futures.remove(uuid, future);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onReconfig(@NotNull PlayerConnectionReconfigureEvent event) {
+        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
+        if (event.getConnection().getProfile().getId() == null) return;
+        sendResourcePack(event.getConnection(), true);
+    }
+
+    @EventHandler
+    public void onClose(@NotNull PlayerConnectionCloseEvent event) {
+        try {
+            CompletableFuture<Void> future = futures.remove(event.getPlayerUniqueId());
+            if (future != null) future.complete(null);
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Nullable
+    private static CompletableFuture<Void> sendResourcePack(PlayerConfigurationConnection connection, boolean reconfigure) {
+        String packUrl = OraxenPlugin.get().getPackURL();
+        String hash = OraxenPlugin.get().getPackSHA1();
+        if (packUrl == null || hash == null) return null;
+        UUID playerId = connection.getProfile().getId();
+        if (playerId == null) return null;
+
+        UUID packUUID;
+        try {
+            byte[] hashBytes = hashArray(hash);
+            packUUID = UUID.nameUUIDFromBytes(hashBytes);
+        } catch (IllegalArgumentException exception) {
+            Logs.logWarning("Invalid resource pack hash for " + playerId + ": " + hash);
+            return null;
+        }
+        CompletableFuture<Void> future = reconfigure ? null : new CompletableFuture<>();
+
+        java.net.URI packUri;
+        try {
+            packUri = java.net.URI.create(packUrl);
+        } catch (IllegalArgumentException ex) {
+            Logs.logWarning("Invalid resource pack URL for " + packUUID + ": " + packUrl);
+            if (future != null) future.complete(null);
+            else connection.completeReconfiguration();
+            return null;
+        }
+
+        ResourcePackInfo info = ResourcePackInfo.resourcePackInfo()
+                .id(packUUID)
+                .uri(packUri)
+                .hash(hash)
+                .build();
+
+        ResourcePackRequest request = ResourcePackRequest.resourcePackRequest()
+                .required(Settings.SEND_PACK_MANDATORY.toBool())
+                .replace(true)
+                .prompt(AdventureUtils.MINI_MESSAGE.deserialize(Settings.SEND_PACK_PROMPT.toString()))
+                .packs(info)
+                .callback((requestId, status, audience) -> {
+                    PackReceiver.handleAdventureStatus(playerId, status);
+                    if (!status.intermediate()) {
+                        if (future != null) future.complete(null);
+                        else connection.completeReconfiguration();
+                    }
+                })
+                .build();
+
+        connection.getAudience().sendResourcePacks(request);
+        return future;
+    }
+
+    private static byte[] hashArray(String hash) {
+        if (hash == null) throw new IllegalArgumentException("Hash cannot be null");
+        int length = hash.length();
+        if (length % 2 != 0) throw new IllegalArgumentException("Hash length must be even");
+
+        byte[] result = new byte[length / 2];
+        for (int i = 0; i < result.length; i++) {
+            int from = i * 2;
+            String pair = hash.substring(from, from + 2);
+            try {
+                result[i] = (byte) Integer.parseInt(pair, 16);
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Invalid hash byte '" + pair + "' at position " + from, ex);
+            }
+        }
+        return result;
+    }
+}

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
@@ -107,7 +107,6 @@ public final class PackDispatchListener implements Listener {
             packUri = java.net.URI.create(packUrl);
         } catch (IllegalArgumentException ex) {
             Logs.logWarning("Invalid resource pack URL for " + packUUID + ": " + packUrl);
-            future.complete(null);
             return null;
         }
 

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
@@ -64,7 +64,10 @@ public final class PackDispatchListener implements Listener {
 
     @EventHandler
     public void onReconfig(@NotNull PlayerConnectionReconfigureEvent event) {
-        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
+        if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) {
+            event.getConnection().completeReconfiguration();
+            return;
+        }
         if (event.getConnection().getProfile().getId() == null) {
             event.getConnection().completeReconfiguration();
             return;

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
@@ -65,8 +65,14 @@ public final class PackDispatchListener implements Listener {
     @EventHandler
     public void onReconfig(@NotNull PlayerConnectionReconfigureEvent event) {
         if (!PackSender.isPreJoinDispatchActive() || !PackSender.isAnyDispatchEnabled()) return;
-        if (event.getConnection().getProfile().getId() == null) return;
-        sendResourcePack(event.getConnection(), true);
+        if (event.getConnection().getProfile().getId() == null) {
+            event.getConnection().completeReconfiguration();
+            return;
+        }
+        CompletableFuture<Void> future = sendResourcePack(event.getConnection(), true);
+        if (future == null) {
+            event.getConnection().completeReconfiguration();
+        }
     }
 
     @EventHandler
@@ -94,15 +100,15 @@ public final class PackDispatchListener implements Listener {
             Logs.logWarning("Invalid resource pack hash for " + playerId + ": " + hash);
             return null;
         }
-        CompletableFuture<Void> future = reconfigure ? null : new CompletableFuture<>();
+        CompletableFuture<Void> future = new CompletableFuture<>();
 
         java.net.URI packUri;
         try {
             packUri = java.net.URI.create(packUrl);
         } catch (IllegalArgumentException ex) {
             Logs.logWarning("Invalid resource pack URL for " + packUUID + ": " + packUrl);
-            if (future != null) future.complete(null);
-            else connection.completeReconfiguration();
+            future.complete(null);
+            if (reconfigure) connection.completeReconfiguration();
             return null;
         }
 
@@ -120,8 +126,8 @@ public final class PackDispatchListener implements Listener {
                 .callback((requestId, status, audience) -> {
                     PackReceiver.handleAdventureStatus(playerId, status);
                     if (!status.intermediate()) {
-                        if (future != null) future.complete(null);
-                        else connection.completeReconfiguration();
+                        future.complete(null);
+                        if (reconfigure) connection.completeReconfiguration();
                     }
                 })
                 .build();

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/PackDispatchListener.java
@@ -108,7 +108,6 @@ public final class PackDispatchListener implements Listener {
         } catch (IllegalArgumentException ex) {
             Logs.logWarning("Invalid resource pack URL for " + packUUID + ": " + packUrl);
             future.complete(null);
-            if (reconfigure) connection.completeReconfiguration();
             return null;
         }
 

--- a/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/ResourceLocationHelper.java
+++ b/v1_26_R1/src/main/java/io/th0rgal/oraxen/nms/v1_26_R1/ResourceLocationHelper.java
@@ -1,0 +1,76 @@
+package io.th0rgal.oraxen.nms.v1_26_R1;
+
+import java.lang.reflect.Method;
+
+/**
+ * Reflection-based helper to handle the ResourceLocation → Identifier rename
+ * between Minecraft 1.21.10 and 1.21.11.
+ * 
+ * On 1.21.10 and earlier: net.minecraft.resources.ResourceLocation
+ * On 1.21.11+: net.minecraft.resources.Identifier
+ * 
+ * Both classes have the same API (parse(), etc.), just different names.
+ */
+public final class ResourceLocationHelper {
+
+    private static final Class<?> RESOURCE_LOCATION_CLASS;
+    private static final Method PARSE_METHOD;
+
+    static {
+        Class<?> clazz = null;
+        Method parseMethod = null;
+
+        // Try 1.21.11+ Identifier first
+        try {
+            clazz = Class.forName("net.minecraft.resources.Identifier");
+            parseMethod = clazz.getMethod("parse", String.class);
+        } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+            // Fall back to ResourceLocation (1.21.10 and earlier)
+            try {
+                clazz = Class.forName("net.minecraft.resources.ResourceLocation");
+                parseMethod = clazz.getMethod("parse", String.class);
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                throw new RuntimeException("Could not find ResourceLocation or Identifier class", e);
+            }
+        }
+
+        RESOURCE_LOCATION_CLASS = clazz;
+        PARSE_METHOD = parseMethod;
+    }
+
+    private ResourceLocationHelper() {
+        // Utility class
+    }
+
+    /**
+     * Parse a resource location string (e.g., "minecraft:stone") into the
+     * appropriate ResourceLocation/Identifier object for the current server version.
+     * 
+     * @param value the resource location string
+     * @return the parsed object (ResourceLocation on 1.21.10, Identifier on 1.21.11)
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T parse(String value) {
+        try {
+            return (T) PARSE_METHOD.invoke(null, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse resource location: " + value, e);
+        }
+    }
+
+    /**
+     * Get the ResourceLocation/Identifier class for the current server version.
+     * Useful for creating Maps with the correct key type.
+     */
+    public static Class<?> getResourceLocationClass() {
+        return RESOURCE_LOCATION_CLASS;
+    }
+
+    /**
+     * Check if running on 1.21.11+ (Identifier) or earlier (ResourceLocation).
+     */
+    public static boolean usesIdentifier() {
+        return RESOURCE_LOCATION_CLASS.getSimpleName().equals("Identifier");
+    }
+}
+


### PR DESCRIPTION
## 🟠 Minecraft 26.1.1 Support & ViaVersion Support / Fix
- **Summary** - Added full Minecraft `26.1.1` support (including new NMS module, version mapping, and pack protocol updates), validated on Paper `26.1.1`, and implemented a critical shader fix for text visibility.
- **Description** - Oraxen's infrastructure has been updated to handle the `26.1.1` hotfix and the broader `26.x` release line. This includes a new `v1_26_R1` NMS module, support for modern pack format ranges (`min_format`/`max_format`), and a multi-overlay resource pack system that ensures compatibility across 1.20.2–26.x (ViaVersion support).
- **Changes**
  - Added new NMS module `v1_26_R1` and registered it for Paper `26.1` and `26.1.1`.
  - Updated `ProtocolVersion` (775), `PackVersionManager`, and `ResourcePackFormatUtil` with format `84` and `1.26.x` version normalization.
  - Implemented `min_format` and `max_format` fields in `pack.mcmeta` for formats ≥65.
  - Upgraded build tooling to Gradle 9.0, Shadow 9.4.1, and Paperweight `2.0.0-beta.21`.
  - Introduced a robust `ShaderOverlay` enum and expanded supported pack ranges to automatically handle shader differences between client versions.
  - Fixed `/oraxen highest_modeldata` NPE and a reconfiguration hang in `PackDispatchListener`.
  - Optimized `GlyphHandler` by removing redundant `ByteBuf` copies and hardening reflection.
  - **Text visibility hotfix** in `TextShaderGenerator`:
    - Suppressed `rendertype_text*.json` emission for `26.x` as the engine now manages pipeline metadata automatically.
    - Preserved JSON generation for legacy overlay targets (`1.21.4`–`1.21.11`).
    - Switched lightmap sampling to `sample_lightmap(Sampler2, UV2)` and added `#moj_import <minecraft:sample_lightmap.glsl>` for `26.x` shaders.
  - **Multi-version shader overlay system** — complete rewrite of cross-version shader compatibility:
    - Introduced `ShaderOverlay` enum defining four shader format groups: `V1_20_2` (formats 18–45), `V1_21_4` (46–62), `V1_21_6` (63–83), `V26` (84+).
    - `TextShaderGenerator` now generates overlay shaders for **all** format groups except the server's own, enabling a single pack to serve clients from 1.20.2 through 26.x.
    - `TextShaderTarget` constants corrected: `PACK_FORMAT_1_21_6` was `55` (1.21.5 format), now `63` (actual 1.21.6). This previously excluded 1.21.5 clients from the 1.21.4 overlay range.
    - `sample_lightmap` is 26.x-only — 1.21.9–1.21.11 use `texelFetch()` (the `sample_lightmap.glsl` file is an empty placeholder in those versions). Shader generation now correctly uses `texelFetch` for `V1_21_6` and `sample_lightmap` only for `V26`.
  - **Overlay entry `min_format`/`max_format` requirement** (critical for 1.21.9+ clients):
    - Minecraft 1.21.9+ (format ≥65) rejects overlay entries whose format range extends past 64 unless they include `min_format` and `max_format` top-level fields.
    - Overlay entries now include **both** `formats: {min_inclusive, max_inclusive}` (read by 1.20.2–1.21.8) **and** `min_format`/`max_format` integers (read by 1.21.9+), matching the creative-api/Nexo convention.
  - **Stale overlay deduplication** — `addShaderOverlayEntries()` now removes pre-existing Oraxen-generated overlay entries before writing fresh ones, preventing duplicate/invalid entries from persisting across regenerations.
  - **Expanded `supported_formats` range** — the base pack's `supported_formats`/`min_format`/`max_format` is automatically expanded to cover all overlay format ranges, so clients of any version see the pack as compatible. For servers on 1.21.9+ (format ≥65), both `supported_formats` and `min_format`/`max_format` are written so pre-1.21.9 clients can also read the range.
  - Fixed `PackFileCollector.isCoreShaderPath()` regex to match actual overlay directory paths (`overlay_*/assets/minecraft/shaders/core/`).