### PR TITLE
fix: bump foojay-resolver-convention to 1.0.0 for Gradle 9

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ pluginManagement {
 
 plugins {
     // allows for better class redefinitions with run-paper
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary
- Bumps `foojay-resolver-convention` from `0.9.0` to `1.0.0` to fix Gradle 9.0 build failure

## Problem
PR #1806 upgraded Gradle to 9.0 and Shadow to 9.4.1, but the `foojay-resolver-convention` plugin was left at `0.9.0`. Version 0.9.0 references `JvmVendorSpec.IBM_SEMERU`, a constant [removed in Gradle 9.0](https://github.com/gradle/foojay-toolchains/issues/105), causing the build to fail immediately during project configuration:

```
Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member
field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU'
```

## Fix
Version `1.0.0` of the plugin removes the `IBM_SEMERU` reference and is fully compatible with Gradle 9.0+.

## Test plan
- [x] `./gradlew shadowJar` builds successfully with the fix
- [x] `./gradlew :core:test` passes all unit tests
- [x] Plugin loads and runs correctly on Paper 1.21.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build configuration change that only updates a Gradle settings plugin version; primary risk is unexpected toolchain resolution behavior changes in the new plugin release.
> 
> **Overview**
> Updates `settings.gradle.kts` to bump `org.gradle.toolchains.foojay-resolver-convention` from `0.9.0` to `1.0.0`, addressing Gradle 9 compatibility by using the plugin release that removes references to APIs deleted in Gradle 9.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf17d78fb00ab62a0aaa9d3ac2f56c271f62dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->