### PR TITLE
Add pack obfuscation and furniture text displays

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -106,6 +106,7 @@ public enum Settings {
     GENERATE_MODEL_BASED_ON_TEXTURE_PATH("Pack.generation.auto_generated_models_follow_texture_path"),
     COMPRESSION("Pack.generation.compression"),
     PROTECTION("Pack.generation.protection"),
+    PACK_OBFUSCATION_TYPE("Pack.generation.obfuscation.type"),
     // 1.21.4+ appearance systems (can be combined)
     APPEARANCE_ITEM_PROPERTIES("Pack.generation.appearance.item_properties"),
     APPEARANCE_MODEL_DATA_IDS("Pack.generation.appearance.model_data_ids"),

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -102,6 +102,7 @@ public class FurnitureFactory extends MechanicFactory {
     }
 
     static void registerTextEntity(Entity entity, boolean spawnForMissingViewers) {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
         if (mechanic != null && mechanic.hasTextDefinitions()) {
             FurnitureTextEntry previous = FurnitureTextRegistry.byUuid(entity.getUniqueId());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -98,8 +98,11 @@ public class FurnitureFactory extends MechanicFactory {
 
     static void registerTextEntity(Entity entity) {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
-        if (mechanic != null && mechanic.hasTextDefinitions())
+        if (mechanic != null && mechanic.hasTextDefinitions()) {
             FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
+        } else {
+            FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());
+        }
     }
 
     private static final class FurnitureTextLoadListener implements Listener {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -92,11 +92,11 @@ public class FurnitureFactory extends MechanicFactory {
         for (org.bukkit.World world : Bukkit.getWorlds()) {
             world.getEntities().stream()
                     .filter(OraxenFurniture::isBaseEntity)
-                    .forEach(FurnitureFactory::registerLoadedFurnitureText);
+                    .forEach(FurnitureFactory::registerTextEntity);
         }
     }
 
-    private static void registerLoadedFurnitureText(Entity entity) {
+    static void registerTextEntity(Entity entity) {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
         if (mechanic != null && mechanic.hasTextDefinitions())
             FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -8,6 +8,7 @@ import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionTask;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox.JukeboxListener;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextPacketBridge;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,6 +43,7 @@ public class FurnitureFactory extends MechanicFactory {
         evolvingFurnitures = false;
         instance = this;
         FurniturePacketDispatcher.init();
+        FurnitureTextPacketBridge.register();
         customSounds = areCustomSoundsEnabled();
 
         if (customSounds) MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new FurnitureSoundListener());
@@ -95,6 +97,7 @@ public class FurnitureFactory extends MechanicFactory {
         if (evolutionTask != null)
             evolutionTask.cancel();
         FurniturePacketDispatcher.shutdown();
+        FurnitureTextPacketBridge.unregister();
     }
 
     @Override

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture;
 
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicConfigProperty;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
@@ -9,7 +10,10 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.Evoluti
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionTask;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox.JukeboxListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextPacketBridge;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,6 +49,7 @@ public class FurnitureFactory extends MechanicFactory {
         FurniturePacketDispatcher.init();
         FurnitureTextPacketBridge.unregister();
         FurnitureTextPacketBridge.register();
+        registerLoadedFurnitureText();
         customSounds = areCustomSoundsEnabled();
 
         if (customSounds) MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new FurnitureSoundListener());
@@ -78,6 +83,20 @@ public class FurnitureFactory extends MechanicFactory {
 
     public static FurnitureFactory getInstance() {
         return instance;
+    }
+
+    private static void registerLoadedFurnitureText() {
+        for (org.bukkit.World world : Bukkit.getWorlds()) {
+            world.getEntities().stream()
+                    .filter(OraxenFurniture::isBaseEntity)
+                    .forEach(FurnitureFactory::registerLoadedFurnitureText);
+        }
+    }
+
+    private static void registerLoadedFurnitureText(Entity entity) {
+        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
+        if (mechanic != null && mechanic.hasTextDefinitions())
+            FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
     }
 
     public static EvolutionTask getEvolutionTask() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -99,6 +99,9 @@ public class FurnitureFactory extends MechanicFactory {
     static void registerTextEntity(Entity entity) {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
         if (mechanic != null && mechanic.hasTextDefinitions()) {
+            if (!FurnitureTextRegistry.canReuse(entity.getUniqueId(), mechanic.getTextDefinitions().size())) {
+                FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());
+            }
             FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
         } else {
             FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture;
 
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenFurniture;
+import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicConfigProperty;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
@@ -14,6 +15,8 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTex
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,14 +45,14 @@ public class FurnitureFactory extends MechanicFactory {
                 new FurnitureListener(),
                 new FurnitureUpdater(),
                 new EvolutionListener(),
-                new JukeboxListener()
+                new JukeboxListener(),
+                new FurnitureTextLoadListener()
         );
         evolvingFurnitures = false;
         instance = this;
         FurniturePacketDispatcher.init();
         FurnitureTextPacketBridge.unregister();
         FurnitureTextPacketBridge.register();
-        registerLoadedFurnitureText();
         customSounds = areCustomSoundsEnabled();
 
         if (customSounds) MechanicsManager.registerListeners(OraxenPlugin.get(), getMechanicID(), new FurnitureSoundListener());
@@ -97,6 +100,13 @@ public class FurnitureFactory extends MechanicFactory {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
         if (mechanic != null && mechanic.hasTextDefinitions())
             FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
+    }
+
+    private static final class FurnitureTextLoadListener implements Listener {
+        @EventHandler
+        public void onItemsLoaded(OraxenItemsLoadedEvent event) {
+            registerLoadedFurnitureText();
+        }
     }
 
     public static EvolutionTask getEvolutionTask() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -10,6 +10,7 @@ import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolutionTask;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox.JukeboxListener;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextEntry;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextPacketBridge;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
 import org.bukkit.Bukkit;
@@ -99,10 +100,17 @@ public class FurnitureFactory extends MechanicFactory {
     static void registerTextEntity(Entity entity) {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
         if (mechanic != null && mechanic.hasTextDefinitions()) {
-            if (!FurnitureTextRegistry.canReuse(entity.getUniqueId(), mechanic.getTextDefinitions().size())) {
+            FurnitureTextEntry previous = FurnitureTextRegistry.byUuid(entity.getUniqueId());
+            boolean reused = FurnitureTextRegistry.canReuse(entity.getUniqueId(), mechanic.getTextDefinitions().size());
+            if (!reused) {
                 FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());
             }
-            FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
+            FurnitureTextEntry entry = FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
+            if (previous != null && reused) {
+                FurnitureTextPacketBridge.updateTrackedViewers(entry);
+            } else {
+                FurnitureTextPacketBridge.spawnForNearbyViewers(entry);
+            }
         } else {
             FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -113,7 +113,7 @@ public class FurnitureFactory extends MechanicFactory {
             if (previous != null && reused) {
                 FurnitureTextPacketBridge.updateTrackedViewers(entry);
             } else if (spawnForMissingViewers) {
-                FurnitureTextPacketBridge.spawnForWorldViewers(entry);
+                FurnitureTextPacketBridge.spawnForTrackedViewers(entry);
             }
         } else {
             FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -113,7 +113,7 @@ public class FurnitureFactory extends MechanicFactory {
             if (previous != null && reused) {
                 FurnitureTextPacketBridge.updateTrackedViewers(entry);
             } else if (spawnForMissingViewers) {
-                FurnitureTextPacketBridge.spawnForNearbyViewers(entry);
+                FurnitureTextPacketBridge.spawnForWorldViewers(entry);
             }
         } else {
             FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -43,6 +43,7 @@ public class FurnitureFactory extends MechanicFactory {
         evolvingFurnitures = false;
         instance = this;
         FurniturePacketDispatcher.init();
+        FurnitureTextPacketBridge.unregister();
         FurnitureTextPacketBridge.register();
         customSounds = areCustomSoundsEnabled();
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -93,22 +93,26 @@ public class FurnitureFactory extends MechanicFactory {
         for (org.bukkit.World world : Bukkit.getWorlds()) {
             world.getEntities().stream()
                     .filter(OraxenFurniture::isBaseEntity)
-                    .forEach(FurnitureFactory::registerTextEntity);
+                    .forEach(entity -> registerTextEntity(entity, true));
         }
     }
 
     static void registerTextEntity(Entity entity) {
+        registerTextEntity(entity, false);
+    }
+
+    static void registerTextEntity(Entity entity, boolean spawnForMissingViewers) {
         FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
         if (mechanic != null && mechanic.hasTextDefinitions()) {
             FurnitureTextEntry previous = FurnitureTextRegistry.byUuid(entity.getUniqueId());
             boolean reused = FurnitureTextRegistry.canReuse(entity.getUniqueId(), mechanic.getTextDefinitions().size());
-            if (!reused) {
+            if (previous != null && !reused) {
                 FurnitureTextPacketBridge.destroyAndUnregister(entity.getUniqueId());
             }
             FurnitureTextEntry entry = FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
             if (previous != null && reused) {
                 FurnitureTextPacketBridge.updateTrackedViewers(entry);
-            } else {
+            } else if (spawnForMissingViewers) {
                 FurnitureTextPacketBridge.spawnForNearbyViewers(entry);
             }
         } else {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -539,22 +539,12 @@ public class FurnitureMechanic extends Mechanic {
         item.setAmount(1);
 
         boolean registerText = OraxenPlugin.supportsDisplayEntities && hasTextDefinitions();
-        final FurnitureTextEntry[] textEntry = registerText ? new FurnitureTextEntry[1] : null;
         Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing, yaw), entityClass, (e) -> {
             setEntityData(e, yaw, item, resolvedFacing);
-            if (registerText) textEntry[0] = FurnitureTextRegistry.register(e, textDefinitions);
+            if (registerText) FurnitureTextRegistry.register(e, textDefinitions);
         });
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
-        }
-        if (textEntry != null && textEntry[0] != null) {
-            UUID baseUuid = textEntry[0].getBaseUuid();
-            int baseEntityId = textEntry[0].getBaseEntityId();
-            SchedulerUtil.runTaskLater(1L, () -> {
-                FurnitureTextEntry current = FurnitureTextRegistry.byUuid(baseUuid);
-                if (current == null || current.getBaseEntityId() != baseEntityId) return;
-                FurnitureTextPacketBridge.spawnForTrackedViewers(current);
-            });
         }
 
         return baseEntity;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -548,8 +548,12 @@ public class FurnitureMechanic extends Mechanic {
             spawnModelEngineFurniture(baseEntity);
         }
         if (textEntry != null && textEntry[0] != null) {
+            UUID baseUuid = textEntry[0].getBaseUuid();
+            int baseEntityId = textEntry[0].getBaseEntityId();
             SchedulerUtil.runTaskLater(1L, () -> {
-                FurnitureTextPacketBridge.spawnForTrackedViewers(textEntry[0]);
+                FurnitureTextEntry current = FurnitureTextRegistry.byUuid(baseUuid);
+                if (current == null || current.getBaseEntityId() != baseEntityId) return;
+                FurnitureTextPacketBridge.spawnForTrackedViewers(current);
             });
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -526,13 +526,12 @@ public class FurnitureMechanic extends Mechanic {
         }
         item.setAmount(1);
 
-        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing, yaw), entityClass, (e) -> setEntityData(e, yaw, item, resolvedFacing));
+        Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing, yaw), entityClass, (e) -> {
+            setEntityData(e, yaw, item, resolvedFacing);
+            if (hasTextDefinitions()) FurnitureTextRegistry.register(e, textDefinitions);
+        });
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
-        }
-
-        if (hasTextDefinitions()) {
-            FurnitureTextRegistry.register(baseEntity, textDefinitions);
         }
 
         return baseEntity;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -15,6 +15,7 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.Evolvin
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.GrowthStage;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox.JukeboxBlock;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextDefinition;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextEntry;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextPacketBridge;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
@@ -537,12 +538,18 @@ public class FurnitureMechanic extends Mechanic {
         }
         item.setAmount(1);
 
+        final FurnitureTextEntry[] textEntry = new FurnitureTextEntry[1];
         Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing, yaw), entityClass, (e) -> {
             setEntityData(e, yaw, item, resolvedFacing);
-            if (hasTextDefinitions()) FurnitureTextRegistry.register(e, textDefinitions);
+            if (hasTextDefinitions()) textEntry[0] = FurnitureTextRegistry.register(e, textDefinitions);
         });
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
+        }
+        if (textEntry[0] != null) {
+            SchedulerUtil.runTaskLater(1L, () -> {
+                if (textEntry[0].getViewers().isEmpty()) FurnitureTextPacketBridge.spawnForTrackedViewers(textEntry[0]);
+            });
         }
 
         return baseEntity;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -287,15 +287,25 @@ public class FurnitureMechanic extends Mechanic {
                 Object raw = list.get(i);
                 if (raw instanceof Map<?, ?> map) {
                     ConfigurationSection temp = section.createSection("_tmp_text_entity_" + i);
-                    for (Map.Entry<?, ?> entry : map.entrySet()) {
-                        temp.set(entry.getKey().toString(), entry.getValue());
-                    }
+                    copyMapToSection(map, temp);
                     defs.add(FurnitureTextDefinition.parse(temp));
                     section.set("_tmp_text_entity_" + i, null);
                 }
             }
         }
         return defs.isEmpty() ? List.of() : List.copyOf(defs);
+    }
+
+    private static void copyMapToSection(Map<?, ?> map, ConfigurationSection section) {
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            String key = entry.getKey().toString();
+            Object value = entry.getValue();
+            if (value instanceof Map<?, ?> nested) {
+                copyMapToSection(nested, section.createSection(key));
+            } else {
+                section.set(key, value);
+            }
+        }
     }
 
     public boolean hasTextDefinitions() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -548,7 +548,7 @@ public class FurnitureMechanic extends Mechanic {
         }
         if (textEntry[0] != null) {
             SchedulerUtil.runTaskLater(1L, () -> {
-                if (textEntry[0].getViewers().isEmpty()) FurnitureTextPacketBridge.spawnForTrackedViewers(textEntry[0]);
+                FurnitureTextPacketBridge.spawnForTrackedViewers(textEntry[0]);
             });
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -32,6 +32,7 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.entity.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -286,10 +287,9 @@ public class FurnitureMechanic extends Mechanic {
             for (int i = 0; i < list.size(); i++) {
                 Object raw = list.get(i);
                 if (raw instanceof Map<?, ?> map) {
-                    ConfigurationSection temp = section.createSection("_tmp_text_entity_" + i);
+                    ConfigurationSection temp = new MemoryConfiguration();
                     copyMapToSection(map, temp);
                     defs.add(FurnitureTextDefinition.parse(temp));
-                    section.set("_tmp_text_entity_" + i, null);
                 }
             }
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -538,15 +538,16 @@ public class FurnitureMechanic extends Mechanic {
         }
         item.setAmount(1);
 
-        final FurnitureTextEntry[] textEntry = new FurnitureTextEntry[1];
+        boolean registerText = OraxenPlugin.supportsDisplayEntities && hasTextDefinitions();
+        final FurnitureTextEntry[] textEntry = registerText ? new FurnitureTextEntry[1] : null;
         Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing, yaw), entityClass, (e) -> {
             setEntityData(e, yaw, item, resolvedFacing);
-            if (hasTextDefinitions()) textEntry[0] = FurnitureTextRegistry.register(e, textDefinitions);
+            if (registerText) textEntry[0] = FurnitureTextRegistry.register(e, textDefinitions);
         });
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }
-        if (textEntry[0] != null) {
+        if (textEntry != null && textEntry[0] != null) {
             SchedulerUtil.runTaskLater(1L, () -> {
                 FurnitureTextPacketBridge.spawnForTrackedViewers(textEntry[0]);
             });

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -1200,6 +1200,9 @@ public class FurnitureMechanic extends Mechanic {
         Rotation newRotation = rotateClockwise(yawToRotation(yaw));
         if (baseEntity instanceof ItemFrame frame) frame.setRotation(newRotation);
         else baseEntity.setRotation(FurnitureMechanic.rotationToYaw(newRotation), baseEntity.getLocation().getPitch());
+
+        FurnitureTextEntry textEntry = FurnitureTextRegistry.updateBaseEntity(baseEntity);
+        if (textEntry != null) FurnitureTextPacketBridge.respawnTrackedViewers(textEntry);
     }
 
     private Rotation rotateClockwise(Rotation rotation) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -15,6 +15,7 @@ import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.Evolvin
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.GrowthStage;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox.JukeboxBlock;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextDefinition;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextPacketBridge;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.light.LightMechanic;
@@ -540,6 +541,13 @@ public class FurnitureMechanic extends Mechanic {
             setEntityData(e, yaw, item, resolvedFacing);
             if (hasTextDefinitions()) FurnitureTextRegistry.register(e, textDefinitions);
         });
+        if (hasTextDefinitions()) {
+            SchedulerUtil.runTask(() -> {
+                if (baseEntity.isValid()) {
+                    FurnitureTextPacketBridge.spawnForTrackedViewers(FurnitureTextRegistry.byUuid(baseEntity.getUniqueId()));
+                }
+            });
+        }
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -939,10 +939,11 @@ public class FurnitureMechanic extends Mechanic {
     private void removeBaseEntity(Entity baseEntity) {
         if (baseEntity == null) return;
         UUID baseUuid = baseEntity.getUniqueId();
+        int baseEntityId = baseEntity.getEntityId();
         removeSubEntitiesOfFurniture(baseEntity);
         removeLight(baseEntity.getLocation().getBlock());
         if (!baseEntity.isDead()) baseEntity.remove();
-        Bukkit.getScheduler().runTask(OraxenPlugin.get(), () -> FurnitureTextRegistry.unregister(baseUuid));
+        SchedulerUtil.runTask(() -> FurnitureTextRegistry.unregister(baseUuid, baseEntityId));
     }
 
     private void removeSubEntitiesOfFurniture(Entity baseEntity) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -541,13 +541,6 @@ public class FurnitureMechanic extends Mechanic {
             setEntityData(e, yaw, item, resolvedFacing);
             if (hasTextDefinitions()) FurnitureTextRegistry.register(e, textDefinitions);
         });
-        if (hasTextDefinitions()) {
-            SchedulerUtil.runTask(() -> {
-                if (baseEntity.isValid()) {
-                    FurnitureTextPacketBridge.spawnForTrackedViewers(FurnitureTextRegistry.byUuid(baseEntity.getUniqueId()));
-                }
-            });
-        }
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -938,10 +938,11 @@ public class FurnitureMechanic extends Mechanic {
 
     private void removeBaseEntity(Entity baseEntity) {
         if (baseEntity == null) return;
-        FurnitureTextRegistry.unregister(baseEntity.getUniqueId());
+        UUID baseUuid = baseEntity.getUniqueId();
         removeSubEntitiesOfFurniture(baseEntity);
         removeLight(baseEntity.getLocation().getBlock());
         if (!baseEntity.isDead()) baseEntity.remove();
+        Bukkit.getScheduler().runTask(OraxenPlugin.get(), () -> FurnitureTextRegistry.unregister(baseUuid));
     }
 
     private void removeSubEntitiesOfFurniture(Entity baseEntity) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -14,6 +14,8 @@ import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.EvolvingFurniture;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.evolution.GrowthStage;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.jukebox.JukeboxBlock;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextDefinition;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.light.LightMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.limitedplacing.LimitedPlacing;
@@ -86,6 +88,7 @@ public class FurnitureMechanic extends Mechanic {
     private final ArmorStandProperties armorStandProperties;
     private final BlockLockerMechanic blockLocker;
     private final RestrictedRotation restrictedRotation;
+    private final List<FurnitureTextDefinition> textDefinitions;
 
     public record FurnitureHitbox(float width, float height) {
     }
@@ -269,6 +272,38 @@ public class FurnitureMechanic extends Mechanic {
 
         ConfigurationSection blockLockerSection = section.getConfigurationSection("blocklocker");
         blockLocker = blockLockerSection != null ? new BlockLockerMechanic(blockLockerSection) : null;
+
+        textDefinitions = parseTextDefinitions(section);
+    }
+
+    private static List<FurnitureTextDefinition> parseTextDefinitions(ConfigurationSection section) {
+        List<FurnitureTextDefinition> defs = new ArrayList<>();
+        ConfigurationSection single = section.getConfigurationSection("text_entity");
+        if (single != null) defs.add(FurnitureTextDefinition.parse(single));
+
+        List<?> list = section.getList("text_entities");
+        if (list != null) {
+            for (int i = 0; i < list.size(); i++) {
+                Object raw = list.get(i);
+                if (raw instanceof Map<?, ?> map) {
+                    ConfigurationSection temp = section.createSection("_tmp_text_entity_" + i);
+                    for (Map.Entry<?, ?> entry : map.entrySet()) {
+                        temp.set(entry.getKey().toString(), entry.getValue());
+                    }
+                    defs.add(FurnitureTextDefinition.parse(temp));
+                    section.set("_tmp_text_entity_" + i, null);
+                }
+            }
+        }
+        return defs.isEmpty() ? List.of() : List.copyOf(defs);
+    }
+
+    public boolean hasTextDefinitions() {
+        return !textDefinitions.isEmpty();
+    }
+
+    public List<FurnitureTextDefinition> getTextDefinitions() {
+        return textDefinitions;
     }
 
     public boolean isModelEngine() {
@@ -494,6 +529,10 @@ public class FurnitureMechanic extends Mechanic {
         Entity baseEntity = EntityUtils.spawnEntity(correctedSpawnLocation(location, resolvedFacing, yaw), entityClass, (e) -> setEntityData(e, yaw, item, resolvedFacing));
         if (this.isModelEngine() && PluginUtils.isEnabled("ModelEngine")) {
             spawnModelEngineFurniture(baseEntity);
+        }
+
+        if (hasTextDefinitions()) {
+            FurnitureTextRegistry.register(baseEntity, textDefinitions);
         }
 
         return baseEntity;
@@ -890,6 +929,7 @@ public class FurnitureMechanic extends Mechanic {
 
     private void removeBaseEntity(Entity baseEntity) {
         if (baseEntity == null) return;
+        FurnitureTextRegistry.unregister(baseEntity.getUniqueId());
         removeSubEntitiesOfFurniture(baseEntity);
         removeLight(baseEntity.getLocation().getBlock());
         if (!baseEntity.isDead()) baseEntity.remove();

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -25,27 +25,19 @@ import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureM
 public class FurnitureUpdater implements Listener {
 
     public FurnitureUpdater() {
-        if (!Settings.UPDATE_FURNITURE.toBool()) return;
-        if (Settings.UPDATE_FURNITURE_ON_LOAD.toBool()) {
-            Bukkit.getPluginManager().registerEvent(EntitiesLoadEvent.class, this, EventPriority.NORMAL, (listener, event) ->
-                    {
-                        if (!FurnitureFactory.isEnabled()) return;
-                        ((EntitiesLoadEvent) event).getEntities().stream().filter(OraxenFurniture::isBaseEntity).forEach(entity -> {
+        Bukkit.getPluginManager().registerEvent(EntitiesLoadEvent.class, this, EventPriority.NORMAL, (listener, event) ->
+                {
+                    if (!FurnitureFactory.isEnabled()) return;
+                    ((EntitiesLoadEvent) event).getEntities().stream().filter(OraxenFurniture::isBaseEntity).forEach(entity -> {
+                        if (Settings.UPDATE_FURNITURE.toBool() && Settings.UPDATE_FURNITURE_ON_LOAD.toBool()) {
                             OraxenFurniture.updateFurniture(entity);
-                            registerTextEntity(entity);
-                        });
-                    }
-                    , OraxenPlugin.get());
-        } else {
-            Bukkit.getPluginManager().registerEvent(EntitiesLoadEvent.class, this, EventPriority.NORMAL, (listener, event) ->
-                    {
-                        if (!FurnitureFactory.isEnabled()) return;
-                        ((EntitiesLoadEvent) event).getEntities().stream().filter(OraxenFurniture::isBaseEntity).forEach(FurnitureUpdater::registerTextEntity);
-                    }
-                    , OraxenPlugin.get());
-        }
+                        }
+                        registerTextEntity(entity);
+                    });
+                }
+                , OraxenPlugin.get());
 
-        if (Settings.EXPERIMENTAL_FIX_BROKEN_FURNITURE.toBool()) {
+        if (Settings.UPDATE_FURNITURE.toBool() && Settings.EXPERIMENTAL_FIX_BROKEN_FURNITURE.toBool()) {
             Bukkit.getPluginManager().registerEvent(ChunkLoadEvent.class, this, EventPriority.NORMAL, ((listener, event) -> {
                 if (!FurnitureFactory.isEnabled()) return;
                 for (Block block : CustomBlockData.getBlocksWithCustomData(OraxenPlugin.get(), ((ChunkLoadEvent) event).getChunk())) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -17,6 +17,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.EntitiesLoadEvent;
+import org.bukkit.event.world.EntitiesUnloadEvent;
 import org.bukkit.persistence.PersistentDataType;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.ORIENTATION_KEY;
@@ -34,6 +35,15 @@ public class FurnitureUpdater implements Listener {
                         }
                         if (entity.isValid()) registerTextEntity(entity);
                     });
+                }
+                , OraxenPlugin.get());
+
+        Bukkit.getPluginManager().registerEvent(EntitiesUnloadEvent.class, this, EventPriority.NORMAL, (listener, event) ->
+                {
+                    if (!FurnitureFactory.isEnabled()) return;
+                    ((EntitiesUnloadEvent) event).getEntities().stream()
+                            .filter(OraxenFurniture::isBaseEntity)
+                            .forEach(entity -> FurnitureTextRegistry.unregister(entity.getUniqueId()));
                 }
                 , OraxenPlugin.get());
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -36,7 +36,7 @@ public class FurnitureUpdater implements Listener {
                         if (Settings.UPDATE_FURNITURE.toBool() && Settings.UPDATE_FURNITURE_ON_LOAD.toBool()) {
                             OraxenFurniture.updateFurniture(entity);
                         }
-                        if (entity.isValid()) registerTextEntity(entity);
+                        if (entity.isValid()) FurnitureFactory.registerTextEntity(entity);
                     });
                 }
                 , OraxenPlugin.get());
@@ -82,9 +82,4 @@ public class FurnitureUpdater implements Listener {
         }
     }
 
-    private static void registerTextEntity(Entity entity) {
-        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
-        if (mechanic != null && mechanic.hasTextDefinitions())
-            FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
-    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -32,7 +32,7 @@ public class FurnitureUpdater implements Listener {
                         if (Settings.UPDATE_FURNITURE.toBool() && Settings.UPDATE_FURNITURE_ON_LOAD.toBool()) {
                             OraxenFurniture.updateFurniture(entity);
                         }
-                        registerTextEntity(entity);
+                        if (entity.isValid()) registerTextEntity(entity);
                     });
                 }
                 , OraxenPlugin.get());

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -5,6 +5,7 @@ import com.jeff_media.morepersistentdatatypes.DataType;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
 import io.th0rgal.oraxen.utils.BlockHelpers;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -29,7 +30,17 @@ public class FurnitureUpdater implements Listener {
             Bukkit.getPluginManager().registerEvent(EntitiesLoadEvent.class, this, EventPriority.NORMAL, (listener, event) ->
                     {
                         if (!FurnitureFactory.isEnabled()) return;
-                        ((EntitiesLoadEvent) event).getEntities().stream().filter(OraxenFurniture::isBaseEntity).forEach(OraxenFurniture::updateFurniture);
+                        ((EntitiesLoadEvent) event).getEntities().stream().filter(OraxenFurniture::isBaseEntity).forEach(entity -> {
+                            OraxenFurniture.updateFurniture(entity);
+                            registerTextEntity(entity);
+                        });
+                    }
+                    , OraxenPlugin.get());
+        } else {
+            Bukkit.getPluginManager().registerEvent(EntitiesLoadEvent.class, this, EventPriority.NORMAL, (listener, event) ->
+                    {
+                        if (!FurnitureFactory.isEnabled()) return;
+                        ((EntitiesLoadEvent) event).getEntities().stream().filter(OraxenFurniture::isBaseEntity).forEach(FurnitureUpdater::registerTextEntity);
                     }
                     , OraxenPlugin.get());
         }
@@ -60,5 +71,11 @@ public class FurnitureUpdater implements Listener {
                 }
             }), OraxenPlugin.get());
         }
+    }
+
+    private static void registerTextEntity(Entity entity) {
+        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
+        if (mechanic != null && mechanic.hasTextDefinitions())
+            FurnitureTextRegistry.register(entity, mechanic.getTextDefinitions());
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -43,7 +43,9 @@ public class FurnitureUpdater implements Listener {
                     if (!FurnitureFactory.isEnabled()) return;
                     ((EntitiesUnloadEvent) event).getEntities().stream()
                             .filter(OraxenFurniture::isBaseEntity)
-                            .forEach(entity -> FurnitureTextRegistry.unregister(entity.getUniqueId()));
+                            .map(Entity::getUniqueId)
+                            .forEach(uuid -> Bukkit.getScheduler().runTask(OraxenPlugin.get(),
+                                    () -> FurnitureTextRegistry.unregister(uuid)));
                 }
                 , OraxenPlugin.get());
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureUpdater.java
@@ -7,6 +7,7 @@ import io.th0rgal.oraxen.api.OraxenFurniture;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text.FurnitureTextRegistry;
 import io.th0rgal.oraxen.utils.BlockHelpers;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -19,6 +20,8 @@ import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.EntitiesLoadEvent;
 import org.bukkit.event.world.EntitiesUnloadEvent;
 import org.bukkit.persistence.PersistentDataType;
+
+import java.util.UUID;
 
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.ORIENTATION_KEY;
 import static io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic.ROOT_KEY;
@@ -43,9 +46,11 @@ public class FurnitureUpdater implements Listener {
                     if (!FurnitureFactory.isEnabled()) return;
                     ((EntitiesUnloadEvent) event).getEntities().stream()
                             .filter(OraxenFurniture::isBaseEntity)
-                            .map(Entity::getUniqueId)
-                            .forEach(uuid -> Bukkit.getScheduler().runTask(OraxenPlugin.get(),
-                                    () -> FurnitureTextRegistry.unregister(uuid)));
+                            .forEach(entity -> {
+                                UUID uuid = entity.getUniqueId();
+                                int entityId = entity.getEntityId();
+                                SchedulerUtil.runTask(() -> FurnitureTextRegistry.unregister(uuid, entityId));
+                            });
                 }
                 , OraxenPlugin.get());
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
@@ -1,0 +1,203 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
+
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.utils.PluginUtils;
+import net.kyori.adventure.text.Component;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.joml.Vector3f;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Parsed configuration for a single virtual text entity attached to a furniture base.
+ *
+ * <p>The text is rendered client-side via packet-spawned TextDisplay entities;
+ * no real entities are created server-side, so chunk saves, collisions, and
+ * AI tick costs are all avoided.</p>
+ */
+public final class FurnitureTextDefinition {
+
+    public enum Alignment { CENTER, LEFT, RIGHT }
+    public enum Billboard { FIXED, VERTICAL, HORIZONTAL, CENTER }
+
+    private final List<String> rawLines;
+    private final int lineWidth;
+    private final int backgroundArgb;
+    private final byte textOpacity;
+    private final boolean seeThrough;
+    private final boolean shadow;
+    private final boolean defaultBackground;
+    private final Alignment alignment;
+    private final Billboard billboard;
+    private final Vector3f translation;
+    private final Vector3f scale;
+    private final float viewRange;
+    private final int refreshTicks;
+    private final boolean usesPlaceholders;
+
+    private FurnitureTextDefinition(List<String> rawLines,
+                                     int lineWidth,
+                                     int backgroundArgb,
+                                     byte textOpacity,
+                                     boolean seeThrough,
+                                     boolean shadow,
+                                     boolean defaultBackground,
+                                     Alignment alignment,
+                                     Billboard billboard,
+                                     Vector3f translation,
+                                     Vector3f scale,
+                                     float viewRange,
+                                     int refreshTicks,
+                                     boolean usesPlaceholders) {
+        this.rawLines = rawLines;
+        this.lineWidth = lineWidth;
+        this.backgroundArgb = backgroundArgb;
+        this.textOpacity = textOpacity;
+        this.seeThrough = seeThrough;
+        this.shadow = shadow;
+        this.defaultBackground = defaultBackground;
+        this.alignment = alignment;
+        this.billboard = billboard;
+        this.translation = translation;
+        this.scale = scale;
+        this.viewRange = viewRange;
+        this.refreshTicks = refreshTicks;
+        this.usesPlaceholders = usesPlaceholders;
+    }
+
+    public static FurnitureTextDefinition parse(ConfigurationSection section) {
+        List<String> lines = new ArrayList<>();
+        if (section.isList("text")) {
+            for (Object entry : section.getList("text", new ArrayList<>())) {
+                if (entry != null) lines.add(entry.toString());
+            }
+        } else if (section.isString("text")) {
+            String raw = section.getString("text", "");
+            lines.addAll(Arrays.asList(raw.split("\\n")));
+        }
+
+        int lineWidth = section.getInt("line_width", 200);
+        int backgroundArgb = parseColor(section.getString("background_color", "#40000000"));
+        byte textOpacity = (byte) Math.max(-1, Math.min(127, section.getInt("text_opacity", -1)));
+        boolean seeThrough = section.getBoolean("see_through", false);
+        boolean shadow = section.getBoolean("shadow", false);
+        boolean defaultBackground = section.getBoolean("default_background", false);
+        Alignment alignment = parseAlignment(section.getString("alignment", "CENTER"));
+        Billboard billboard = parseBillboard(section.getString("billboard", "CENTER"));
+
+        Vector3f translation = readVector(section, "offset", new Vector3f(0f, 0.6f, 0f));
+        Vector3f scale = readVector(section, "scale", new Vector3f(1f, 1f, 1f));
+
+        float viewRange = (float) section.getDouble("view_range", 32.0);
+        int refreshTicks = Math.max(0, section.getInt("refresh_ticks", 0));
+
+        boolean usesPlaceholders = refreshTicks > 0
+                || lines.stream().anyMatch(line -> line.contains("%") || line.contains("{"));
+
+        return new FurnitureTextDefinition(
+                List.copyOf(lines),
+                lineWidth,
+                backgroundArgb,
+                textOpacity,
+                seeThrough,
+                shadow,
+                defaultBackground,
+                alignment,
+                billboard,
+                translation,
+                scale,
+                viewRange,
+                refreshTicks,
+                usesPlaceholders
+        );
+    }
+
+    private static Vector3f readVector(ConfigurationSection section, String path, Vector3f fallback) {
+        ConfigurationSection sub = section.getConfigurationSection(path);
+        if (sub != null) {
+            return new Vector3f(
+                    (float) sub.getDouble("x", fallback.x),
+                    (float) sub.getDouble("y", fallback.y),
+                    (float) sub.getDouble("z", fallback.z)
+            );
+        }
+        Object raw = section.get(path);
+        if (raw instanceof List<?> list && list.size() == 3) {
+            return new Vector3f(
+                    ((Number) list.get(0)).floatValue(),
+                    ((Number) list.get(1)).floatValue(),
+                    ((Number) list.get(2)).floatValue()
+            );
+        }
+        return new Vector3f(fallback);
+    }
+
+    private static Alignment parseAlignment(String value) {
+        if (value == null) return Alignment.CENTER;
+        try {
+            return Alignment.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return Alignment.CENTER;
+        }
+    }
+
+    private static Billboard parseBillboard(String value) {
+        if (value == null) return Billboard.CENTER;
+        try {
+            return Billboard.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return Billboard.CENTER;
+        }
+    }
+
+    private static int parseColor(String raw) {
+        if (raw == null || raw.isEmpty()) return 0x40000000;
+        String s = raw.trim();
+        if (s.startsWith("#")) s = s.substring(1);
+        try {
+            if (s.length() == 6) {
+                // RGB → add 0x40 alpha by default for visibility
+                return 0x40000000 | Integer.parseUnsignedInt(s, 16);
+            }
+            if (s.length() == 8) {
+                return Integer.parseUnsignedInt(s, 16);
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        return 0x40000000;
+    }
+
+    public Component renderComponent(@org.jetbrains.annotations.Nullable Player viewer) {
+        if (rawLines.isEmpty()) return Component.empty();
+        boolean papi = viewer != null && PluginUtils.isEnabled("PlaceholderAPI");
+        Component result = null;
+        for (String rawLine : rawLines) {
+            String expanded = papi
+                    ? me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(viewer, rawLine)
+                    : rawLine;
+            Component line = viewer != null
+                    ? AdventureUtils.MINI_MESSAGE_PLAYER(viewer).deserialize(expanded)
+                    : AdventureUtils.MINI_MESSAGE.deserialize(expanded);
+            result = result == null ? line : result.append(Component.newline()).append(line);
+        }
+        return result == null ? Component.empty() : result;
+    }
+
+    public int getLineWidth() { return lineWidth; }
+    public int getBackgroundArgb() { return backgroundArgb; }
+    public byte getTextOpacity() { return textOpacity; }
+    public boolean isSeeThrough() { return seeThrough; }
+    public boolean hasShadow() { return shadow; }
+    public boolean hasDefaultBackground() { return defaultBackground; }
+    public Alignment getAlignment() { return alignment; }
+    public Billboard getBillboard() { return billboard; }
+    public Vector3f getTranslation() { return new Vector3f(translation); }
+    public Vector3f getScale() { return new Vector3f(scale); }
+    public float getViewRange() { return viewRange; }
+    public int getRefreshTicks() { return refreshTicks; }
+    public boolean usesPlaceholders() { return usesPlaceholders; }
+    public List<String> getRawLines() { return rawLines; }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
@@ -12,11 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Parsed configuration for a single virtual text entity attached to a furniture base.
- *
- * <p>The text is rendered client-side via packet-spawned TextDisplay entities;
- * no real entities are created server-side, so chunk saves, collisions, and
- * AI tick costs are all avoided.</p>
+ * Parsed configuration for a single text entity attached to a furniture base.
  */
 public final class FurnitureTextDefinition {
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
@@ -81,7 +81,8 @@ public final class FurnitureTextDefinition {
 
         int lineWidth = section.getInt("line_width", 200);
         int backgroundArgb = parseColor(section.getString("background_color", "#40000000"));
-        byte textOpacity = (byte) Math.max(-1, Math.min(127, section.getInt("text_opacity", -1)));
+        int rawTextOpacity = section.getInt("text_opacity", -1);
+        byte textOpacity = (byte) (rawTextOpacity < 0 ? -1 : Math.min(255, rawTextOpacity));
         boolean seeThrough = section.getBoolean("see_through", false);
         boolean shadow = section.getBoolean("shadow", false);
         boolean defaultBackground = section.getBoolean("default_background", false);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
@@ -137,13 +137,28 @@ public final class FurnitureTextDefinition {
         }
         Object raw = section.get(path);
         if (raw instanceof List<?> list && list.size() == 3) {
+            Float x = parseFloat(list.get(0));
+            Float y = parseFloat(list.get(1));
+            Float z = parseFloat(list.get(2));
+            if (x == null || y == null || z == null) return new Vector3f(fallback);
             return new Vector3f(
-                    ((Number) list.get(0)).floatValue(),
-                    ((Number) list.get(1)).floatValue(),
-                    ((Number) list.get(2)).floatValue()
+                    x,
+                    y,
+                    z
             );
         }
         return new Vector3f(fallback);
+    }
+
+    private static Float parseFloat(Object value) {
+        if (value instanceof Number number) return number.floatValue();
+        if (value instanceof String string) {
+            try {
+                return Float.parseFloat(string);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return null;
     }
 
     private static Alignment parseAlignment(String value) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextDefinition.java
@@ -96,7 +96,7 @@ public final class FurnitureTextDefinition {
         int refreshTicks = Math.max(0, section.getInt("refresh_ticks", 0));
 
         boolean usesPlaceholders = refreshTicks > 0
-                || lines.stream().anyMatch(line -> line.contains("%") || line.contains("{"));
+                || lines.stream().anyMatch(FurnitureTextDefinition::hasPlaceholderToken);
 
         return new FurnitureTextDefinition(
                 List.copyOf(lines),
@@ -114,6 +114,16 @@ public final class FurnitureTextDefinition {
                 refreshTicks,
                 usesPlaceholders
         );
+    }
+
+    private static boolean hasPlaceholderToken(String line) {
+        int start = line.indexOf('%');
+        while (start >= 0) {
+            int end = line.indexOf('%', start + 1);
+            if (end > start + 1) return true;
+            start = end;
+        }
+        return false;
     }
 
     private static Vector3f readVector(ConfigurationSection section, String path, Vector3f fallback) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -1,6 +1,14 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.util.Transformation;
+import org.joml.AxisAngle4f;
+import org.joml.Vector3f;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,10 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Runtime registration entry for a placed furniture base that has one or more
- * virtual text displays attached to it.
- *
- * <p>Each entry owns a stable set of "virtual" entity IDs drawn from a negative
- * id range to avoid any chance of colliding with real server-assigned ids.</p>
+ * text displays attached to it.
  */
 public final class FurnitureTextEntry {
 
@@ -26,6 +31,7 @@ public final class FurnitureTextEntry {
     private final List<FurnitureTextDefinition> definitions;
     private final int[] virtualEntityIds;
     private final UUID[] virtualUuids;
+    private final UUID[] textEntityUuids;
     private final Set<UUID> viewers = ConcurrentHashMap.newKeySet();
 
     public FurnitureTextEntry(UUID baseUuid,
@@ -38,6 +44,7 @@ public final class FurnitureTextEntry {
         this.definitions = definitions;
         this.virtualEntityIds = new int[definitions.size()];
         this.virtualUuids = new UUID[definitions.size()];
+        this.textEntityUuids = new UUID[definitions.size()];
         for (int i = 0; i < definitions.size(); i++) {
             virtualEntityIds[i] = VIRTUAL_ID_COUNTER.getAndDecrement();
             virtualUuids[i] = UUID.randomUUID();
@@ -54,6 +61,7 @@ public final class FurnitureTextEntry {
         this.definitions = definitions;
         this.virtualEntityIds = Arrays.copyOf(previous.virtualEntityIds, previous.virtualEntityIds.length);
         this.virtualUuids = Arrays.copyOf(previous.virtualUuids, previous.virtualUuids.length);
+        this.textEntityUuids = new UUID[definitions.size()];
         this.viewers.addAll(previous.viewers);
     }
 
@@ -68,6 +76,71 @@ public final class FurnitureTextEntry {
     public void addViewer(UUID viewer) { if (viewer != null) viewers.add(viewer); }
     public void removeViewer(UUID viewer) { if (viewer != null) viewers.remove(viewer); }
     public Set<UUID> getViewers() { return Set.copyOf(viewers); }
+
+    public void spawnTextDisplays() {
+        if (baseLocation.getWorld() == null) return;
+        removeTextDisplays();
+        for (int i = 0; i < definitions.size(); i++) {
+            FurnitureTextDefinition definition = definitions.get(i);
+            Vector3f offset = definition.getTranslation();
+            Location textLocation = baseLocation.clone().add(offset.x, offset.y, offset.z);
+            TextDisplay display = baseLocation.getWorld().spawn(textLocation, TextDisplay.class, text -> {
+                applyDefinition(text, definition);
+                text.setPersistent(false);
+                text.setInvulnerable(true);
+                text.setGravity(false);
+            });
+            textEntityUuids[i] = display.getUniqueId();
+        }
+    }
+
+    public void updateTextDisplays() {
+        for (int i = 0; i < textEntityUuids.length; i++) {
+            UUID uuid = textEntityUuids[i];
+            if (uuid == null) continue;
+            Entity entity = Bukkit.getEntity(uuid);
+            if (entity instanceof TextDisplay text && !text.isDead()) applyDefinition(text, definitions.get(i));
+        }
+    }
+
+    public void removeTextDisplays() {
+        for (int i = 0; i < textEntityUuids.length; i++) {
+            UUID uuid = textEntityUuids[i];
+            if (uuid == null) continue;
+            Entity entity = Bukkit.getEntity(uuid);
+            if (entity != null && !entity.isDead()) entity.remove();
+            textEntityUuids[i] = null;
+        }
+    }
+
+    private static void applyDefinition(TextDisplay text, FurnitureTextDefinition definition) {
+        text.text(definition.renderComponent(null));
+        text.setLineWidth(definition.getLineWidth());
+        text.setBackgroundColor(Color.fromARGB(definition.getBackgroundArgb()));
+        text.setTextOpacity(definition.getTextOpacity());
+        text.setShadowed(definition.hasShadow());
+        text.setSeeThrough(definition.isSeeThrough());
+        text.setDefaultBackground(definition.hasDefaultBackground());
+        text.setAlignment(switch (definition.getAlignment()) {
+            case LEFT -> TextDisplay.TextAlignment.LEFT;
+            case RIGHT -> TextDisplay.TextAlignment.RIGHT;
+            case CENTER -> TextDisplay.TextAlignment.CENTER;
+        });
+        text.setBillboard(switch (definition.getBillboard()) {
+            case FIXED -> Display.Billboard.FIXED;
+            case VERTICAL -> Display.Billboard.VERTICAL;
+            case HORIZONTAL -> Display.Billboard.HORIZONTAL;
+            case CENTER -> Display.Billboard.CENTER;
+        });
+        Vector3f scale = definition.getScale();
+        text.setTransformation(new Transformation(
+                new Vector3f(),
+                new AxisAngle4f(),
+                new Vector3f(scale.x, scale.y, scale.z),
+                new AxisAngle4f()
+        ));
+        text.setViewRange(definition.getViewRange());
+    }
 
     public boolean needsRefresh() {
         for (FurnitureTextDefinition definition : definitions) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -65,9 +65,18 @@ public final class FurnitureTextEntry {
 
     public boolean shouldRefresh(long tick) {
         for (FurnitureTextDefinition definition : definitions) {
-            int refreshTicks = definition.getRefreshTicks() > 0 ? definition.getRefreshTicks() : (definition.usesPlaceholders() ? 20 : 0);
+            int refreshTicks = refreshInterval(definition);
             if (refreshTicks > 0 && tick % refreshTicks == 0) return true;
         }
         return false;
+    }
+
+    public boolean shouldRefresh(FurnitureTextDefinition definition, long tick) {
+        int refreshTicks = refreshInterval(definition);
+        return refreshTicks > 0 && tick % refreshTicks == 0;
+    }
+
+    private static int refreshInterval(FurnitureTextDefinition definition) {
+        return definition.getRefreshTicks() > 0 ? definition.getRefreshTicks() : (definition.usesPlaceholders() ? 20 : 0);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -44,6 +44,19 @@ public final class FurnitureTextEntry {
         }
     }
 
+    FurnitureTextEntry(FurnitureTextEntry previous,
+                       int baseEntityId,
+                       Location baseLocation,
+                       List<FurnitureTextDefinition> definitions) {
+        this.baseUuid = previous.baseUuid;
+        this.baseEntityId = baseEntityId;
+        this.baseLocation = baseLocation.clone();
+        this.definitions = definitions;
+        this.virtualEntityIds = Arrays.copyOf(previous.virtualEntityIds, previous.virtualEntityIds.length);
+        this.virtualUuids = Arrays.copyOf(previous.virtualUuids, previous.virtualUuids.length);
+        this.viewers.addAll(previous.viewers);
+    }
+
     public UUID getBaseUuid() { return baseUuid; }
     public int getBaseEntityId() { return baseEntityId; }
     public Location getBaseLocation() { return baseLocation.clone(); }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -1,14 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
 import org.bukkit.Location;
-import org.bukkit.entity.Display;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.TextDisplay;
-import org.bukkit.util.Transformation;
-import org.joml.AxisAngle4f;
-import org.joml.Vector3f;
 
 import java.util.Arrays;
 import java.util.List;
@@ -23,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class FurnitureTextEntry {
 
-    private static final AtomicInteger VIRTUAL_ID_COUNTER = new AtomicInteger(-1_000_000_000);
+    private static final AtomicInteger VIRTUAL_ID_COUNTER = new AtomicInteger(20_000);
 
     private final UUID baseUuid;
     private final int baseEntityId;
@@ -31,7 +23,6 @@ public final class FurnitureTextEntry {
     private final List<FurnitureTextDefinition> definitions;
     private final int[] virtualEntityIds;
     private final UUID[] virtualUuids;
-    private final UUID[] textEntityUuids;
     private final Set<UUID> viewers = ConcurrentHashMap.newKeySet();
 
     public FurnitureTextEntry(UUID baseUuid,
@@ -44,9 +35,8 @@ public final class FurnitureTextEntry {
         this.definitions = definitions;
         this.virtualEntityIds = new int[definitions.size()];
         this.virtualUuids = new UUID[definitions.size()];
-        this.textEntityUuids = new UUID[definitions.size()];
         for (int i = 0; i < definitions.size(); i++) {
-            virtualEntityIds[i] = VIRTUAL_ID_COUNTER.getAndDecrement();
+            virtualEntityIds[i] = VIRTUAL_ID_COUNTER.getAndIncrement();
             virtualUuids[i] = UUID.randomUUID();
         }
     }
@@ -61,7 +51,6 @@ public final class FurnitureTextEntry {
         this.definitions = definitions;
         this.virtualEntityIds = Arrays.copyOf(previous.virtualEntityIds, previous.virtualEntityIds.length);
         this.virtualUuids = Arrays.copyOf(previous.virtualUuids, previous.virtualUuids.length);
-        this.textEntityUuids = new UUID[definitions.size()];
         this.viewers.addAll(previous.viewers);
     }
 
@@ -76,71 +65,6 @@ public final class FurnitureTextEntry {
     public void addViewer(UUID viewer) { if (viewer != null) viewers.add(viewer); }
     public void removeViewer(UUID viewer) { if (viewer != null) viewers.remove(viewer); }
     public Set<UUID> getViewers() { return Set.copyOf(viewers); }
-
-    public void spawnTextDisplays() {
-        if (baseLocation.getWorld() == null) return;
-        removeTextDisplays();
-        for (int i = 0; i < definitions.size(); i++) {
-            FurnitureTextDefinition definition = definitions.get(i);
-            Vector3f offset = definition.getTranslation();
-            Location textLocation = baseLocation.clone().add(offset.x, offset.y, offset.z);
-            TextDisplay display = baseLocation.getWorld().spawn(textLocation, TextDisplay.class, text -> {
-                applyDefinition(text, definition);
-                text.setPersistent(false);
-                text.setInvulnerable(true);
-                text.setGravity(false);
-            });
-            textEntityUuids[i] = display.getUniqueId();
-        }
-    }
-
-    public void updateTextDisplays() {
-        for (int i = 0; i < textEntityUuids.length; i++) {
-            UUID uuid = textEntityUuids[i];
-            if (uuid == null) continue;
-            Entity entity = Bukkit.getEntity(uuid);
-            if (entity instanceof TextDisplay text && !text.isDead()) applyDefinition(text, definitions.get(i));
-        }
-    }
-
-    public void removeTextDisplays() {
-        for (int i = 0; i < textEntityUuids.length; i++) {
-            UUID uuid = textEntityUuids[i];
-            if (uuid == null) continue;
-            Entity entity = Bukkit.getEntity(uuid);
-            if (entity != null && !entity.isDead()) entity.remove();
-            textEntityUuids[i] = null;
-        }
-    }
-
-    private static void applyDefinition(TextDisplay text, FurnitureTextDefinition definition) {
-        text.text(definition.renderComponent(null));
-        text.setLineWidth(definition.getLineWidth());
-        text.setBackgroundColor(Color.fromARGB(definition.getBackgroundArgb()));
-        text.setTextOpacity(definition.getTextOpacity());
-        text.setShadowed(definition.hasShadow());
-        text.setSeeThrough(definition.isSeeThrough());
-        text.setDefaultBackground(definition.hasDefaultBackground());
-        text.setAlignment(switch (definition.getAlignment()) {
-            case LEFT -> TextDisplay.TextAlignment.LEFT;
-            case RIGHT -> TextDisplay.TextAlignment.RIGHT;
-            case CENTER -> TextDisplay.TextAlignment.CENTER;
-        });
-        text.setBillboard(switch (definition.getBillboard()) {
-            case FIXED -> Display.Billboard.FIXED;
-            case VERTICAL -> Display.Billboard.VERTICAL;
-            case HORIZONTAL -> Display.Billboard.HORIZONTAL;
-            case CENTER -> Display.Billboard.CENTER;
-        });
-        Vector3f scale = definition.getScale();
-        text.setTransformation(new Transformation(
-                new Vector3f(),
-                new AxisAngle4f(),
-                new Vector3f(scale.x, scale.y, scale.z),
-                new AxisAngle4f()
-        ));
-        text.setViewRange(definition.getViewRange());
-    }
 
     public boolean needsRefresh() {
         for (FurnitureTextDefinition definition : definitions) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -20,7 +20,7 @@ public final class FurnitureTextEntry {
 
     private final UUID baseUuid;
     private final int baseEntityId;
-    private final Location baseLocation;
+    private volatile Location baseLocation;
     private final List<FurnitureTextDefinition> definitions;
     private final int[] virtualEntityIds;
     private final UUID[] virtualUuids;
@@ -58,6 +58,9 @@ public final class FurnitureTextEntry {
     public UUID getBaseUuid() { return baseUuid; }
     public int getBaseEntityId() { return baseEntityId; }
     public Location getBaseLocation() { return baseLocation.clone(); }
+    public void updateBaseLocation(Location location) {
+        if (location != null) baseLocation = location.clone();
+    }
     public List<FurnitureTextDefinition> getDefinitions() { return definitions; }
     public int[] getVirtualEntityIds() { return Arrays.copyOf(virtualEntityIds, virtualEntityIds.length); }
     public UUID virtualUuid(int index) { return virtualUuids[index]; }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -1,0 +1,73 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
+
+import org.bukkit.Location;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Runtime registration entry for a placed furniture base that has one or more
+ * virtual text displays attached to it.
+ *
+ * <p>Each entry owns a stable set of "virtual" entity IDs drawn from a negative
+ * id range to avoid any chance of colliding with real server-assigned ids.</p>
+ */
+public final class FurnitureTextEntry {
+
+    private static final AtomicInteger VIRTUAL_ID_COUNTER = new AtomicInteger(-1_000_000_000);
+
+    private final UUID baseUuid;
+    private final int baseEntityId;
+    private final Location baseLocation;
+    private final List<FurnitureTextDefinition> definitions;
+    private final int[] virtualEntityIds;
+    private final UUID[] virtualUuids;
+    private final Set<UUID> viewers = ConcurrentHashMap.newKeySet();
+
+    public FurnitureTextEntry(UUID baseUuid,
+                               int baseEntityId,
+                               Location baseLocation,
+                               List<FurnitureTextDefinition> definitions) {
+        this.baseUuid = baseUuid;
+        this.baseEntityId = baseEntityId;
+        this.baseLocation = baseLocation.clone();
+        this.definitions = definitions;
+        this.virtualEntityIds = new int[definitions.size()];
+        this.virtualUuids = new UUID[definitions.size()];
+        for (int i = 0; i < definitions.size(); i++) {
+            virtualEntityIds[i] = VIRTUAL_ID_COUNTER.getAndDecrement();
+            virtualUuids[i] = UUID.randomUUID();
+        }
+    }
+
+    public UUID getBaseUuid() { return baseUuid; }
+    public int getBaseEntityId() { return baseEntityId; }
+    public Location getBaseLocation() { return baseLocation.clone(); }
+    public List<FurnitureTextDefinition> getDefinitions() { return definitions; }
+    public int[] getVirtualEntityIds() { return Arrays.copyOf(virtualEntityIds, virtualEntityIds.length); }
+    public UUID virtualUuid(int index) { return virtualUuids[index]; }
+    public int virtualEntityId(int index) { return virtualEntityIds[index]; }
+    public int size() { return definitions.size(); }
+    public void addViewer(UUID viewer) { if (viewer != null) viewers.add(viewer); }
+    public void removeViewer(UUID viewer) { if (viewer != null) viewers.remove(viewer); }
+    public Set<UUID> getViewers() { return Set.copyOf(viewers); }
+
+    public boolean needsRefresh() {
+        for (FurnitureTextDefinition definition : definitions) {
+            if (definition.getRefreshTicks() > 0 || definition.usesPlaceholders()) return true;
+        }
+        return false;
+    }
+
+    public boolean shouldRefresh(long tick) {
+        for (FurnitureTextDefinition definition : definitions) {
+            int refreshTicks = definition.getRefreshTicks() > 0 ? definition.getRefreshTicks() : (definition.usesPlaceholders() ? 20 : 0);
+            if (refreshTicks > 0 && tick % refreshTicks == 0) return true;
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextEntry.java
@@ -1,12 +1,12 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
+import io.th0rgal.oraxen.nms.NMSHandlers;
 import org.bukkit.Location;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -15,7 +15,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class FurnitureTextEntry {
 
-    private static final AtomicInteger VIRTUAL_ID_COUNTER = new AtomicInteger(20_000);
+    private static final int FALLBACK_VIRTUAL_ID_START = Integer.MAX_VALUE / 2;
+    private static int fallbackVirtualId = FALLBACK_VIRTUAL_ID_START;
 
     private final UUID baseUuid;
     private final int baseEntityId;
@@ -36,7 +37,7 @@ public final class FurnitureTextEntry {
         this.virtualEntityIds = new int[definitions.size()];
         this.virtualUuids = new UUID[definitions.size()];
         for (int i = 0; i < definitions.size(); i++) {
-            virtualEntityIds[i] = VIRTUAL_ID_COUNTER.getAndIncrement();
+            virtualEntityIds[i] = nextVirtualEntityId();
             virtualUuids[i] = UUID.randomUUID();
         }
     }
@@ -88,5 +89,11 @@ public final class FurnitureTextEntry {
 
     private static int refreshInterval(FurnitureTextDefinition definition) {
         return definition.getRefreshTicks() > 0 ? definition.getRefreshTicks() : (definition.usesPlaceholders() ? 20 : 0);
+    }
+
+    private static synchronized int nextVirtualEntityId() {
+        int entityId = NMSHandlers.getHandler().getNextEntityId();
+        if (entityId != -1) return entityId;
+        return --fallbackVirtualId;
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -1,0 +1,53 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import io.th0rgal.oraxen.packets.PacketAdapter;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
+
+/**
+ * Thin bridge that registers/unregisters the furniture text packet listener.
+ *
+ * <p>Isolated in its own class so that {@link FurnitureTextPacketListener} is not
+ * referenced (and therefore not class-loaded) on servers that don't have
+ * PacketEvents installed.</p>
+ */
+public final class FurnitureTextPacketBridge {
+
+    private static PacketListenerCommon registered;
+    private static FurnitureTextPacketListener listener;
+    private static SchedulerUtil.ScheduledTask refreshTask;
+    private static long tick;
+
+    private FurnitureTextPacketBridge() {
+    }
+
+    public static void register() {
+        if (registered != null) return;
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        listener = new FurnitureTextPacketListener();
+        registered = PacketEvents.getAPI().getEventManager()
+                .registerListener(listener, PacketListenerPriority.NORMAL);
+        refreshTask = SchedulerUtil.runTaskTimer(1L, 1L, () -> {
+            FurnitureTextPacketListener activeListener = listener;
+            if (activeListener != null) activeListener.refresh(++tick);
+        });
+    }
+
+    public static void unregister() {
+        if (refreshTask != null) {
+            refreshTask.cancel();
+            refreshTask = null;
+        }
+        if (registered == null) return;
+        try {
+            PacketEvents.getAPI().getEventManager().unregisterListener(registered);
+        } catch (Throwable ignored) {
+        }
+        registered = null;
+        listener = null;
+        tick = 0L;
+        FurnitureTextRegistry.clear();
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -15,11 +15,13 @@ public final class FurnitureTextPacketBridge {
     }
 
     public static void unregister() {
-        FurnitureTextRegistry.clear();
-        if (!PacketAdapter.isPacketEventsEnabled()) return;
-        try {
-            FurnitureTextPacketRegistration.unregister();
-        } catch (NoClassDefFoundError ignored) {
+        if (PacketAdapter.isPacketEventsEnabled()) {
+            try {
+                FurnitureTextPacketRegistration.destroyRegisteredTextEntities();
+                FurnitureTextPacketRegistration.unregister();
+            } catch (NoClassDefFoundError ignored) {
+            }
         }
+        FurnitureTextRegistry.clear();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -38,10 +38,10 @@ public final class FurnitureTextPacketBridge {
         FurnitureTextRegistry.unregister(uuid);
     }
 
-    public static void spawnForWorldViewers(FurnitureTextEntry entry) {
+    public static void spawnForTrackedViewers(FurnitureTextEntry entry) {
         if (!PacketAdapter.isPacketEventsEnabled()) return;
         try {
-            FurnitureTextPacketRegistration.spawnForWorldViewers(entry);
+            FurnitureTextPacketRegistration.spawnForTrackedViewers(entry);
         } catch (NoClassDefFoundError ignored) {
         }
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -40,7 +40,12 @@ public final class FurnitureTextPacketBridge {
             refreshTask.cancel();
             refreshTask = null;
         }
-        if (registered == null) return;
+        FurnitureTextRegistry.clear();
+        if (registered == null) {
+            listener = null;
+            tick = 0L;
+            return;
+        }
         try {
             PacketEvents.getAPI().getEventManager().unregisterListener(registered);
         } catch (Throwable ignored) {
@@ -48,6 +53,5 @@ public final class FurnitureTextPacketBridge {
         registered = null;
         listener = null;
         tick = 0L;
-        FurnitureTextRegistry.clear();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -37,4 +37,20 @@ public final class FurnitureTextPacketBridge {
         }
         FurnitureTextRegistry.unregister(uuid);
     }
+
+    public static void spawnForNearbyViewers(FurnitureTextEntry entry) {
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        try {
+            FurnitureTextPacketRegistration.spawnForNearbyViewers(entry);
+        } catch (NoClassDefFoundError ignored) {
+        }
+    }
+
+    public static void updateTrackedViewers(FurnitureTextEntry entry) {
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        try {
+            FurnitureTextPacketRegistration.updateTrackedViewers(entry);
+        } catch (NoClassDefFoundError ignored) {
+        }
+    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.packets.PacketAdapter;
 
 public final class FurnitureTextPacketBridge {
@@ -8,6 +9,7 @@ public final class FurnitureTextPacketBridge {
     }
 
     public static void register() {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
         if (!PacketAdapter.isPacketEventsEnabled()) return;
         FurnitureTextPacketRegistration.register();
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -38,10 +38,10 @@ public final class FurnitureTextPacketBridge {
         FurnitureTextRegistry.unregister(uuid);
     }
 
-    public static void spawnForNearbyViewers(FurnitureTextEntry entry) {
+    public static void spawnForWorldViewers(FurnitureTextEntry entry) {
         if (!PacketAdapter.isPacketEventsEnabled()) return;
         try {
-            FurnitureTextPacketRegistration.spawnForNearbyViewers(entry);
+            FurnitureTextPacketRegistration.spawnForWorldViewers(entry);
         } catch (NoClassDefFoundError ignored) {
         }
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -1,8 +1,5 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
-import io.th0rgal.oraxen.OraxenPlugin;
-import io.th0rgal.oraxen.packets.PacketAdapter;
-
 import java.util.UUID;
 
 public final class FurnitureTextPacketBridge {
@@ -11,50 +8,20 @@ public final class FurnitureTextPacketBridge {
     }
 
     public static void register() {
-        if (!OraxenPlugin.supportsDisplayEntities) return;
-        if (!PacketAdapter.isPacketEventsEnabled()) return;
-        FurnitureTextPacketRegistration.register();
     }
 
     public static void unregister() {
-        if (PacketAdapter.isPacketEventsEnabled()) {
-            try {
-                FurnitureTextPacketRegistration.destroyRegisteredTextEntities();
-                FurnitureTextPacketRegistration.unregister();
-            } catch (NoClassDefFoundError ignored) {
-            }
-        }
         FurnitureTextRegistry.clear();
     }
 
     public static void destroyAndUnregister(UUID uuid) {
-        FurnitureTextEntry entry = FurnitureTextRegistry.byUuid(uuid);
-        if (PacketAdapter.isPacketEventsEnabled()) {
-            try {
-                FurnitureTextPacketRegistration.destroyTextEntry(entry);
-            } catch (NoClassDefFoundError ignored) {
-            }
-        }
         FurnitureTextRegistry.unregister(uuid);
     }
 
     public static void spawnForTrackedViewers(FurnitureTextEntry entry) {
-        if (!OraxenPlugin.supportsDisplayEntities) return;
-        if (!PacketAdapter.isPacketEventsEnabled()) return;
-        try {
-            FurnitureTextPacketRegistration.register();
-            FurnitureTextPacketRegistration.spawnForTrackedViewers(entry);
-        } catch (NoClassDefFoundError ignored) {
-        }
     }
 
     public static void updateTrackedViewers(FurnitureTextEntry entry) {
-        if (!OraxenPlugin.supportsDisplayEntities) return;
-        if (!PacketAdapter.isPacketEventsEnabled()) return;
-        try {
-            FurnitureTextPacketRegistration.register();
-            FurnitureTextPacketRegistration.updateTrackedViewers(entry);
-        } catch (NoClassDefFoundError ignored) {
-        }
+        if (entry != null) entry.updateTextDisplays();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -3,6 +3,8 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.packets.PacketAdapter;
 
+import java.util.UUID;
+
 public final class FurnitureTextPacketBridge {
 
     private FurnitureTextPacketBridge() {
@@ -23,5 +25,16 @@ public final class FurnitureTextPacketBridge {
             }
         }
         FurnitureTextRegistry.clear();
+    }
+
+    public static void destroyAndUnregister(UUID uuid) {
+        FurnitureTextEntry entry = FurnitureTextRegistry.byUuid(uuid);
+        if (PacketAdapter.isPacketEventsEnabled()) {
+            try {
+                FurnitureTextPacketRegistration.destroyTextEntry(entry);
+            } catch (NoClassDefFoundError ignored) {
+            }
+        }
+        FurnitureTextRegistry.unregister(uuid);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -39,16 +39,20 @@ public final class FurnitureTextPacketBridge {
     }
 
     public static void spawnForTrackedViewers(FurnitureTextEntry entry) {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
         if (!PacketAdapter.isPacketEventsEnabled()) return;
         try {
+            FurnitureTextPacketRegistration.register();
             FurnitureTextPacketRegistration.spawnForTrackedViewers(entry);
         } catch (NoClassDefFoundError ignored) {
         }
     }
 
     public static void updateTrackedViewers(FurnitureTextEntry entry) {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
         if (!PacketAdapter.isPacketEventsEnabled()) return;
         try {
+            FurnitureTextPacketRegistration.register();
             FurnitureTextPacketRegistration.updateTrackedViewers(entry);
         } catch (NoClassDefFoundError ignored) {
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -1,5 +1,8 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.packets.PacketAdapter;
+
 import java.util.UUID;
 
 public final class FurnitureTextPacketBridge {
@@ -8,20 +11,50 @@ public final class FurnitureTextPacketBridge {
     }
 
     public static void register() {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        FurnitureTextPacketRegistration.register();
     }
 
     public static void unregister() {
+        if (PacketAdapter.isPacketEventsEnabled()) {
+            try {
+                FurnitureTextPacketRegistration.destroyRegisteredTextEntities();
+                FurnitureTextPacketRegistration.unregister();
+            } catch (NoClassDefFoundError ignored) {
+            }
+        }
         FurnitureTextRegistry.clear();
     }
 
     public static void destroyAndUnregister(UUID uuid) {
+        FurnitureTextEntry entry = FurnitureTextRegistry.byUuid(uuid);
+        if (PacketAdapter.isPacketEventsEnabled()) {
+            try {
+                FurnitureTextPacketRegistration.destroyTextEntry(entry);
+            } catch (NoClassDefFoundError ignored) {
+            }
+        }
         FurnitureTextRegistry.unregister(uuid);
     }
 
     public static void spawnForTrackedViewers(FurnitureTextEntry entry) {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        try {
+            FurnitureTextPacketRegistration.register();
+            FurnitureTextPacketRegistration.spawnForTrackedViewers(entry);
+        } catch (NoClassDefFoundError ignored) {
+        }
     }
 
     public static void updateTrackedViewers(FurnitureTextEntry entry) {
-        if (entry != null) entry.updateTextDisplays();
+        if (!OraxenPlugin.supportsDisplayEntities) return;
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        try {
+            FurnitureTextPacketRegistration.register();
+            FurnitureTextPacketRegistration.updateTrackedViewers(entry);
+        } catch (NoClassDefFoundError ignored) {
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -57,4 +57,15 @@ public final class FurnitureTextPacketBridge {
         } catch (NoClassDefFoundError ignored) {
         }
     }
+
+    public static void respawnTrackedViewers(FurnitureTextEntry entry) {
+        if (!OraxenPlugin.supportsDisplayEntities) return;
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
+        try {
+            FurnitureTextPacketRegistration.register();
+            FurnitureTextPacketRegistration.destroyTextEntry(entry);
+            FurnitureTextPacketRegistration.spawnForTrackedViewers(entry);
+        } catch (NoClassDefFoundError ignored) {
+        }
+    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketBridge.java
@@ -1,57 +1,23 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
-import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.event.PacketListenerCommon;
-import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import io.th0rgal.oraxen.packets.PacketAdapter;
-import io.th0rgal.oraxen.utils.SchedulerUtil;
 
-/**
- * Thin bridge that registers/unregisters the furniture text packet listener.
- *
- * <p>Isolated in its own class so that {@link FurnitureTextPacketListener} is not
- * referenced (and therefore not class-loaded) on servers that don't have
- * PacketEvents installed.</p>
- */
 public final class FurnitureTextPacketBridge {
-
-    private static PacketListenerCommon registered;
-    private static FurnitureTextPacketListener listener;
-    private static SchedulerUtil.ScheduledTask refreshTask;
-    private static long tick;
 
     private FurnitureTextPacketBridge() {
     }
 
     public static void register() {
-        if (registered != null) return;
         if (!PacketAdapter.isPacketEventsEnabled()) return;
-        listener = new FurnitureTextPacketListener();
-        registered = PacketEvents.getAPI().getEventManager()
-                .registerListener(listener, PacketListenerPriority.NORMAL);
-        refreshTask = SchedulerUtil.runTaskTimer(1L, 1L, () -> {
-            FurnitureTextPacketListener activeListener = listener;
-            if (activeListener != null) activeListener.refresh(++tick);
-        });
+        FurnitureTextPacketRegistration.register();
     }
 
     public static void unregister() {
-        if (refreshTask != null) {
-            refreshTask.cancel();
-            refreshTask = null;
-        }
         FurnitureTextRegistry.clear();
-        if (registered == null) {
-            listener = null;
-            tick = 0L;
-            return;
-        }
+        if (!PacketAdapter.isPacketEventsEnabled()) return;
         try {
-            PacketEvents.getAPI().getEventManager().unregisterListener(registered);
-        } catch (Throwable ignored) {
+            FurnitureTextPacketRegistration.unregister();
+        } catch (NoClassDefFoundError ignored) {
         }
-        registered = null;
-        listener = null;
-        tick = 0L;
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -100,18 +100,17 @@ public class FurnitureTextPacketListener implements PacketListener {
     }
 
     private void sendTextEntry(FurnitureTextEntry entry, Player viewer, User user, int baseEntityId, Vector3d basePos) {
-        List<Integer> passengerIds = new ArrayList<>(entry.size());
-
         for (int i = 0; i < entry.size(); i++) {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
             int virtualId = entry.virtualEntityId(i);
             UUID virtualUuid = entry.virtualUuid(i);
+            Vector3f offset = convertVector(def.getTranslation());
 
             WrapperPlayServerSpawnEntity textSpawn = new WrapperPlayServerSpawnEntity(
                     virtualId,
                     virtualUuid,
                     EntityTypes.TEXT_DISPLAY,
-                    new Location(basePos.x, basePos.y, basePos.z, 0f, 0f),
+                    new Location(basePos.x + offset.x, basePos.y + offset.y, basePos.z + offset.z, 0f, 0f),
                     0f,
                     0,
                     null
@@ -124,16 +123,6 @@ public class FurnitureTextPacketListener implements PacketListener {
 
             sendPacket(user, viewer, textSpawn);
             sendPacket(user, viewer, textMeta);
-            passengerIds.add(virtualId);
-        }
-
-        if (!passengerIds.isEmpty()) {
-            int[] virtualIds = new int[passengerIds.size()];
-            for (int i = 0; i < virtualIds.length; i++) virtualIds[i] = passengerIds.get(i);
-            int[] ids = user == null ? appendUnique(currentPassengerIds(entry), virtualIds) : virtualIds;
-
-            WrapperPlayServerSetPassengers setPassengers = new WrapperPlayServerSetPassengers(baseEntityId, ids);
-            sendPacket(user, viewer, setPassengers);
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -169,14 +169,15 @@ public class FurnitureTextPacketListener implements PacketListener {
 
             for (UUID viewerId : entry.getViewers()) {
                 Player viewer = Bukkit.getPlayer(viewerId);
-                if (viewer == null || !viewer.isOnline() || !isWithinRange(entry, viewer)) {
+                if (viewer == null || !viewer.isOnline()) {
                     entry.removeViewer(viewerId);
                     continue;
                 }
+                if (!isWithinRange(entry, viewer)) continue;
 
                 for (int i = 0; i < entry.size(); i++) {
                     FurnitureTextDefinition def = entry.getDefinitions().get(i);
-                    if (def.getRefreshTicks() <= 0 && !def.usesPlaceholders()) continue;
+                    if (!entry.shouldRefresh(def, tick)) continue;
                     PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
                             new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
                 }
@@ -225,7 +226,7 @@ public class FurnitureTextPacketListener implements PacketListener {
             case CENTER -> (byte) 3;
         };
         data.add(new EntityData<>(DATA_DISPLAY_BILLBOARD, EntityDataTypes.BYTE, billboard));
-        data.add(new EntityData<>(DATA_DISPLAY_VIEW_RANGE, EntityDataTypes.FLOAT, def.getViewRange()));
+        data.add(new EntityData<>(DATA_DISPLAY_VIEW_RANGE, EntityDataTypes.FLOAT, def.getViewRange() / 64.0f));
 
         Component text = def.renderComponent(viewer);
         data.add(new EntityData<>(DATA_TEXT_DISPLAY_TEXT, EntityDataTypes.ADV_COMPONENT, text));

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -48,6 +48,7 @@ public class FurnitureTextPacketListener implements PacketListener {
 
     @Override
     public void onPacketSend(PacketSendEvent event) {
+        if (event.isCancelled()) return;
         if (FurnitureTextRegistry.isEmpty()) return;
 
         if (event.getPacketType() == PacketType.Play.Server.SPAWN_ENTITY) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -8,36 +8,35 @@ import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.protocol.world.Location;
-import com.github.retrooper.packetevents.util.Quaternion4f;
 import com.github.retrooper.packetevents.util.Vector3d;
 import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDestroyEntities;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
+import io.th0rgal.oraxen.utils.AdventureUtils;
+import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.VersionUtil;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * PacketEvents listener that appends virtual text-display entities to furniture
- * when it is spawned client-side, and destroys them when the base entity is
- * destroyed client-side.
+ * PacketEvents listener that spawns virtual text-display entities beside
+ * furniture when it is spawned client-side, and destroys them when the base
+ * entity is destroyed client-side.
  *
  * <p>No real entities are created server-side; we simply ride on top of the
  * server's existing visibility/tracker logic for the base furniture entity.</p>
  */
 public class FurnitureTextPacketListener implements PacketListener {
 
-    private static final int DATA_SHARED_FLAGS = 0;
+    private static final int DATA_NO_GRAVITY = 5;
     private static final MetadataIndices DATA = MetadataIndices.current();
 
     private static final byte FLAG_SHADOW = 0x01;
@@ -55,8 +54,6 @@ public class FurnitureTextPacketListener implements PacketListener {
             handleSpawn(event);
         } else if (event.getPacketType() == PacketType.Play.Server.DESTROY_ENTITIES) {
             handleDestroy(event);
-        } else if (event.getPacketType() == PacketType.Play.Server.SET_PASSENGERS) {
-            handlePassengers(event);
         }
     }
 
@@ -74,7 +71,7 @@ public class FurnitureTextPacketListener implements PacketListener {
         if (viewer != null) entry.addViewer(viewer.getUniqueId());
 
         Vector3d basePos = spawn.getPosition();
-        sendTextEntry(entry, viewer, user, basePos);
+        SchedulerUtil.runTaskLater(1L, () -> sendTextEntry(entry, viewer, null, basePos));
     }
 
     void sendTextEntry(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
@@ -92,25 +89,40 @@ public class FurnitureTextPacketListener implements PacketListener {
         entry.addViewer(viewer.getUniqueId());
         for (int i = 0; i < entry.size(); i++) {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
+            Component text = def.renderComponent(viewer);
+            if (NMSHandlers.getHandler().sendTextDisplayMetadata(viewer, entry.virtualEntityId(i), text,
+                    billboardByte(def), def.getViewRange(), def.getBackgroundArgb(), textFlags(def))) {
+                continue;
+            }
             PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
                     new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
         }
     }
 
-    private void sendTextEntry(FurnitureTextEntry entry, Player viewer, User user, Vector3d basePos) {
+    private void sendTextEntry(FurnitureTextEntry entry, Player viewer, User user, Vector3d packetBasePos) {
+        org.bukkit.Location baseLocation = entry.getBaseLocation();
+        float pitch = baseLocation.getPitch();
+        float yaw = baseLocation.getYaw();
         for (int i = 0; i < entry.size(); i++) {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
             int virtualId = entry.virtualEntityId(i);
             UUID virtualUuid = entry.virtualUuid(i);
+            Vector3f offset = convertVector(def.getTranslation());
+            Vector3d basePos = packetBasePos != null
+                    ? packetBasePos
+                    : new Vector3d(baseLocation.getX(), baseLocation.getY(), baseLocation.getZ());
+            Vector3d textPos = new Vector3d(basePos.x + offset.x, basePos.y + offset.y, basePos.z + offset.z);
 
             WrapperPlayServerSpawnEntity textSpawn = new WrapperPlayServerSpawnEntity(
                     virtualId,
-                    virtualUuid,
+                    Optional.of(virtualUuid),
                     EntityTypes.TEXT_DISPLAY,
-                    new Location(basePos.x, basePos.y, basePos.z, 0f, 0f),
+                    textPos,
+                    pitch,
+                    yaw,
                     0f,
                     0,
-                    null
+                    Optional.of(new Vector3d(0.0, 0.0, 0.0))
             );
 
             WrapperPlayServerEntityMetadata textMeta = new WrapperPlayServerEntityMetadata(
@@ -118,8 +130,15 @@ public class FurnitureTextPacketListener implements PacketListener {
                     buildMetadata(def, viewer)
             );
 
+            Component text = def.renderComponent(viewer);
+            org.bukkit.Location textLocation = new org.bukkit.Location(baseLocation.getWorld(), textPos.x, textPos.y, textPos.z, yaw, pitch);
+            if (viewer != null && NMSHandlers.getHandler().spawnTextDisplay(viewer, virtualId, virtualUuid, textLocation,
+                    text, billboardByte(def), def.getViewRange(), def.getBackgroundArgb(), textFlags(def))) {
+                continue;
+            }
+
             sendPacket(user, viewer, textSpawn);
-            sendPacket(user, viewer, textMeta);
+            SchedulerUtil.runTaskLater(1L, () -> sendPacket(user, viewer, textMeta));
         }
     }
 
@@ -163,16 +182,6 @@ public class FurnitureTextPacketListener implements PacketListener {
         event.markForReEncode(true);
     }
 
-    private void handlePassengers(PacketSendEvent event) {
-        WrapperPlayServerSetPassengers passengers = new WrapperPlayServerSetPassengers(event);
-        FurnitureTextEntry entry = FurnitureTextRegistry.byEntityId(passengers.getEntityId());
-        if (entry == null) return;
-
-        int[] combined = appendUnique(passengers.getPassengers(), entry.getVirtualEntityIds());
-        passengers.setPassengers(combined);
-        event.markForReEncode(true);
-    }
-
     void refresh(long tick) {
         if (!FurnitureTextRegistry.hasRefreshableEntries()) return;
 
@@ -190,6 +199,11 @@ public class FurnitureTextPacketListener implements PacketListener {
                 for (int i = 0; i < entry.size(); i++) {
                     FurnitureTextDefinition def = entry.getDefinitions().get(i);
                     if (!entry.shouldRefresh(def, tick)) continue;
+                    Component text = def.renderComponent(viewer);
+                    if (NMSHandlers.getHandler().sendTextDisplayMetadata(viewer, entry.virtualEntityId(i), text,
+                            billboardByte(def), def.getViewRange(), def.getBackgroundArgb(), textFlags(def))) {
+                        continue;
+                    }
                     PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
                             new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
                 }
@@ -210,43 +224,48 @@ public class FurnitureTextPacketListener implements PacketListener {
         return baseLocation.distanceSquared(viewer.getLocation()) <= range * range;
     }
 
-    private static int[] appendUnique(int[] base, int[] extra) {
-        Set<Integer> ids = new LinkedHashSet<>();
-        if (base != null) for (int id : base) ids.add(id);
-        for (int id : extra) ids.add(id);
-        int[] combined = new int[ids.size()];
-        int index = 0;
-        for (int id : ids) combined[index++] = id;
-        return combined;
-    }
-
     List<EntityData<?>> buildMetadata(FurnitureTextDefinition def, Player viewer) {
         List<EntityData<?>> data = new ArrayList<>(8);
 
-        data.add(new EntityData<>(DATA_SHARED_FLAGS, EntityDataTypes.BYTE, (byte) 0));
+        data.add(new EntityData<>(DATA_NO_GRAVITY, EntityDataTypes.BOOLEAN, true));
 
-        Vector3f translation = convertVector(def.getTranslation());
         Vector3f scale = convertVector(def.getScale());
-        data.add(new EntityData<>(DATA.displayTranslation, EntityDataTypes.VECTOR3F, translation));
-        data.add(new EntityData<>(DATA.displayScale, EntityDataTypes.VECTOR3F, scale));
-        data.add(new EntityData<>(DATA.displayLeftRotation, EntityDataTypes.QUATERNION,
-                new Quaternion4f(0f, 0f, 0f, 1f)));
+        if (scale.x != 1f || scale.y != 1f || scale.z != 1f) {
+            data.add(new EntityData<>(DATA.displayScale, EntityDataTypes.VECTOR3F, scale));
+        }
 
-        byte billboard = switch (def.getBillboard()) {
+        byte billboard = billboardByte(def);
+        data.add(new EntityData<>(DATA.displayBillboard, EntityDataTypes.BYTE, billboard));
+        data.add(new EntityData<>(DATA.displayViewRange, EntityDataTypes.FLOAT, def.getViewRange()));
+
+        Component text = def.renderComponent(viewer);
+        data.add(new EntityData<>(DATA.textDisplayText, EntityDataTypes.COMPONENT, AdventureUtils.GSON_SERIALIZER.serialize(text)));
+        if (def.getLineWidth() != 200) {
+            data.add(new EntityData<>(DATA.textDisplayLineWidth, EntityDataTypes.INT, def.getLineWidth()));
+        }
+        if (def.getBackgroundArgb() != 0x40000000) {
+            data.add(new EntityData<>(DATA.textDisplayBackground, EntityDataTypes.INT, def.getBackgroundArgb()));
+        }
+        if (def.getTextOpacity() != (byte) -1) {
+            data.add(new EntityData<>(DATA.textDisplayOpacity, EntityDataTypes.BYTE, def.getTextOpacity()));
+        }
+
+        byte flags = textFlags(def);
+        if (flags != 0) data.add(new EntityData<>(DATA.textDisplayFlags, EntityDataTypes.BYTE, flags));
+
+        return data;
+    }
+
+    private static byte billboardByte(FurnitureTextDefinition def) {
+        return switch (def.getBillboard()) {
             case FIXED -> (byte) 0;
             case VERTICAL -> (byte) 1;
             case HORIZONTAL -> (byte) 2;
             case CENTER -> (byte) 3;
         };
-        data.add(new EntityData<>(DATA.displayBillboard, EntityDataTypes.BYTE, billboard));
-        data.add(new EntityData<>(DATA.displayViewRange, EntityDataTypes.FLOAT, def.getViewRange() / 64.0f));
+    }
 
-        Component text = def.renderComponent(viewer);
-        data.add(new EntityData<>(DATA.textDisplayText, EntityDataTypes.ADV_COMPONENT, text));
-        data.add(new EntityData<>(DATA.textDisplayLineWidth, EntityDataTypes.INT, def.getLineWidth()));
-        data.add(new EntityData<>(DATA.textDisplayBackground, EntityDataTypes.INT, def.getBackgroundArgb()));
-        data.add(new EntityData<>(DATA.textDisplayOpacity, EntityDataTypes.BYTE, def.getTextOpacity()));
-
+    private static byte textFlags(FurnitureTextDefinition def) {
         byte flags = 0;
         if (def.hasShadow()) flags |= FLAG_SHADOW;
         if (def.isSeeThrough()) flags |= FLAG_SEE_THROUGH;
@@ -256,9 +275,7 @@ public class FurnitureTextPacketListener implements PacketListener {
             case RIGHT -> flags |= FLAG_ALIGN_RIGHT;
             case CENTER -> { /* default */ }
         }
-        data.add(new EntityData<>(DATA.textDisplayFlags, EntityDataTypes.BYTE, flags));
-
-        return data;
+        return flags;
     }
 
     private static Vector3f convertVector(org.joml.Vector3f v) {
@@ -271,9 +288,7 @@ public class FurnitureTextPacketListener implements PacketListener {
     }
 
     private static final class MetadataIndices {
-        private final int displayTranslation;
         private final int displayScale;
-        private final int displayLeftRotation;
         private final int displayBillboard;
         private final int displayViewRange;
         private final int textDisplayText;
@@ -283,9 +298,7 @@ public class FurnitureTextPacketListener implements PacketListener {
         private final int textDisplayFlags;
 
         private MetadataIndices(int offset) {
-            this.displayTranslation = 11 + offset;
             this.displayScale = 12 + offset;
-            this.displayLeftRotation = 13 + offset;
             this.displayBillboard = 15 + offset;
             this.displayViewRange = 17 + offset;
             this.textDisplayText = 23 + offset;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -79,10 +79,6 @@ public class FurnitureTextPacketListener implements PacketListener {
         sendTextEntry(entry, viewer, user, baseEntityId, basePos);
     }
 
-    void sendTextEntry(FurnitureTextEntry entry, Player viewer) {
-        sendTextEntry(entry, viewer, false);
-    }
-
     void sendTextEntry(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
         if (entry == null || viewer == null || !viewer.isOnline()) return;
         if (!ignoreRange && !isWithinRange(entry, viewer)) return;
@@ -90,10 +86,6 @@ public class FurnitureTextPacketListener implements PacketListener {
         org.bukkit.Location location = entry.getBaseLocation();
         Vector3d basePos = new Vector3d(location.getX(), location.getY(), location.getZ());
         sendTextEntry(entry, viewer, null, entry.getBaseEntityId(), basePos);
-    }
-
-    void sendTextMetadata(FurnitureTextEntry entry, Player viewer) {
-        sendTextMetadata(entry, viewer, false);
     }
 
     void sendTextMetadata(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -198,7 +198,8 @@ public class FurnitureTextPacketListener implements PacketListener {
     }
 
     static boolean isWithinRange(FurnitureTextEntry entry, Player viewer) {
-        if (entry.getBaseLocation().getWorld() == null || !entry.getBaseLocation().getWorld().equals(viewer.getWorld())) {
+        org.bukkit.Location baseLocation = entry.getBaseLocation();
+        if (baseLocation.getWorld() == null || !baseLocation.getWorld().equals(viewer.getWorld())) {
             return false;
         }
         double maxRange = 0.0;
@@ -206,7 +207,7 @@ public class FurnitureTextPacketListener implements PacketListener {
             maxRange = Math.max(maxRange, definition.getViewRange());
         }
         double range = Math.max(8.0, maxRange);
-        return entry.getBaseLocation().distanceSquared(viewer.getLocation()) <= range * range;
+        return baseLocation.distanceSquared(viewer.getLocation()) <= range * range;
     }
 
     private static int[] appendUnique(int[] base, int[] extra) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -13,7 +13,6 @@ import com.github.retrooper.packetevents.util.Vector3f;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDestroyEntities;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
-import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
@@ -91,7 +90,8 @@ public class FurnitureTextPacketListener implements PacketListener {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
             Component text = def.renderComponent(viewer);
             if (NMSHandlers.getHandler().sendTextDisplayMetadata(viewer, entry.virtualEntityId(i), text,
-                    billboardByte(def), def.getViewRange(), def.getBackgroundArgb(), textFlags(def))) {
+                    def.getScale(), billboardByte(def), def.getViewRange(), def.getLineWidth(),
+                    def.getBackgroundArgb(), def.getTextOpacity(), textFlags(def))) {
                 continue;
             }
             PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
@@ -133,7 +133,8 @@ public class FurnitureTextPacketListener implements PacketListener {
             Component text = def.renderComponent(viewer);
             org.bukkit.Location textLocation = new org.bukkit.Location(baseLocation.getWorld(), textPos.x, textPos.y, textPos.z, yaw, pitch);
             if (viewer != null && NMSHandlers.getHandler().spawnTextDisplay(viewer, virtualId, virtualUuid, textLocation,
-                    text, billboardByte(def), def.getViewRange(), def.getBackgroundArgb(), textFlags(def))) {
+                    text, def.getScale(), billboardByte(def), def.getViewRange(), def.getLineWidth(),
+                    def.getBackgroundArgb(), def.getTextOpacity(), textFlags(def))) {
                 continue;
             }
 
@@ -201,7 +202,8 @@ public class FurnitureTextPacketListener implements PacketListener {
                     if (!entry.shouldRefresh(def, tick)) continue;
                     Component text = def.renderComponent(viewer);
                     if (NMSHandlers.getHandler().sendTextDisplayMetadata(viewer, entry.virtualEntityId(i), text,
-                            billboardByte(def), def.getViewRange(), def.getBackgroundArgb(), textFlags(def))) {
+                            def.getScale(), billboardByte(def), def.getViewRange(), def.getLineWidth(),
+                            def.getBackgroundArgb(), def.getTextOpacity(), textFlags(def))) {
                         continue;
                     }
                     PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
@@ -239,7 +241,7 @@ public class FurnitureTextPacketListener implements PacketListener {
         data.add(new EntityData<>(DATA.displayViewRange, EntityDataTypes.FLOAT, def.getViewRange()));
 
         Component text = def.renderComponent(viewer);
-        data.add(new EntityData<>(DATA.textDisplayText, EntityDataTypes.COMPONENT, AdventureUtils.GSON_SERIALIZER.serialize(text)));
+        data.add(new EntityData<>(DATA.textDisplayText, EntityDataTypes.ADV_COMPONENT, text));
         if (def.getLineWidth() != 200) {
             data.add(new EntityData<>(DATA.textDisplayLineWidth, EntityDataTypes.INT, def.getLineWidth()));
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -19,7 +19,6 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSp
 import io.th0rgal.oraxen.utils.VersionUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -75,8 +74,7 @@ public class FurnitureTextPacketListener implements PacketListener {
         if (viewer != null) entry.addViewer(viewer.getUniqueId());
 
         Vector3d basePos = spawn.getPosition();
-        int baseEntityId = spawn.getEntityId();
-        sendTextEntry(entry, viewer, user, baseEntityId, basePos);
+        sendTextEntry(entry, viewer, user, basePos);
     }
 
     void sendTextEntry(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
@@ -85,7 +83,7 @@ public class FurnitureTextPacketListener implements PacketListener {
         entry.addViewer(viewer.getUniqueId());
         org.bukkit.Location location = entry.getBaseLocation();
         Vector3d basePos = new Vector3d(location.getX(), location.getY(), location.getZ());
-        sendTextEntry(entry, viewer, null, entry.getBaseEntityId(), basePos);
+        sendTextEntry(entry, viewer, null, basePos);
     }
 
     void sendTextMetadata(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
@@ -99,18 +97,17 @@ public class FurnitureTextPacketListener implements PacketListener {
         }
     }
 
-    private void sendTextEntry(FurnitureTextEntry entry, Player viewer, User user, int baseEntityId, Vector3d basePos) {
+    private void sendTextEntry(FurnitureTextEntry entry, Player viewer, User user, Vector3d basePos) {
         for (int i = 0; i < entry.size(); i++) {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
             int virtualId = entry.virtualEntityId(i);
             UUID virtualUuid = entry.virtualUuid(i);
-            Vector3f offset = convertVector(def.getTranslation());
 
             WrapperPlayServerSpawnEntity textSpawn = new WrapperPlayServerSpawnEntity(
                     virtualId,
                     virtualUuid,
                     EntityTypes.TEXT_DISPLAY,
-                    new Location(basePos.x + offset.x, basePos.y + offset.y, basePos.z + offset.z, 0f, 0f),
+                    new Location(basePos.x, basePos.y, basePos.z, 0f, 0f),
                     0f,
                     0,
                     null
@@ -124,12 +121,6 @@ public class FurnitureTextPacketListener implements PacketListener {
             sendPacket(user, viewer, textSpawn);
             sendPacket(user, viewer, textMeta);
         }
-    }
-
-    private static int[] currentPassengerIds(FurnitureTextEntry entry) {
-        Entity entity = Bukkit.getEntity(entry.getBaseUuid());
-        if (entity == null || entity.getPassengers().isEmpty()) return new int[0];
-        return entity.getPassengers().stream().mapToInt(Entity::getEntityId).toArray();
     }
 
     private static void sendPacket(User user, Player viewer, Object packet) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -95,7 +95,7 @@ public class FurnitureTextPacketListener implements PacketListener {
                 continue;
             }
             PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
-                    new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
+                    new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer, text)));
         }
     }
 
@@ -125,11 +125,6 @@ public class FurnitureTextPacketListener implements PacketListener {
                     Optional.of(new Vector3d(0.0, 0.0, 0.0))
             );
 
-            WrapperPlayServerEntityMetadata textMeta = new WrapperPlayServerEntityMetadata(
-                    virtualId,
-                    buildMetadata(def, viewer)
-            );
-
             Component text = def.renderComponent(viewer);
             org.bukkit.Location textLocation = new org.bukkit.Location(baseLocation.getWorld(), textPos.x, textPos.y, textPos.z, yaw, pitch);
             if (viewer != null && NMSHandlers.getHandler().spawnTextDisplay(viewer, virtualId, virtualUuid, textLocation,
@@ -138,6 +133,10 @@ public class FurnitureTextPacketListener implements PacketListener {
                 continue;
             }
 
+            WrapperPlayServerEntityMetadata textMeta = new WrapperPlayServerEntityMetadata(
+                    virtualId,
+                    buildMetadata(def, viewer, text)
+            );
             sendPacket(user, viewer, textSpawn);
             SchedulerUtil.runTaskLater(1L, () -> sendPacket(user, viewer, textMeta));
         }
@@ -207,7 +206,7 @@ public class FurnitureTextPacketListener implements PacketListener {
                         continue;
                     }
                     PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
-                            new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
+                            new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer, text)));
                 }
             }
         }
@@ -227,33 +226,28 @@ public class FurnitureTextPacketListener implements PacketListener {
     }
 
     List<EntityData<?>> buildMetadata(FurnitureTextDefinition def, Player viewer) {
+        return buildMetadata(def, viewer, def.renderComponent(viewer));
+    }
+
+    private List<EntityData<?>> buildMetadata(FurnitureTextDefinition def, Player viewer, Component text) {
         List<EntityData<?>> data = new ArrayList<>(8);
 
         data.add(new EntityData<>(DATA_NO_GRAVITY, EntityDataTypes.BOOLEAN, true));
 
         Vector3f scale = convertVector(def.getScale());
-        if (scale.x != 1f || scale.y != 1f || scale.z != 1f) {
-            data.add(new EntityData<>(DATA.displayScale, EntityDataTypes.VECTOR3F, scale));
-        }
+        data.add(new EntityData<>(DATA.displayScale, EntityDataTypes.VECTOR3F, scale));
 
         byte billboard = billboardByte(def);
         data.add(new EntityData<>(DATA.displayBillboard, EntityDataTypes.BYTE, billboard));
         data.add(new EntityData<>(DATA.displayViewRange, EntityDataTypes.FLOAT, def.getViewRange()));
 
-        Component text = def.renderComponent(viewer);
         data.add(new EntityData<>(DATA.textDisplayText, EntityDataTypes.ADV_COMPONENT, text));
-        if (def.getLineWidth() != 200) {
-            data.add(new EntityData<>(DATA.textDisplayLineWidth, EntityDataTypes.INT, def.getLineWidth()));
-        }
-        if (def.getBackgroundArgb() != 0x40000000) {
-            data.add(new EntityData<>(DATA.textDisplayBackground, EntityDataTypes.INT, def.getBackgroundArgb()));
-        }
-        if (def.getTextOpacity() != (byte) -1) {
-            data.add(new EntityData<>(DATA.textDisplayOpacity, EntityDataTypes.BYTE, def.getTextOpacity()));
-        }
+        data.add(new EntityData<>(DATA.textDisplayLineWidth, EntityDataTypes.INT, def.getLineWidth()));
+        data.add(new EntityData<>(DATA.textDisplayBackground, EntityDataTypes.INT, def.getBackgroundArgb()));
+        data.add(new EntityData<>(DATA.textDisplayOpacity, EntityDataTypes.BYTE, def.getTextOpacity()));
 
         byte flags = textFlags(def);
-        if (flags != 0) data.add(new EntityData<>(DATA.textDisplayFlags, EntityDataTypes.BYTE, flags));
+        data.add(new EntityData<>(DATA.textDisplayFlags, EntityDataTypes.BYTE, flags));
 
         return data;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -72,6 +72,7 @@ public class FurnitureTextPacketListener implements PacketListener {
 
         Vector3d basePos = spawn.getPosition();
         SchedulerUtil.runTaskLater(1L, () -> {
+            if (viewer == null || !viewer.isOnline()) return;
             FurnitureTextEntry current = FurnitureTextRegistry.byUuid(baseUuid);
             if (current == null || current.getBaseEntityId() != baseEntityId) return;
             sendTextEntry(current, viewer, null, basePos);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -1,0 +1,258 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.world.Location;
+import com.github.retrooper.packetevents.util.Quaternion4f;
+import com.github.retrooper.packetevents.util.Vector3d;
+import com.github.retrooper.packetevents.util.Vector3f;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDestroyEntities;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * PacketEvents listener that appends virtual text-display entities to furniture
+ * when it is spawned client-side, and destroys them when the base entity is
+ * destroyed client-side.
+ *
+ * <p>No real entities are created server-side; we simply ride on top of the
+ * server's existing visibility/tracker logic for the base furniture entity.</p>
+ */
+public class FurnitureTextPacketListener implements PacketListener {
+
+    private static final int DATA_SHARED_FLAGS = 0;
+    private static final int DATA_DISPLAY_TRANSLATION = 11;
+    private static final int DATA_DISPLAY_SCALE = 12;
+    private static final int DATA_DISPLAY_LEFT_ROTATION = 13;
+    private static final int DATA_DISPLAY_BILLBOARD = 15;
+    private static final int DATA_DISPLAY_VIEW_RANGE = 17;
+    private static final int DATA_TEXT_DISPLAY_TEXT = 23;
+    private static final int DATA_TEXT_DISPLAY_LINE_WIDTH = 24;
+    private static final int DATA_TEXT_DISPLAY_BACKGROUND = 25;
+    private static final int DATA_TEXT_DISPLAY_OPACITY = 26;
+    private static final int DATA_TEXT_DISPLAY_FLAGS = 27;
+
+    private static final byte FLAG_SHADOW = 0x01;
+    private static final byte FLAG_SEE_THROUGH = 0x02;
+    private static final byte FLAG_DEFAULT_BACKGROUND = 0x04;
+    private static final byte FLAG_ALIGN_LEFT = 0x08;
+    private static final byte FLAG_ALIGN_RIGHT = 0x10;
+
+    @Override
+    public void onPacketSend(PacketSendEvent event) {
+        if (FurnitureTextRegistry.isEmpty()) return;
+
+        if (event.getPacketType() == PacketType.Play.Server.SPAWN_ENTITY) {
+            handleSpawn(event);
+        } else if (event.getPacketType() == PacketType.Play.Server.DESTROY_ENTITIES) {
+            handleDestroy(event);
+        } else if (event.getPacketType() == PacketType.Play.Server.SET_PASSENGERS) {
+            handlePassengers(event);
+        }
+    }
+
+    private void handleSpawn(PacketSendEvent event) {
+        WrapperPlayServerSpawnEntity spawn = new WrapperPlayServerSpawnEntity(event);
+        UUID baseUuid = spawn.getUUID().orElse(null);
+        if (baseUuid == null) return;
+
+        FurnitureTextEntry entry = FurnitureTextRegistry.byUuid(baseUuid);
+        if (entry == null) return;
+
+        User user = event.getUser();
+        if (user == null) return;
+        Player viewer = viewerFromEvent(event);
+        if (viewer != null) entry.addViewer(viewer.getUniqueId());
+
+        Vector3d basePos = spawn.getPosition();
+        int baseEntityId = spawn.getEntityId();
+
+        List<Integer> passengerIds = new ArrayList<>(entry.size());
+
+        for (int i = 0; i < entry.size(); i++) {
+            FurnitureTextDefinition def = entry.getDefinitions().get(i);
+            int virtualId = entry.virtualEntityId(i);
+            UUID virtualUuid = entry.virtualUuid(i);
+
+            WrapperPlayServerSpawnEntity textSpawn = new WrapperPlayServerSpawnEntity(
+                    virtualId,
+                    virtualUuid,
+                    EntityTypes.TEXT_DISPLAY,
+                    new Location(basePos.x, basePos.y, basePos.z, 0f, 0f),
+                    0f,
+                    0,
+                    null
+            );
+
+            WrapperPlayServerEntityMetadata textMeta = new WrapperPlayServerEntityMetadata(
+                    virtualId,
+                    buildMetadata(def, viewer)
+            );
+
+            user.sendPacket(textSpawn);
+            user.sendPacket(textMeta);
+            passengerIds.add(virtualId);
+        }
+
+        if (!passengerIds.isEmpty()) {
+            int[] ids = new int[passengerIds.size()];
+            for (int i = 0; i < ids.length; i++) ids[i] = passengerIds.get(i);
+
+            WrapperPlayServerSetPassengers setPassengers = new WrapperPlayServerSetPassengers(baseEntityId, ids);
+            user.sendPacket(setPassengers);
+        }
+    }
+
+    private void handleDestroy(PacketSendEvent event) {
+        WrapperPlayServerDestroyEntities destroy = new WrapperPlayServerDestroyEntities(event);
+        int[] ids = destroy.getEntityIds();
+        if (ids == null || ids.length == 0) return;
+
+        List<Integer> extra = null;
+        for (int id : ids) {
+            FurnitureTextEntry entry = FurnitureTextRegistry.byEntityId(id);
+            if (entry == null) continue;
+            int[] vids = entry.getVirtualEntityIds();
+            if (vids.length == 0) continue;
+            if (extra == null) extra = new ArrayList<>();
+            for (int v : vids) extra.add(v);
+        }
+
+        if (extra == null || extra.isEmpty()) return;
+
+        Player viewer = viewerFromEvent(event);
+        if (viewer != null) {
+            for (int id : ids) {
+                FurnitureTextEntry entry = FurnitureTextRegistry.byEntityId(id);
+                if (entry != null) entry.removeViewer(viewer.getUniqueId());
+            }
+        }
+
+        int[] combined = new int[ids.length + extra.size()];
+        System.arraycopy(ids, 0, combined, 0, ids.length);
+        for (int i = 0; i < extra.size(); i++) combined[ids.length + i] = extra.get(i);
+        destroy.setEntityIds(combined);
+        event.markForReEncode(true);
+    }
+
+    private void handlePassengers(PacketSendEvent event) {
+        WrapperPlayServerSetPassengers passengers = new WrapperPlayServerSetPassengers(event);
+        FurnitureTextEntry entry = FurnitureTextRegistry.byEntityId(passengers.getEntityId());
+        if (entry == null) return;
+
+        int[] combined = appendUnique(passengers.getPassengers(), entry.getVirtualEntityIds());
+        passengers.setPassengers(combined);
+        event.markForReEncode(true);
+    }
+
+    void refresh(long tick) {
+        if (!FurnitureTextRegistry.hasRefreshableEntries()) return;
+
+        for (FurnitureTextEntry entry : FurnitureTextRegistry.all()) {
+            if (!entry.needsRefresh() || !entry.shouldRefresh(tick)) continue;
+
+            for (UUID viewerId : entry.getViewers()) {
+                Player viewer = Bukkit.getPlayer(viewerId);
+                if (viewer == null || !viewer.isOnline() || !isWithinRange(entry, viewer)) {
+                    entry.removeViewer(viewerId);
+                    continue;
+                }
+
+                for (int i = 0; i < entry.size(); i++) {
+                    FurnitureTextDefinition def = entry.getDefinitions().get(i);
+                    if (def.getRefreshTicks() <= 0 && !def.usesPlaceholders()) continue;
+                    PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
+                            new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
+                }
+            }
+        }
+    }
+
+    private static boolean isWithinRange(FurnitureTextEntry entry, Player viewer) {
+        if (entry.getBaseLocation().getWorld() == null || !entry.getBaseLocation().getWorld().equals(viewer.getWorld())) {
+            return false;
+        }
+        double maxRange = 0.0;
+        for (FurnitureTextDefinition definition : entry.getDefinitions()) {
+            maxRange = Math.max(maxRange, definition.getViewRange());
+        }
+        double range = Math.max(8.0, maxRange);
+        return entry.getBaseLocation().distanceSquared(viewer.getLocation()) <= range * range;
+    }
+
+    private static int[] appendUnique(int[] base, int[] extra) {
+        Set<Integer> ids = new LinkedHashSet<>();
+        if (base != null) for (int id : base) ids.add(id);
+        for (int id : extra) ids.add(id);
+        int[] combined = new int[ids.size()];
+        int index = 0;
+        for (int id : ids) combined[index++] = id;
+        return combined;
+    }
+
+    List<EntityData<?>> buildMetadata(FurnitureTextDefinition def, Player viewer) {
+        List<EntityData<?>> data = new ArrayList<>(8);
+
+        data.add(new EntityData<>(DATA_SHARED_FLAGS, EntityDataTypes.BYTE, (byte) 0));
+
+        Vector3f translation = convertVector(def.getTranslation());
+        Vector3f scale = convertVector(def.getScale());
+        data.add(new EntityData<>(DATA_DISPLAY_TRANSLATION, EntityDataTypes.VECTOR3F, translation));
+        data.add(new EntityData<>(DATA_DISPLAY_SCALE, EntityDataTypes.VECTOR3F, scale));
+        data.add(new EntityData<>(DATA_DISPLAY_LEFT_ROTATION, EntityDataTypes.QUATERNION,
+                new Quaternion4f(0f, 0f, 0f, 1f)));
+
+        byte billboard = switch (def.getBillboard()) {
+            case FIXED -> (byte) 0;
+            case VERTICAL -> (byte) 1;
+            case HORIZONTAL -> (byte) 2;
+            case CENTER -> (byte) 3;
+        };
+        data.add(new EntityData<>(DATA_DISPLAY_BILLBOARD, EntityDataTypes.BYTE, billboard));
+        data.add(new EntityData<>(DATA_DISPLAY_VIEW_RANGE, EntityDataTypes.FLOAT, def.getViewRange()));
+
+        Component text = def.renderComponent(viewer);
+        data.add(new EntityData<>(DATA_TEXT_DISPLAY_TEXT, EntityDataTypes.ADV_COMPONENT, text));
+        data.add(new EntityData<>(DATA_TEXT_DISPLAY_LINE_WIDTH, EntityDataTypes.INT, def.getLineWidth()));
+        data.add(new EntityData<>(DATA_TEXT_DISPLAY_BACKGROUND, EntityDataTypes.INT, def.getBackgroundArgb()));
+        data.add(new EntityData<>(DATA_TEXT_DISPLAY_OPACITY, EntityDataTypes.BYTE, def.getTextOpacity()));
+
+        byte flags = 0;
+        if (def.hasShadow()) flags |= FLAG_SHADOW;
+        if (def.isSeeThrough()) flags |= FLAG_SEE_THROUGH;
+        if (def.hasDefaultBackground()) flags |= FLAG_DEFAULT_BACKGROUND;
+        switch (def.getAlignment()) {
+            case LEFT -> flags |= FLAG_ALIGN_LEFT;
+            case RIGHT -> flags |= FLAG_ALIGN_RIGHT;
+            case CENTER -> { /* default */ }
+        }
+        data.add(new EntityData<>(DATA_TEXT_DISPLAY_FLAGS, EntityDataTypes.BYTE, flags));
+
+        return data;
+    }
+
+    private static Vector3f convertVector(org.joml.Vector3f v) {
+        return new Vector3f(v.x, v.y, v.z);
+    }
+
+    private static Player viewerFromEvent(PacketSendEvent event) {
+        Object player = event.getPlayer();
+        return player instanceof Player p ? p : null;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -19,6 +19,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSp
 import io.th0rgal.oraxen.utils.VersionUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -79,7 +80,12 @@ public class FurnitureTextPacketListener implements PacketListener {
     }
 
     void sendTextEntry(FurnitureTextEntry entry, Player viewer) {
-        if (entry == null || viewer == null || !viewer.isOnline() || !isWithinRange(entry, viewer)) return;
+        sendTextEntry(entry, viewer, false);
+    }
+
+    void sendTextEntry(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
+        if (entry == null || viewer == null || !viewer.isOnline()) return;
+        if (!ignoreRange && !isWithinRange(entry, viewer)) return;
         entry.addViewer(viewer.getUniqueId());
         org.bukkit.Location location = entry.getBaseLocation();
         Vector3d basePos = new Vector3d(location.getX(), location.getY(), location.getZ());
@@ -87,7 +93,12 @@ public class FurnitureTextPacketListener implements PacketListener {
     }
 
     void sendTextMetadata(FurnitureTextEntry entry, Player viewer) {
-        if (entry == null || viewer == null || !viewer.isOnline() || !isWithinRange(entry, viewer)) return;
+        sendTextMetadata(entry, viewer, false);
+    }
+
+    void sendTextMetadata(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
+        if (entry == null || viewer == null || !viewer.isOnline()) return;
+        if (!ignoreRange && !isWithinRange(entry, viewer)) return;
         entry.addViewer(viewer.getUniqueId());
         for (int i = 0; i < entry.size(); i++) {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
@@ -125,12 +136,19 @@ public class FurnitureTextPacketListener implements PacketListener {
         }
 
         if (!passengerIds.isEmpty()) {
-            int[] ids = new int[passengerIds.size()];
-            for (int i = 0; i < ids.length; i++) ids[i] = passengerIds.get(i);
+            int[] virtualIds = new int[passengerIds.size()];
+            for (int i = 0; i < virtualIds.length; i++) virtualIds[i] = passengerIds.get(i);
+            int[] ids = user == null ? appendUnique(currentPassengerIds(entry), virtualIds) : virtualIds;
 
             WrapperPlayServerSetPassengers setPassengers = new WrapperPlayServerSetPassengers(baseEntityId, ids);
             sendPacket(user, viewer, setPassengers);
         }
+    }
+
+    private static int[] currentPassengerIds(FurnitureTextEntry entry) {
+        Entity entity = Bukkit.getEntity(entry.getBaseUuid());
+        if (entity == null || entity.getPassengers().isEmpty()) return new int[0];
+        return entity.getPassengers().stream().mapToInt(Entity::getEntityId).toArray();
     }
 
     private static void sendPacket(User user, Player viewer, Object packet) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -63,6 +63,7 @@ public class FurnitureTextPacketListener implements PacketListener {
 
         FurnitureTextEntry entry = FurnitureTextRegistry.byUuid(baseUuid);
         if (entry == null) return;
+        int baseEntityId = spawn.getEntityId();
 
         User user = event.getUser();
         if (user == null) return;
@@ -70,7 +71,11 @@ public class FurnitureTextPacketListener implements PacketListener {
         if (viewer != null) entry.addViewer(viewer.getUniqueId());
 
         Vector3d basePos = spawn.getPosition();
-        SchedulerUtil.runTaskLater(1L, () -> sendTextEntry(entry, viewer, null, basePos));
+        SchedulerUtil.runTaskLater(1L, () -> {
+            FurnitureTextEntry current = FurnitureTextRegistry.byUuid(baseUuid);
+            if (current == null || current.getBaseEntityId() != baseEntityId) return;
+            sendTextEntry(current, viewer, null, basePos);
+        });
     }
 
     void sendTextEntry(FurnitureTextEntry entry, Player viewer, boolean ignoreRange) {
@@ -107,7 +112,7 @@ public class FurnitureTextPacketListener implements PacketListener {
             FurnitureTextDefinition def = entry.getDefinitions().get(i);
             int virtualId = entry.virtualEntityId(i);
             UUID virtualUuid = entry.virtualUuid(i);
-            Vector3f offset = convertVector(def.getTranslation());
+            Vector3f offset = rotateOffset(convertVector(def.getTranslation()), yaw);
             Vector3d basePos = packetBasePos != null
                     ? packetBasePos
                     : new Vector3d(baseLocation.getX(), baseLocation.getY(), baseLocation.getZ());
@@ -276,6 +281,17 @@ public class FurnitureTextPacketListener implements PacketListener {
 
     private static Vector3f convertVector(org.joml.Vector3f v) {
         return new Vector3f(v.x, v.y, v.z);
+    }
+
+    private static Vector3f rotateOffset(Vector3f offset, float yaw) {
+        double radians = Math.toRadians(-(double) yaw);
+        double x = offset.x;
+        double z = offset.z;
+        return new Vector3f(
+                (float) (Math.cos(radians) * x - Math.sin(radians) * z),
+                offset.y,
+                (float) (Math.sin(radians) * x + Math.cos(radians) * z)
+        );
     }
 
     private static Player viewerFromEvent(PacketSendEvent event) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketListener.java
@@ -16,6 +16,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDe
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
+import io.th0rgal.oraxen.utils.VersionUtil;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -37,16 +38,7 @@ import java.util.UUID;
 public class FurnitureTextPacketListener implements PacketListener {
 
     private static final int DATA_SHARED_FLAGS = 0;
-    private static final int DATA_DISPLAY_TRANSLATION = 11;
-    private static final int DATA_DISPLAY_SCALE = 12;
-    private static final int DATA_DISPLAY_LEFT_ROTATION = 13;
-    private static final int DATA_DISPLAY_BILLBOARD = 15;
-    private static final int DATA_DISPLAY_VIEW_RANGE = 17;
-    private static final int DATA_TEXT_DISPLAY_TEXT = 23;
-    private static final int DATA_TEXT_DISPLAY_LINE_WIDTH = 24;
-    private static final int DATA_TEXT_DISPLAY_BACKGROUND = 25;
-    private static final int DATA_TEXT_DISPLAY_OPACITY = 26;
-    private static final int DATA_TEXT_DISPLAY_FLAGS = 27;
+    private static final MetadataIndices DATA = MetadataIndices.current();
 
     private static final byte FLAG_SHADOW = 0x01;
     private static final byte FLAG_SEE_THROUGH = 0x02;
@@ -82,7 +74,28 @@ public class FurnitureTextPacketListener implements PacketListener {
 
         Vector3d basePos = spawn.getPosition();
         int baseEntityId = spawn.getEntityId();
+        sendTextEntry(entry, viewer, user, baseEntityId, basePos);
+    }
 
+    void sendTextEntry(FurnitureTextEntry entry, Player viewer) {
+        if (entry == null || viewer == null || !viewer.isOnline() || !isWithinRange(entry, viewer)) return;
+        entry.addViewer(viewer.getUniqueId());
+        org.bukkit.Location location = entry.getBaseLocation();
+        Vector3d basePos = new Vector3d(location.getX(), location.getY(), location.getZ());
+        sendTextEntry(entry, viewer, null, entry.getBaseEntityId(), basePos);
+    }
+
+    void sendTextMetadata(FurnitureTextEntry entry, Player viewer) {
+        if (entry == null || viewer == null || !viewer.isOnline() || !isWithinRange(entry, viewer)) return;
+        entry.addViewer(viewer.getUniqueId());
+        for (int i = 0; i < entry.size(); i++) {
+            FurnitureTextDefinition def = entry.getDefinitions().get(i);
+            PacketEvents.getAPI().getPlayerManager().sendPacket(viewer,
+                    new WrapperPlayServerEntityMetadata(entry.virtualEntityId(i), buildMetadata(def, viewer)));
+        }
+    }
+
+    private void sendTextEntry(FurnitureTextEntry entry, Player viewer, User user, int baseEntityId, Vector3d basePos) {
         List<Integer> passengerIds = new ArrayList<>(entry.size());
 
         for (int i = 0; i < entry.size(); i++) {
@@ -105,8 +118,8 @@ public class FurnitureTextPacketListener implements PacketListener {
                     buildMetadata(def, viewer)
             );
 
-            user.sendPacket(textSpawn);
-            user.sendPacket(textMeta);
+            sendPacket(user, viewer, textSpawn);
+            sendPacket(user, viewer, textMeta);
             passengerIds.add(virtualId);
         }
 
@@ -115,7 +128,15 @@ public class FurnitureTextPacketListener implements PacketListener {
             for (int i = 0; i < ids.length; i++) ids[i] = passengerIds.get(i);
 
             WrapperPlayServerSetPassengers setPassengers = new WrapperPlayServerSetPassengers(baseEntityId, ids);
-            user.sendPacket(setPassengers);
+            sendPacket(user, viewer, setPassengers);
+        }
+    }
+
+    private static void sendPacket(User user, Player viewer, Object packet) {
+        if (user != null) {
+            user.sendPacket(packet);
+        } else if (viewer != null) {
+            PacketEvents.getAPI().getPlayerManager().sendPacket(viewer, packet);
         }
     }
 
@@ -185,7 +206,7 @@ public class FurnitureTextPacketListener implements PacketListener {
         }
     }
 
-    private static boolean isWithinRange(FurnitureTextEntry entry, Player viewer) {
+    static boolean isWithinRange(FurnitureTextEntry entry, Player viewer) {
         if (entry.getBaseLocation().getWorld() == null || !entry.getBaseLocation().getWorld().equals(viewer.getWorld())) {
             return false;
         }
@@ -214,9 +235,9 @@ public class FurnitureTextPacketListener implements PacketListener {
 
         Vector3f translation = convertVector(def.getTranslation());
         Vector3f scale = convertVector(def.getScale());
-        data.add(new EntityData<>(DATA_DISPLAY_TRANSLATION, EntityDataTypes.VECTOR3F, translation));
-        data.add(new EntityData<>(DATA_DISPLAY_SCALE, EntityDataTypes.VECTOR3F, scale));
-        data.add(new EntityData<>(DATA_DISPLAY_LEFT_ROTATION, EntityDataTypes.QUATERNION,
+        data.add(new EntityData<>(DATA.displayTranslation, EntityDataTypes.VECTOR3F, translation));
+        data.add(new EntityData<>(DATA.displayScale, EntityDataTypes.VECTOR3F, scale));
+        data.add(new EntityData<>(DATA.displayLeftRotation, EntityDataTypes.QUATERNION,
                 new Quaternion4f(0f, 0f, 0f, 1f)));
 
         byte billboard = switch (def.getBillboard()) {
@@ -225,14 +246,14 @@ public class FurnitureTextPacketListener implements PacketListener {
             case HORIZONTAL -> (byte) 2;
             case CENTER -> (byte) 3;
         };
-        data.add(new EntityData<>(DATA_DISPLAY_BILLBOARD, EntityDataTypes.BYTE, billboard));
-        data.add(new EntityData<>(DATA_DISPLAY_VIEW_RANGE, EntityDataTypes.FLOAT, def.getViewRange() / 64.0f));
+        data.add(new EntityData<>(DATA.displayBillboard, EntityDataTypes.BYTE, billboard));
+        data.add(new EntityData<>(DATA.displayViewRange, EntityDataTypes.FLOAT, def.getViewRange() / 64.0f));
 
         Component text = def.renderComponent(viewer);
-        data.add(new EntityData<>(DATA_TEXT_DISPLAY_TEXT, EntityDataTypes.ADV_COMPONENT, text));
-        data.add(new EntityData<>(DATA_TEXT_DISPLAY_LINE_WIDTH, EntityDataTypes.INT, def.getLineWidth()));
-        data.add(new EntityData<>(DATA_TEXT_DISPLAY_BACKGROUND, EntityDataTypes.INT, def.getBackgroundArgb()));
-        data.add(new EntityData<>(DATA_TEXT_DISPLAY_OPACITY, EntityDataTypes.BYTE, def.getTextOpacity()));
+        data.add(new EntityData<>(DATA.textDisplayText, EntityDataTypes.ADV_COMPONENT, text));
+        data.add(new EntityData<>(DATA.textDisplayLineWidth, EntityDataTypes.INT, def.getLineWidth()));
+        data.add(new EntityData<>(DATA.textDisplayBackground, EntityDataTypes.INT, def.getBackgroundArgb()));
+        data.add(new EntityData<>(DATA.textDisplayOpacity, EntityDataTypes.BYTE, def.getTextOpacity()));
 
         byte flags = 0;
         if (def.hasShadow()) flags |= FLAG_SHADOW;
@@ -243,7 +264,7 @@ public class FurnitureTextPacketListener implements PacketListener {
             case RIGHT -> flags |= FLAG_ALIGN_RIGHT;
             case CENTER -> { /* default */ }
         }
-        data.add(new EntityData<>(DATA_TEXT_DISPLAY_FLAGS, EntityDataTypes.BYTE, flags));
+        data.add(new EntityData<>(DATA.textDisplayFlags, EntityDataTypes.BYTE, flags));
 
         return data;
     }
@@ -255,5 +276,35 @@ public class FurnitureTextPacketListener implements PacketListener {
     private static Player viewerFromEvent(PacketSendEvent event) {
         Object player = event.getPlayer();
         return player instanceof Player p ? p : null;
+    }
+
+    private static final class MetadataIndices {
+        private final int displayTranslation;
+        private final int displayScale;
+        private final int displayLeftRotation;
+        private final int displayBillboard;
+        private final int displayViewRange;
+        private final int textDisplayText;
+        private final int textDisplayLineWidth;
+        private final int textDisplayBackground;
+        private final int textDisplayOpacity;
+        private final int textDisplayFlags;
+
+        private MetadataIndices(int offset) {
+            this.displayTranslation = 11 + offset;
+            this.displayScale = 12 + offset;
+            this.displayLeftRotation = 13 + offset;
+            this.displayBillboard = 15 + offset;
+            this.displayViewRange = 17 + offset;
+            this.textDisplayText = 23 + offset;
+            this.textDisplayLineWidth = 24 + offset;
+            this.textDisplayBackground = 25 + offset;
+            this.textDisplayOpacity = 26 + offset;
+            this.textDisplayFlags = 27 + offset;
+        }
+
+        private static MetadataIndices current() {
+            return new MetadataIndices(VersionUtil.atOrAbove("1.20.2") ? 0 : -1);
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -63,14 +63,19 @@ final class FurnitureTextPacketRegistration {
 
     static void destroyRegisteredTextEntities() {
         for (FurnitureTextEntry entry : FurnitureTextRegistry.all()) {
-            int[] virtualIds = entry.getVirtualEntityIds();
-            if (virtualIds.length == 0) continue;
-            WrapperPlayServerDestroyEntities destroy = new WrapperPlayServerDestroyEntities(virtualIds);
-            for (UUID viewerId : entry.getViewers()) {
-                Player viewer = Bukkit.getPlayer(viewerId);
-                if (viewer == null || !viewer.isOnline()) continue;
-                PacketEvents.getAPI().getPlayerManager().getUser(viewer).sendPacket(destroy);
-            }
+            destroyTextEntry(entry);
+        }
+    }
+
+    static void destroyTextEntry(FurnitureTextEntry entry) {
+        if (entry == null) return;
+        int[] virtualIds = entry.getVirtualEntityIds();
+        if (virtualIds.length == 0) return;
+        WrapperPlayServerDestroyEntities destroy = new WrapperPlayServerDestroyEntities(virtualIds);
+        for (UUID viewerId : entry.getViewers()) {
+            Player viewer = Bukkit.getPlayer(viewerId);
+            if (viewer == null || !viewer.isOnline()) continue;
+            PacketEvents.getAPI().getPlayerManager().getUser(viewer).sendPacket(destroy);
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -3,14 +3,18 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerCommon;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDestroyEntities;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.UUID;
 
 final class FurnitureTextPacketRegistration {
 
@@ -55,6 +59,19 @@ final class FurnitureTextPacketRegistration {
         registered = null;
         listener = null;
         tick = 0L;
+    }
+
+    static void destroyRegisteredTextEntities() {
+        for (FurnitureTextEntry entry : FurnitureTextRegistry.all()) {
+            int[] virtualIds = entry.getVirtualEntityIds();
+            if (virtualIds.length == 0) continue;
+            WrapperPlayServerDestroyEntities destroy = new WrapperPlayServerDestroyEntities(virtualIds);
+            for (UUID viewerId : entry.getViewers()) {
+                Player viewer = Bukkit.getPlayer(viewerId);
+                if (viewer == null || !viewer.isOnline()) continue;
+                PacketEvents.getAPI().getPlayerManager().getUser(viewer).sendPacket(destroy);
+            }
+        }
     }
 
     private static final class ViewerCleanupListener implements Listener {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -1,0 +1,44 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerCommon;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
+
+final class FurnitureTextPacketRegistration {
+
+    private static PacketListenerCommon registered;
+    private static FurnitureTextPacketListener listener;
+    private static SchedulerUtil.ScheduledTask refreshTask;
+    private static long tick;
+
+    private FurnitureTextPacketRegistration() {
+    }
+
+    static void register() {
+        if (registered != null) return;
+        listener = new FurnitureTextPacketListener();
+        registered = PacketEvents.getAPI().getEventManager()
+                .registerListener(listener, PacketListenerPriority.NORMAL);
+        refreshTask = SchedulerUtil.runTaskTimer(1L, 1L, () -> {
+            FurnitureTextPacketListener activeListener = listener;
+            if (activeListener != null) activeListener.refresh(++tick);
+        });
+    }
+
+    static void unregister() {
+        if (refreshTask != null) {
+            refreshTask.cancel();
+            refreshTask = null;
+        }
+        if (registered != null) {
+            try {
+                PacketEvents.getAPI().getEventManager().unregisterListener(registered);
+            } catch (Throwable ignored) {
+            }
+        }
+        registered = null;
+        listener = null;
+        tick = 0L;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerCommon;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -33,6 +34,7 @@ final class FurnitureTextPacketRegistration {
             FurnitureTextPacketListener activeListener = listener;
             if (activeListener != null) activeListener.refresh(++tick);
         });
+        MechanicsManager.registerTask("furniture", refreshTask);
     }
 
     static void unregister() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -79,12 +79,12 @@ final class FurnitureTextPacketRegistration {
         }
     }
 
-    static void spawnForNearbyViewers(FurnitureTextEntry entry) {
+    static void spawnForWorldViewers(FurnitureTextEntry entry) {
         FurnitureTextPacketListener activeListener = listener;
         if (entry == null || activeListener == null) return;
         for (Player viewer : Bukkit.getOnlinePlayers()) {
-            if (!FurnitureTextPacketListener.isWithinRange(entry, viewer)) continue;
-            activeListener.sendTextEntry(entry, viewer);
+            if (!viewer.getWorld().equals(entry.getBaseLocation().getWorld())) continue;
+            activeListener.sendTextEntry(entry, viewer, true);
         }
     }
 
@@ -97,7 +97,7 @@ final class FurnitureTextPacketRegistration {
                 entry.removeViewer(viewerId);
                 continue;
             }
-            activeListener.sendTextMetadata(entry, viewer);
+            activeListener.sendTextMetadata(entry, viewer, true);
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -15,6 +15,10 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 final class FurnitureTextPacketRegistration {
@@ -85,9 +89,29 @@ final class FurnitureTextPacketRegistration {
         if (entry == null || activeListener == null) return;
         Entity baseEntity = Bukkit.getEntity(entry.getBaseUuid());
         if (baseEntity == null) return;
-        for (Player viewer : baseEntity.getTrackedBy()) {
+        for (Player viewer : trackedViewers(entry, baseEntity)) {
             activeListener.sendTextEntry(entry, viewer, true);
         }
+    }
+
+    private static List<Player> trackedViewers(FurnitureTextEntry entry, Entity baseEntity) {
+        try {
+            Object tracked = Entity.class.getMethod("getTrackedBy").invoke(baseEntity);
+            if (tracked instanceof Collection<?> collection) {
+                List<Player> viewers = new ArrayList<>(collection.size());
+                for (Object candidate : collection) {
+                    if (candidate instanceof Player player) viewers.add(player);
+                }
+                return viewers;
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | LinkageError ignored) {
+        }
+
+        List<Player> viewers = new ArrayList<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (FurnitureTextPacketListener.isWithinRange(entry, player)) viewers.add(player);
+        }
+        return viewers;
     }
 
     static void updateTrackedViewers(FurnitureTextEntry entry) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -79,6 +79,28 @@ final class FurnitureTextPacketRegistration {
         }
     }
 
+    static void spawnForNearbyViewers(FurnitureTextEntry entry) {
+        FurnitureTextPacketListener activeListener = listener;
+        if (entry == null || activeListener == null) return;
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            if (!FurnitureTextPacketListener.isWithinRange(entry, viewer)) continue;
+            activeListener.sendTextEntry(entry, viewer);
+        }
+    }
+
+    static void updateTrackedViewers(FurnitureTextEntry entry) {
+        FurnitureTextPacketListener activeListener = listener;
+        if (entry == null || activeListener == null) return;
+        for (UUID viewerId : entry.getViewers()) {
+            Player viewer = Bukkit.getPlayer(viewerId);
+            if (viewer == null || !viewer.isOnline()) {
+                entry.removeViewer(viewerId);
+                continue;
+            }
+            activeListener.sendTextMetadata(entry, viewer);
+        }
+    }
+
     private static final class ViewerCleanupListener implements Listener {
         @EventHandler
         public void onPlayerQuit(PlayerQuitEvent event) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -102,7 +102,7 @@ final class FurnitureTextPacketRegistration {
                 for (Object candidate : collection) {
                     if (candidate instanceof Player player) viewers.add(player);
                 }
-                return viewers;
+                if (!viewers.isEmpty()) return viewers;
             }
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | LinkageError ignored) {
         }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -3,12 +3,19 @@ package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerCommon;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 final class FurnitureTextPacketRegistration {
 
     private static PacketListenerCommon registered;
     private static FurnitureTextPacketListener listener;
+    private static Listener bukkitListener;
     private static SchedulerUtil.ScheduledTask refreshTask;
     private static long tick;
 
@@ -20,6 +27,8 @@ final class FurnitureTextPacketRegistration {
         listener = new FurnitureTextPacketListener();
         registered = PacketEvents.getAPI().getEventManager()
                 .registerListener(listener, PacketListenerPriority.NORMAL);
+        bukkitListener = new ViewerCleanupListener();
+        Bukkit.getPluginManager().registerEvents(bukkitListener, OraxenPlugin.get());
         refreshTask = SchedulerUtil.runTaskTimer(1L, 1L, () -> {
             FurnitureTextPacketListener activeListener = listener;
             if (activeListener != null) activeListener.refresh(++tick);
@@ -37,8 +46,19 @@ final class FurnitureTextPacketRegistration {
             } catch (Throwable ignored) {
             }
         }
+        if (bukkitListener != null) {
+            HandlerList.unregisterAll(bukkitListener);
+            bukkitListener = null;
+        }
         registered = null;
         listener = null;
         tick = 0L;
+    }
+
+    private static final class ViewerCleanupListener implements Listener {
+        @EventHandler
+        public void onPlayerQuit(PlayerQuitEvent event) {
+            FurnitureTextRegistry.removeViewer(event.getPlayer().getUniqueId());
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -8,6 +8,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.MechanicsManager;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -79,11 +80,12 @@ final class FurnitureTextPacketRegistration {
         }
     }
 
-    static void spawnForWorldViewers(FurnitureTextEntry entry) {
+    static void spawnForTrackedViewers(FurnitureTextEntry entry) {
         FurnitureTextPacketListener activeListener = listener;
         if (entry == null || activeListener == null) return;
-        for (Player viewer : Bukkit.getOnlinePlayers()) {
-            if (!viewer.getWorld().equals(entry.getBaseLocation().getWorld())) continue;
+        Entity baseEntity = Bukkit.getEntity(entry.getBaseUuid());
+        if (baseEntity == null) return;
+        for (Player viewer : baseEntity.getTrackedBy()) {
             activeListener.sendTextEntry(entry, viewer, true);
         }
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextPacketRegistration.java
@@ -31,7 +31,7 @@ final class FurnitureTextPacketRegistration {
         if (registered != null) return;
         listener = new FurnitureTextPacketListener();
         registered = PacketEvents.getAPI().getEventManager()
-                .registerListener(listener, PacketListenerPriority.NORMAL);
+                .registerListener(listener, PacketListenerPriority.MONITOR);
         bukkitListener = new ViewerCleanupListener();
         Bukkit.getPluginManager().registerEvents(bukkitListener, OraxenPlugin.get());
         refreshTask = SchedulerUtil.runTaskTimer(1L, 1L, () -> {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * In-memory registry of placed furniture bases that own virtual text entities.
+ * In-memory registry of placed furniture bases that own text entities.
  *
  * <p>Lookup is done by the base entity's UUID (matches the UUID carried in the
  * SPAWN_ENTITY packet for the base ItemDisplay/ArmorStand/ItemFrame) as well as
@@ -36,9 +36,13 @@ public final class FurnitureTextRegistry {
                 ? new FurnitureTextEntry(previous, entityId, location, copiedDefinitions)
                 : new FurnitureTextEntry(uuid, entityId, location, copiedDefinitions);
         previous = BY_UUID.put(uuid, entry);
-        if (previous != null) BY_ENTITY_ID.remove(previous.getBaseEntityId());
+        if (previous != null) {
+            previous.removeTextDisplays();
+            BY_ENTITY_ID.remove(previous.getBaseEntityId());
+        }
         BY_ENTITY_ID.put(entityId, entry);
         updateRefreshableCount(previous, entry);
+        entry.spawnTextDisplays();
         return entry;
     }
 
@@ -58,7 +62,10 @@ public final class FurnitureTextRegistry {
     public static void unregister(UUID uuid) {
         if (uuid == null) return;
         FurnitureTextEntry entry = BY_UUID.remove(uuid);
-        if (entry != null) BY_ENTITY_ID.remove(entry.getBaseEntityId());
+        if (entry != null) {
+            entry.removeTextDisplays();
+            BY_ENTITY_ID.remove(entry.getBaseEntityId());
+        }
         updateRefreshableCount(entry, null);
     }
 
@@ -66,7 +73,10 @@ public final class FurnitureTextRegistry {
         if (uuid == null) return;
         FurnitureTextEntry entry = BY_UUID.get(uuid);
         if (entry == null || entry.getBaseEntityId() != entityId) return;
-        if (BY_UUID.remove(uuid, entry)) updateRefreshableCount(entry, null);
+        if (BY_UUID.remove(uuid, entry)) {
+            entry.removeTextDisplays();
+            updateRefreshableCount(entry, null);
+        }
         BY_ENTITY_ID.remove(entityId, entry);
     }
 
@@ -90,6 +100,9 @@ public final class FurnitureTextRegistry {
     }
 
     public static void clear() {
+        for (FurnitureTextEntry entry : BY_UUID.values()) {
+            entry.removeTextDisplays();
+        }
         BY_UUID.clear();
         BY_ENTITY_ID.clear();
         REFRESHABLE_ENTRIES.set(0);

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -41,7 +41,7 @@ public final class FurnitureTextRegistry {
 
     public static boolean canReuse(UUID uuid, int definitionCount) {
         FurnitureTextEntry entry = byUuid(uuid);
-        return entry == null || entry.size() == definitionCount;
+        return entry != null && entry.size() == definitionCount;
     }
 
     public static FurnitureTextEntry byUuid(UUID uuid) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -49,6 +49,14 @@ public final class FurnitureTextRegistry {
         if (entry != null) BY_ENTITY_ID.remove(entry.getBaseEntityId());
     }
 
+    public static void unregister(UUID uuid, int entityId) {
+        if (uuid == null) return;
+        FurnitureTextEntry entry = BY_UUID.get(uuid);
+        if (entry == null || entry.getBaseEntityId() != entityId) return;
+        BY_UUID.remove(uuid, entry);
+        BY_ENTITY_ID.remove(entityId, entry);
+    }
+
     public static boolean isEmpty() {
         return BY_UUID.isEmpty();
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * In-memory registry of placed furniture bases that own virtual text entities.
@@ -19,6 +20,7 @@ public final class FurnitureTextRegistry {
 
     private static final Map<UUID, FurnitureTextEntry> BY_UUID = new ConcurrentHashMap<>();
     private static final Map<Integer, FurnitureTextEntry> BY_ENTITY_ID = new ConcurrentHashMap<>();
+    private static final AtomicInteger REFRESHABLE_ENTRIES = new AtomicInteger();
 
     private FurnitureTextRegistry() {
     }
@@ -36,6 +38,7 @@ public final class FurnitureTextRegistry {
         previous = BY_UUID.put(uuid, entry);
         if (previous != null) BY_ENTITY_ID.remove(previous.getBaseEntityId());
         BY_ENTITY_ID.put(entityId, entry);
+        updateRefreshableCount(previous, entry);
         return entry;
     }
 
@@ -56,13 +59,14 @@ public final class FurnitureTextRegistry {
         if (uuid == null) return;
         FurnitureTextEntry entry = BY_UUID.remove(uuid);
         if (entry != null) BY_ENTITY_ID.remove(entry.getBaseEntityId());
+        updateRefreshableCount(entry, null);
     }
 
     public static void unregister(UUID uuid, int entityId) {
         if (uuid == null) return;
         FurnitureTextEntry entry = BY_UUID.get(uuid);
         if (entry == null || entry.getBaseEntityId() != entityId) return;
-        BY_UUID.remove(uuid, entry);
+        if (BY_UUID.remove(uuid, entry)) updateRefreshableCount(entry, null);
         BY_ENTITY_ID.remove(entityId, entry);
     }
 
@@ -75,10 +79,7 @@ public final class FurnitureTextRegistry {
     }
 
     public static boolean hasRefreshableEntries() {
-        for (FurnitureTextEntry entry : BY_UUID.values()) {
-            if (entry.needsRefresh()) return true;
-        }
-        return false;
+        return REFRESHABLE_ENTRIES.get() > 0;
     }
 
     public static void removeViewer(UUID viewer) {
@@ -91,5 +92,11 @@ public final class FurnitureTextRegistry {
     public static void clear() {
         BY_UUID.clear();
         BY_ENTITY_ID.clear();
+        REFRESHABLE_ENTRIES.set(0);
+    }
+
+    private static void updateRefreshableCount(FurnitureTextEntry previous, FurnitureTextEntry current) {
+        if (previous != null && previous.needsRefresh()) REFRESHABLE_ENTRIES.decrementAndGet();
+        if (current != null && current.needsRefresh()) REFRESHABLE_ENTRIES.incrementAndGet();
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
 
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 
@@ -29,7 +30,7 @@ public final class FurnitureTextRegistry {
         if (baseEntity == null || definitions == null || definitions.isEmpty()) return null;
         UUID uuid = baseEntity.getUniqueId();
         int entityId = baseEntity.getEntityId();
-        Location location = baseEntity.getLocation();
+        Location location = baseLocation(baseEntity);
         FurnitureTextEntry previous = BY_UUID.get(uuid);
         List<FurnitureTextDefinition> copiedDefinitions = List.copyOf(definitions);
         FurnitureTextEntry entry = previous != null && previous.size() == copiedDefinitions.size()
@@ -55,6 +56,14 @@ public final class FurnitureTextRegistry {
 
     public static FurnitureTextEntry byEntityId(int entityId) {
         return BY_ENTITY_ID.get(entityId);
+    }
+
+    public static FurnitureTextEntry updateBaseEntity(Entity baseEntity) {
+        if (baseEntity == null) return null;
+        FurnitureTextEntry entry = byUuid(baseEntity.getUniqueId());
+        if (entry == null || entry.getBaseEntityId() != baseEntity.getEntityId()) return null;
+        entry.updateBaseLocation(baseLocation(baseEntity));
+        return entry;
     }
 
     public static void unregister(UUID uuid) {
@@ -104,5 +113,11 @@ public final class FurnitureTextRegistry {
     private static void updateRefreshableCount(FurnitureTextEntry previous, FurnitureTextEntry current) {
         if (previous != null && previous.needsRefresh()) REFRESHABLE_ENTRIES.decrementAndGet();
         if (current != null && current.needsRefresh()) REFRESHABLE_ENTRIES.incrementAndGet();
+    }
+
+    private static Location baseLocation(Entity baseEntity) {
+        Location location = baseEntity.getLocation();
+        location.setYaw(FurnitureMechanic.getFurnitureYaw(baseEntity));
+        return location;
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -29,7 +29,8 @@ public final class FurnitureTextRegistry {
         int entityId = baseEntity.getEntityId();
         Location location = baseEntity.getLocation();
         FurnitureTextEntry entry = new FurnitureTextEntry(uuid, entityId, location, List.copyOf(definitions));
-        BY_UUID.put(uuid, entry);
+        FurnitureTextEntry previous = BY_UUID.put(uuid, entry);
+        if (previous != null) BY_ENTITY_ID.remove(previous.getBaseEntityId());
         BY_ENTITY_ID.put(entityId, entry);
         return entry;
     }
@@ -46,11 +47,6 @@ public final class FurnitureTextRegistry {
         if (uuid == null) return;
         FurnitureTextEntry entry = BY_UUID.remove(uuid);
         if (entry != null) BY_ENTITY_ID.remove(entry.getBaseEntityId());
-    }
-
-    public static void unregisterByEntityId(int entityId) {
-        FurnitureTextEntry entry = BY_ENTITY_ID.remove(entityId);
-        if (entry != null) BY_UUID.remove(entry.getBaseUuid());
     }
 
     public static boolean isEmpty() {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -28,11 +28,20 @@ public final class FurnitureTextRegistry {
         UUID uuid = baseEntity.getUniqueId();
         int entityId = baseEntity.getEntityId();
         Location location = baseEntity.getLocation();
-        FurnitureTextEntry entry = new FurnitureTextEntry(uuid, entityId, location, List.copyOf(definitions));
-        FurnitureTextEntry previous = BY_UUID.put(uuid, entry);
+        FurnitureTextEntry previous = BY_UUID.get(uuid);
+        List<FurnitureTextDefinition> copiedDefinitions = List.copyOf(definitions);
+        FurnitureTextEntry entry = previous != null && previous.size() == copiedDefinitions.size()
+                ? new FurnitureTextEntry(previous, entityId, location, copiedDefinitions)
+                : new FurnitureTextEntry(uuid, entityId, location, copiedDefinitions);
+        previous = BY_UUID.put(uuid, entry);
         if (previous != null) BY_ENTITY_ID.remove(previous.getBaseEntityId());
         BY_ENTITY_ID.put(entityId, entry);
         return entry;
+    }
+
+    public static boolean canReuse(UUID uuid, int definitionCount) {
+        FurnitureTextEntry entry = byUuid(uuid);
+        return entry == null || entry.size() == definitionCount;
     }
 
     public static FurnitureTextEntry byUuid(UUID uuid) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -1,0 +1,75 @@
+package io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.text;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory registry of placed furniture bases that own virtual text entities.
+ *
+ * <p>Lookup is done by the base entity's UUID (matches the UUID carried in the
+ * SPAWN_ENTITY packet for the base ItemDisplay/ArmorStand/ItemFrame) as well as
+ * by the integer entity id (used when the DESTROY_ENTITIES packet is intercepted).</p>
+ */
+public final class FurnitureTextRegistry {
+
+    private static final Map<UUID, FurnitureTextEntry> BY_UUID = new ConcurrentHashMap<>();
+    private static final Map<Integer, FurnitureTextEntry> BY_ENTITY_ID = new ConcurrentHashMap<>();
+
+    private FurnitureTextRegistry() {
+    }
+
+    public static FurnitureTextEntry register(Entity baseEntity, List<FurnitureTextDefinition> definitions) {
+        if (baseEntity == null || definitions == null || definitions.isEmpty()) return null;
+        UUID uuid = baseEntity.getUniqueId();
+        int entityId = baseEntity.getEntityId();
+        Location location = baseEntity.getLocation();
+        FurnitureTextEntry entry = new FurnitureTextEntry(uuid, entityId, location, List.copyOf(definitions));
+        BY_UUID.put(uuid, entry);
+        BY_ENTITY_ID.put(entityId, entry);
+        return entry;
+    }
+
+    public static FurnitureTextEntry byUuid(UUID uuid) {
+        return uuid == null ? null : BY_UUID.get(uuid);
+    }
+
+    public static FurnitureTextEntry byEntityId(int entityId) {
+        return BY_ENTITY_ID.get(entityId);
+    }
+
+    public static void unregister(UUID uuid) {
+        if (uuid == null) return;
+        FurnitureTextEntry entry = BY_UUID.remove(uuid);
+        if (entry != null) BY_ENTITY_ID.remove(entry.getBaseEntityId());
+    }
+
+    public static void unregisterByEntityId(int entityId) {
+        FurnitureTextEntry entry = BY_ENTITY_ID.remove(entityId);
+        if (entry != null) BY_UUID.remove(entry.getBaseUuid());
+    }
+
+    public static boolean isEmpty() {
+        return BY_UUID.isEmpty();
+    }
+
+    public static Iterable<FurnitureTextEntry> all() {
+        return BY_UUID.values();
+    }
+
+    public static boolean hasRefreshableEntries() {
+        for (FurnitureTextEntry entry : BY_UUID.values()) {
+            if (entry.needsRefresh()) return true;
+        }
+        return false;
+    }
+
+    public static void clear() {
+        BY_UUID.clear();
+        BY_ENTITY_ID.clear();
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -64,6 +64,13 @@ public final class FurnitureTextRegistry {
         return false;
     }
 
+    public static void removeViewer(UUID viewer) {
+        if (viewer == null) return;
+        for (FurnitureTextEntry entry : BY_UUID.values()) {
+            entry.removeViewer(viewer);
+        }
+    }
+
     public static void clear() {
         BY_UUID.clear();
         BY_ENTITY_ID.clear();

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/text/FurnitureTextRegistry.java
@@ -37,12 +37,10 @@ public final class FurnitureTextRegistry {
                 : new FurnitureTextEntry(uuid, entityId, location, copiedDefinitions);
         previous = BY_UUID.put(uuid, entry);
         if (previous != null) {
-            previous.removeTextDisplays();
             BY_ENTITY_ID.remove(previous.getBaseEntityId());
         }
         BY_ENTITY_ID.put(entityId, entry);
         updateRefreshableCount(previous, entry);
-        entry.spawnTextDisplays();
         return entry;
     }
 
@@ -63,7 +61,6 @@ public final class FurnitureTextRegistry {
         if (uuid == null) return;
         FurnitureTextEntry entry = BY_UUID.remove(uuid);
         if (entry != null) {
-            entry.removeTextDisplays();
             BY_ENTITY_ID.remove(entry.getBaseEntityId());
         }
         updateRefreshableCount(entry, null);
@@ -74,7 +71,6 @@ public final class FurnitureTextRegistry {
         FurnitureTextEntry entry = BY_UUID.get(uuid);
         if (entry == null || entry.getBaseEntityId() != entityId) return;
         if (BY_UUID.remove(uuid, entry)) {
-            entry.removeTextDisplays();
             updateRefreshableCount(entry, null);
         }
         BY_ENTITY_ID.remove(entityId, entry);
@@ -100,9 +96,6 @@ public final class FurnitureTextRegistry {
     }
 
     public static void clear() {
-        for (FurnitureTextEntry entry : BY_UUID.values()) {
-            entry.removeTextDisplays();
-        }
         BY_UUID.clear();
         BY_ENTITY_ID.clear();
         REFRESHABLE_ENTRIES.set(0);

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -1,6 +1,7 @@
 package io.th0rgal.oraxen.nms;
 
 import io.th0rgal.oraxen.items.ItemBuilder;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
@@ -13,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 public interface NMSHandler {
 
@@ -113,6 +115,16 @@ public interface NMSHandler {
      * Send entity destroy packet
      */
     default void sendEntityDestroy(Player viewer, int... entityIds) {
+    }
+
+    default boolean spawnTextDisplay(Player viewer, int entityId, UUID uuid, Location location, Component text,
+                                     byte billboard, float viewRange, int backgroundArgb, byte flags) {
+        return false;
+    }
+
+    default boolean sendTextDisplayMetadata(Player viewer, int entityId, Component text,
+                                            byte billboard, float viewRange, int backgroundArgb, byte flags) {
+        return false;
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/NMSHandler.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
 
 import java.util.Map;
 import java.util.Set;
@@ -118,12 +119,14 @@ public interface NMSHandler {
     }
 
     default boolean spawnTextDisplay(Player viewer, int entityId, UUID uuid, Location location, Component text,
-                                     byte billboard, float viewRange, int backgroundArgb, byte flags) {
+                                     Vector3f scale, byte billboard, float viewRange, int lineWidth,
+                                     int backgroundArgb, byte textOpacity, byte flags) {
         return false;
     }
 
     default boolean sendTextDisplayMetadata(Player viewer, int entityId, Component text,
-                                            byte billboard, float viewRange, int backgroundArgb, byte flags) {
+                                            Vector3f scale, byte billboard, float viewRange, int lineWidth,
+                                            int backgroundArgb, byte textOpacity, byte flags) {
         return false;
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/MultiVersionPackGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/MultiVersionPackGenerator.java
@@ -95,6 +95,7 @@ public class MultiVersionPackGenerator {
         OraxenPackGeneratedEvent event = new OraxenPackGeneratedEvent(output);
         EventUtils.callEvent(event);
         output = event.getOutput();
+        PackObfuscator.obfuscate(output);
 
         // Define which pack versions to generate
         versionManager.definePackVersions();

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -77,9 +77,10 @@ public final class PackObfuscator {
 
             for (FileData file : files) {
                 String originalPath = file.path;
-                file.path = filePaths.getOrDefault(file.path, file.path);
                 if (file.isJson()) rewriteJson(file);
-                if (!file.path.equals(originalPath)) file.virtualFile.setPath(file.path);
+                String rewrittenPath = filePaths.getOrDefault(originalPath, originalPath);
+                if (!rewrittenPath.equals(originalPath)) file.virtualFile.setPath(rewrittenPath);
+                file.path = rewrittenPath;
                 file.virtualFile.setInputStream(new ByteArrayInputStream(file.content));
             }
 
@@ -193,7 +194,9 @@ public final class PackObfuscator {
 
             if (prop.equals("file") || prop.equals("texture") || prop.equals("resource") || prop.equals("sprite")
                     || prop.equals("particle") || prop.startsWith("layer") || isTextureFace(prop)) {
-                String replacement = lookup(textureKeys, value, namespace);
+                String replacement = prop.equals("file")
+                        ? lookup(textureKeys, value, namespace, extensionFrom(value))
+                        : lookup(textureKeys, value, namespace);
                 if (replacement != null) return replacement;
             }
 
@@ -228,14 +231,18 @@ public final class PackObfuscator {
         }
 
         private String lookup(Map<String, String> map, String value, String namespace) {
+            return lookup(map, value, namespace, "");
+        }
+
+        private String lookup(Map<String, String> map, String value, String namespace, String suffix) {
             String direct = stripKnownExtension(value);
-            if (direct.contains(":")) return map.get(direct);
+            if (direct.contains(":")) return appendSuffix(map.get(direct), suffix);
 
             String local = namespace + ":" + direct;
             String replacement = map.get(local);
-            if (replacement != null) return replacement;
+            if (replacement != null) return appendSuffix(replacement, suffix);
 
-            return map.get("minecraft:" + direct);
+            return appendSuffix(map.get("minecraft:" + direct), suffix);
         }
 
         private String obfuscateKey(String originalKey, String prefix) {
@@ -272,6 +279,18 @@ public final class PackObfuscator {
             if (stripped.endsWith(".png")) stripped = stripped.substring(0, stripped.length() - 4);
             if (stripped.endsWith(".ogg")) stripped = stripped.substring(0, stripped.length() - 4);
             return stripped;
+        }
+
+        private static String extensionFrom(String value) {
+            if (value == null) return "";
+            if (value.endsWith(".json")) return ".json";
+            if (value.endsWith(".png")) return ".png";
+            if (value.endsWith(".ogg")) return ".ogg";
+            return "";
+        }
+
+        private static String appendSuffix(String value, String suffix) {
+            return value == null ? null : value + suffix;
         }
 
         private static String keyFromPackPath(String path, String marker, String suffix) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -29,11 +29,19 @@ public final class PackObfuscator {
     }
 
     public static void obfuscate(List<VirtualFile> output) {
-        Type type = Type.from(Settings.PACK_OBFUSCATION_TYPE.toString());
+        obfuscate(output, Settings.PACK_OBFUSCATION_TYPE.toString(), true);
+    }
+
+    static void obfuscate(List<VirtualFile> output, String rawType) {
+        obfuscate(output, rawType, true);
+    }
+
+    static void obfuscate(List<VirtualFile> output, String rawType, boolean logSummary) {
+        Type type = Type.from(rawType);
         if (type == Type.NONE || output == null || output.isEmpty()) return;
 
         try {
-            new Pass(type).run(output);
+            new Pass(type, logSummary).run(output);
         } catch (Exception exception) {
             Logs.logError("Failed to obfuscate resource pack. Keeping readable pack output.");
             if (Settings.DEBUG.toBool()) exception.printStackTrace();
@@ -60,14 +68,16 @@ public final class PackObfuscator {
 
     private static final class Pass {
         private final Type type;
+        private final boolean logSummary;
         private final Map<String, String> namespaceMap = new LinkedHashMap<>();
         private final Map<String, String> modelKeys = new LinkedHashMap<>();
         private final Map<String, String> textureKeys = new LinkedHashMap<>();
         private final Map<String, String> soundKeys = new LinkedHashMap<>();
         private final Map<String, String> filePaths = new LinkedHashMap<>();
 
-        private Pass(Type type) {
+        private Pass(Type type, boolean logSummary) {
             this.type = type;
+            this.logSummary = logSummary;
         }
 
         private void run(List<VirtualFile> output) throws Exception {
@@ -84,8 +94,10 @@ public final class PackObfuscator {
                 file.virtualFile.setInputStream(new ByteArrayInputStream(file.content));
             }
 
-            Logs.logInfo("Obfuscated resource pack keys: " + modelKeys.size() + " models, "
-                    + textureKeys.size() + " textures, " + soundKeys.size() + " sounds");
+            if (logSummary) {
+                Logs.logInfo("Obfuscated resource pack keys: " + modelKeys.size() + " models, "
+                        + textureKeys.size() + " textures, " + soundKeys.size() + " sounds");
+            }
         }
 
         private List<FileData> materialize(List<VirtualFile> output) throws Exception {
@@ -205,10 +217,10 @@ public final class PackObfuscator {
                 if (replacement != null) return replacement;
             }
 
-            String model = lookup(modelKeys, value, namespace);
-            if (model != null) return model;
             String texture = lookup(textureKeys, value, namespace);
             if (texture != null) return texture;
+            String model = lookup(modelKeys, value, namespace);
+            if (model != null) return model;
             String sound = lookup(soundKeys, value, namespace);
             return sound != null ? sound : value;
         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -448,28 +448,6 @@ public final class PackObfuscator {
             return sprites;
         }
 
-        private Set<String> collectAtlasTextureKeys(JsonElement atlas, String namespace) {
-            Set<String> keys = new HashSet<>();
-            if (atlas == null || !atlas.isJsonObject()) return keys;
-            JsonObject object = atlas.getAsJsonObject();
-            if (!object.has("sources") || !object.get("sources").isJsonArray()) return keys;
-
-            for (JsonElement sourceElement : object.getAsJsonArray("sources")) {
-                if (!sourceElement.isJsonObject()) continue;
-                JsonObject source = sourceElement.getAsJsonObject();
-                String type = source.has("type") && source.get("type").isJsonPrimitive()
-                        ? source.get("type").getAsString()
-                        : "";
-                if (type.endsWith("single")) {
-                    addAtlasSingleReference(source, "resource", namespace, keys);
-                    addAtlasSingleReference(source, "sprite", namespace, keys);
-                } else if (type.endsWith("directory")) {
-                    addAtlasDirectoryReferences(source, namespace, keys);
-                }
-            }
-            return keys;
-        }
-
         private void addAtlasSingleReference(JsonObject source, String property, String namespace, Set<String> keys) {
             if (!source.has(property) || !source.get(property).isJsonPrimitive()) return;
             String value = stripKnownExtension(source.get(property).getAsString());
@@ -510,16 +488,6 @@ public final class PackObfuscator {
 
         private static String namespacedKey(String value, String namespace) {
             return value.contains(":") ? value : namespace + ":" + value;
-        }
-
-        private void addAtlasDirectoryReferences(JsonObject source, String namespace, Set<String> keys) {
-            if (!source.has("source") || !source.get("source").isJsonPrimitive()) return;
-            String directory = stripKnownExtension(source.get("source").getAsString());
-            String explicitNamespace = directory.contains(":") ? directory.substring(0, directory.indexOf(':')) : namespace;
-            String path = directory.contains(":") ? directory.substring(directory.indexOf(':') + 1) : directory;
-            for (String key : textureKeys.keySet()) {
-                if (isKeyUnderDirectory(key, explicitNamespace, path)) keys.add(key);
-            }
         }
 
         private static boolean isKeyUnderDirectory(String key, String namespace, String directory) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -291,7 +291,8 @@ public final class PackObfuscator {
             if (element == null || element.isJsonNull()) return;
             if (element.isJsonObject()) {
                 for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
-                    collectReferencedTextureKeys(entry.getValue(), entry.getKey(), namespace, keys);
+                    String childProperty = "textures".equalsIgnoreCase(property) ? "texture" : entry.getKey();
+                    collectReferencedTextureKeys(entry.getValue(), childProperty, namespace, keys);
                 }
                 return;
             }
@@ -331,7 +332,8 @@ public final class PackObfuscator {
                 JsonObject object = element.getAsJsonObject();
                 JsonObject copy = new JsonObject();
                 for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
-                    copy.add(entry.getKey(), rewriteElement(entry.getValue(), entry.getKey(), namespace, soundsJson));
+                    String childProperty = "textures".equalsIgnoreCase(property) ? "texture" : entry.getKey();
+                    copy.add(entry.getKey(), rewriteElement(entry.getValue(), childProperty, namespace, soundsJson));
                 }
                 return copy;
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -375,7 +375,7 @@ public final class PackObfuscator {
                 return replacement != null ? replacement : value;
             }
             if (soundsJson && isSoundProperty(prop)) return replaceOrOriginal(soundKeys, value, namespace);
-            if (prop.equals("when")) return value;
+            if (prop.equals("type") || prop.equals("when")) return value;
 
             String model = lookup(modelKeys, value, namespace);
             if (model != null) return model;

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -329,32 +329,39 @@ public final class PackObfuscator {
 
         private JsonElement rewriteElement(JsonElement element, String property, String namespace, boolean soundsJson) {
             if (element == null || element.isJsonNull()) return element;
-            if (element.isJsonObject()) {
-                JsonObject object = element.getAsJsonObject();
-                JsonObject copy = new JsonObject();
-                for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
-                    String childProperty = "textures".equalsIgnoreCase(property) ? "texture" : entry.getKey();
-                    if ("sprite".equals(childProperty) && isAtlasSource(object)) {
-                        copy.add(entry.getKey(), entry.getValue());
-                        continue;
-                    }
-                    copy.add(entry.getKey(), rewriteElement(entry.getValue(), childProperty, namespace, soundsJson));
-                }
-                return copy;
-            }
-            if (element.isJsonArray()) {
-                JsonArray array = element.getAsJsonArray();
-                JsonArray copy = new JsonArray();
-                for (JsonElement child : array) {
-                    copy.add(rewriteElement(child, property, namespace, soundsJson));
-                }
-                return copy;
-            }
+            if (element.isJsonObject()) return rewriteObject(element.getAsJsonObject(), property, namespace, soundsJson);
+            if (element.isJsonArray()) return rewriteArray(element.getAsJsonArray(), property, namespace, soundsJson);
             if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) return element;
 
             String value = element.getAsString();
             String replacement = rewriteString(property, value, namespace, soundsJson);
             return replacement.equals(value) ? element : new JsonPrimitive(replacement);
+        }
+
+        private JsonObject rewriteObject(JsonObject object, String property, String namespace, boolean soundsJson) {
+            JsonObject copy = new JsonObject();
+            for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+                String childProperty = "textures".equalsIgnoreCase(property) ? "texture" : entry.getKey();
+                if (shouldKeepRawValue(object, childProperty, soundsJson)) {
+                    copy.add(entry.getKey(), entry.getValue());
+                    continue;
+                }
+                copy.add(entry.getKey(), rewriteElement(entry.getValue(), childProperty, namespace, soundsJson));
+            }
+            return copy;
+        }
+
+        private JsonArray rewriteArray(JsonArray array, String property, String namespace, boolean soundsJson) {
+            JsonArray copy = new JsonArray();
+            for (JsonElement child : array) {
+                copy.add(rewriteElement(child, property, namespace, soundsJson));
+            }
+            return copy;
+        }
+
+        private boolean shouldKeepRawValue(JsonObject object, String property, boolean soundsJson) {
+            return "sprite".equals(property) && isAtlasSource(object)
+                    || soundsJson && "name".equalsIgnoreCase(property) && isSoundEventReference(object);
         }
 
         private String rewriteString(String property, String value, String namespace, boolean soundsJson) {
@@ -397,6 +404,12 @@ public final class PackObfuscator {
 
         private static boolean isSoundProperty(String prop) {
             return prop.equals("name") || prop.equals("sounds");
+        }
+
+        private static boolean isSoundEventReference(JsonObject object) {
+            if (!object.has("type") || !object.get("type").isJsonPrimitive()) return false;
+            String type = object.get("type").getAsString();
+            return type.equals("event") || type.equals("minecraft:event");
         }
 
         private void addAtlasSingles(JsonObject atlas, JsonElement originalAtlas, String namespace, boolean includeAll) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -200,23 +200,8 @@ public final class PackObfuscator {
             if (value == null || value.isBlank() || value.startsWith("#")) return value;
             String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
 
-            if (prop.equals("parent") || prop.equals("model") || prop.equals("base")) {
-                String replacement = lookup(modelKeys, value, namespace);
-                if (replacement != null) return replacement;
-            }
-
-            if (prop.equals("file") || prop.equals("texture") || prop.equals("resource") || prop.equals("sprite")
-                    || prop.equals("particle") || prop.startsWith("layer") || isTextureFace(prop)) {
-                String replacement = prop.equals("file")
-                        ? lookup(textureKeys, value, namespace, extensionFrom(value))
-                        : lookup(textureKeys, value, namespace);
-                if (replacement != null) return replacement;
-            }
-
-            if (prop.equals("name") || prop.equals("sounds")) {
-                String replacement = lookup(soundKeys, value, namespace);
-                if (replacement != null) return replacement;
-            }
+            String propertyReplacement = rewriteKnownProperty(prop, value, namespace);
+            if (propertyReplacement != null) return propertyReplacement;
 
             String model = lookup(modelKeys, value, namespace);
             if (model != null) return model;
@@ -224,6 +209,32 @@ public final class PackObfuscator {
             if (texture != null) return texture;
             String sound = lookup(soundKeys, value, namespace);
             return sound != null ? sound : value;
+        }
+
+        private String rewriteKnownProperty(String prop, String value, String namespace) {
+            if (isModelProperty(prop)) return lookup(modelKeys, value, namespace);
+            if (isTextureProperty(prop)) return lookupTextureProperty(prop, value, namespace);
+            if (isSoundProperty(prop)) return lookup(soundKeys, value, namespace);
+            return null;
+        }
+
+        private String lookupTextureProperty(String prop, String value, String namespace) {
+            return prop.equals("file")
+                    ? lookup(textureKeys, value, namespace, extensionFrom(value))
+                    : lookup(textureKeys, value, namespace);
+        }
+
+        private static boolean isModelProperty(String prop) {
+            return prop.equals("parent") || prop.equals("model") || prop.equals("base");
+        }
+
+        private static boolean isTextureProperty(String prop) {
+            return prop.equals("file") || prop.equals("texture") || prop.equals("resource") || prop.equals("sprite")
+                    || prop.equals("particle") || prop.startsWith("layer") || isTextureFace(prop);
+        }
+
+        private static boolean isSoundProperty(String prop) {
+            return prop.equals("name") || prop.equals("sounds");
         }
 
         private void addAtlasSingles(JsonObject atlas) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -16,10 +16,12 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public final class PackObfuscator {
 
@@ -120,11 +122,14 @@ public final class PackObfuscator {
         }
 
         private void collectRenames(List<FileData> files) {
+            Set<String> referencedTextureKeys = collectReferencedTextureKeys(files);
+
             for (FileData file : files) {
                 String path = file.path;
 
                 if (isTexture(path)) {
                     String originalKey = keyFromPackPath(path, "/textures/", ".png");
+                    if (isUntrackedVanillaTexture(originalKey, referencedTextureKeys)) continue;
                     String obfuscatedKey = obfuscateKey(originalKey, "t");
                     textureKeys.put(originalKey, obfuscatedKey);
                     filePaths.put(path, texturePath(obfuscatedKey, ".png"));
@@ -134,6 +139,7 @@ public final class PackObfuscator {
                 if (isTextureMetadata(path)) {
                     String pngPath = path.substring(0, path.length() - ".mcmeta".length());
                     String originalKey = keyFromPackPath(pngPath, "/textures/", ".png");
+                    if (isUntrackedVanillaTexture(originalKey, referencedTextureKeys)) continue;
                     String obfuscatedKey = obfuscateKey(originalKey, "t");
                     textureKeys.put(originalKey, obfuscatedKey);
                     filePaths.put(path, texturePath(obfuscatedKey, ".png.mcmeta"));
@@ -155,6 +161,42 @@ public final class PackObfuscator {
                     filePaths.put(path, soundPath(obfuscatedKey));
                 }
             }
+        }
+
+        private Set<String> collectReferencedTextureKeys(List<FileData> files) {
+            Set<String> keys = new HashSet<>();
+            for (FileData file : files) {
+                if (!file.isJson()) continue;
+                JsonElement parsed;
+                try {
+                    parsed = JsonParser.parseString(new String(file.content, StandardCharsets.UTF_8));
+                } catch (Exception ignored) {
+                    continue;
+                }
+                collectReferencedTextureKeys(parsed, null, namespaceFromPath(file.path), keys);
+            }
+            return keys;
+        }
+
+        private void collectReferencedTextureKeys(JsonElement element, String property, String namespace, Set<String> keys) {
+            if (element == null || element.isJsonNull()) return;
+            if (element.isJsonObject()) {
+                for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                    collectReferencedTextureKeys(entry.getValue(), entry.getKey(), namespace, keys);
+                }
+                return;
+            }
+            if (element.isJsonArray()) {
+                for (JsonElement child : element.getAsJsonArray()) {
+                    collectReferencedTextureKeys(child, property, namespace, keys);
+                }
+                return;
+            }
+            if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) return;
+
+            String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
+            if (!isTextureProperty(prop)) return;
+            addTextureReference(element.getAsString(), namespace, keys);
         }
 
         private void rewriteJson(FileData file) {
@@ -200,8 +242,12 @@ public final class PackObfuscator {
             if (value == null || value.isBlank() || value.startsWith("#")) return value;
             String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
 
-            String propertyReplacement = rewriteKnownProperty(prop, value, namespace);
-            if (propertyReplacement != null) return propertyReplacement;
+            if (isModelProperty(prop)) return replaceOrOriginal(modelKeys, value, namespace);
+            if (isTextureProperty(prop)) {
+                String replacement = lookupTextureProperty(prop, value, namespace);
+                return replacement != null ? replacement : value;
+            }
+            if (isSoundProperty(prop)) return replaceOrOriginal(soundKeys, value, namespace);
 
             String model = lookup(modelKeys, value, namespace);
             if (model != null) return model;
@@ -211,11 +257,9 @@ public final class PackObfuscator {
             return sound != null ? sound : value;
         }
 
-        private String rewriteKnownProperty(String prop, String value, String namespace) {
-            if (isModelProperty(prop)) return lookup(modelKeys, value, namespace);
-            if (isTextureProperty(prop)) return lookupTextureProperty(prop, value, namespace);
-            if (isSoundProperty(prop)) return lookup(soundKeys, value, namespace);
-            return null;
+        private String replaceOrOriginal(Map<String, String> map, String value, String namespace) {
+            String replacement = lookup(map, value, namespace);
+            return replacement != null ? replacement : value;
         }
 
         private String lookupTextureProperty(String prop, String value, String namespace) {
@@ -315,6 +359,21 @@ public final class PackObfuscator {
 
         private static String appendSuffix(String value, String suffix) {
             return value == null ? null : value + suffix;
+        }
+
+        private static boolean isUntrackedVanillaTexture(String key, Set<String> referencedTextureKeys) {
+            return key.startsWith("minecraft:") && !referencedTextureKeys.contains(key);
+        }
+
+        private static void addTextureReference(String value, String namespace, Set<String> keys) {
+            if (value == null || value.isBlank() || value.startsWith("#")) return;
+            String stripped = stripKnownExtension(value);
+            if (stripped.contains(":")) {
+                keys.add(stripped);
+                return;
+            }
+            keys.add(namespace + ":" + stripped);
+            keys.add("minecraft:" + stripped);
         }
 
         private static String keyFromPackPath(String path, String marker, String suffix) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -122,6 +122,7 @@ public final class PackObfuscator {
         }
 
         private void collectRenames(List<FileData> files) {
+            Set<String> referencedModelKeys = collectReferencedModelKeys(files);
             Set<String> referencedTextureKeys = collectReferencedTextureKeys(files);
             Set<String> referencedSoundKeys = collectReferencedSoundKeys(files);
 
@@ -149,6 +150,7 @@ public final class PackObfuscator {
 
                 if (isModel(path) && !isStableModelRoot(path)) {
                     String originalKey = keyFromPackPath(path, "/models/", ".json");
+                    if (isUntrackedVanillaModel(originalKey, referencedModelKeys)) continue;
                     String obfuscatedKey = obfuscateKey(originalKey, "m");
                     modelKeys.put(originalKey, obfuscatedKey);
                     filePaths.put(path, modelPath(obfuscatedKey));
@@ -179,6 +181,42 @@ public final class PackObfuscator {
                 if (isAtlas(file.path)) collectAtlasTextureKeys(parsed, namespaceFromPath(file.path), files, keys);
             }
             return keys;
+        }
+
+        private Set<String> collectReferencedModelKeys(List<FileData> files) {
+            Set<String> keys = new HashSet<>();
+            for (FileData file : files) {
+                if (!file.isJson()) continue;
+                JsonElement parsed;
+                try {
+                    parsed = JsonParser.parseString(new String(file.content, StandardCharsets.UTF_8));
+                } catch (Exception ignored) {
+                    continue;
+                }
+                collectReferencedModelKeys(parsed, null, namespaceFromPath(file.path), keys);
+            }
+            return keys;
+        }
+
+        private void collectReferencedModelKeys(JsonElement element, String property, String namespace, Set<String> keys) {
+            if (element == null || element.isJsonNull()) return;
+            if (element.isJsonObject()) {
+                for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                    collectReferencedModelKeys(entry.getValue(), entry.getKey(), namespace, keys);
+                }
+                return;
+            }
+            if (element.isJsonArray()) {
+                for (JsonElement child : element.getAsJsonArray()) {
+                    collectReferencedModelKeys(child, property, namespace, keys);
+                }
+                return;
+            }
+            if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) return;
+
+            String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
+            if (!isModelProperty(prop)) return;
+            addResourceReference(element.getAsString(), namespace, keys);
         }
 
         private void collectAtlasTextureKeys(JsonElement atlas, String namespace, List<FileData> files, Set<String> keys) {
@@ -246,7 +284,7 @@ public final class PackObfuscator {
 
             String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
             if (!isSoundProperty(prop)) return;
-            addSoundReference(element.getAsString(), namespace, keys);
+            addResourceReference(element.getAsString(), namespace, keys);
         }
 
         private void collectReferencedTextureKeys(JsonElement element, String property, String namespace, Set<String> keys) {
@@ -267,7 +305,7 @@ public final class PackObfuscator {
 
             String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
             if (!isTextureProperty(prop)) return;
-            addTextureReference(element.getAsString(), namespace, keys);
+            addResourceReference(element.getAsString(), namespace, keys);
         }
 
         private void rewriteJson(FileData file) {
@@ -495,22 +533,16 @@ public final class PackObfuscator {
             return key.startsWith("minecraft:") && !referencedTextureKeys.contains(key);
         }
 
+        private static boolean isUntrackedVanillaModel(String key, Set<String> referencedModelKeys) {
+            return key.startsWith("minecraft:") && !referencedModelKeys.contains(key);
+        }
+
         private static boolean isUntrackedVanillaSound(String key, Set<String> referencedSoundKeys) {
             return key.startsWith("minecraft:") && !referencedSoundKeys.contains(key);
         }
 
-        private static void addTextureReference(String value, String namespace, Set<String> keys) {
+        private static void addResourceReference(String value, String namespace, Set<String> keys) {
             if (value == null || value.isBlank() || value.startsWith("#")) return;
-            String stripped = stripKnownExtension(value);
-            if (stripped.contains(":")) {
-                keys.add(stripped);
-                return;
-            }
-            keys.add(namespace + ":" + stripped);
-        }
-
-        private static void addSoundReference(String value, String namespace, Set<String> keys) {
-            if (value == null || value.isBlank()) return;
             String stripped = stripKnownExtension(value);
             if (stripped.contains(":")) {
                 keys.add(stripped);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -362,8 +362,7 @@ public final class PackObfuscator {
         }
 
         private boolean shouldKeepRawValue(JsonObject object, String property, boolean soundsJson) {
-            return "sprite".equals(property) && isAtlasSource(object)
-                    || soundsJson && "name".equalsIgnoreCase(property) && isSoundEventReference(object);
+            return soundsJson && "name".equalsIgnoreCase(property) && isSoundEventReference(object);
         }
 
         private String rewriteString(String property, String value, String namespace, boolean soundsJson) {
@@ -432,7 +431,7 @@ public final class PackObfuscator {
                 JsonObject source = new JsonObject();
                 source.addProperty("type", "single");
                 source.addProperty("resource", obfuscatedKey);
-                source.addProperty("sprite", entry.getValue());
+                source.addProperty("sprite", replaceOrOriginal(textureKeys, entry.getValue(), namespace));
                 sources.add(source);
             }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -232,7 +232,6 @@ public final class PackObfuscator {
                         : "";
                 if (type.endsWith("single")) {
                     addAtlasSingleReference(source, "resource", namespace, keys);
-                    addAtlasSingleReference(source, "sprite", namespace, keys);
                 } else if (type.endsWith("directory")) {
                     addAtlasDirectoryReferences(source, namespace, files, keys);
                 }
@@ -290,8 +289,10 @@ public final class PackObfuscator {
         private void collectReferencedTextureKeys(JsonElement element, String property, String namespace, Set<String> keys) {
             if (element == null || element.isJsonNull()) return;
             if (element.isJsonObject()) {
-                for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                JsonObject object = element.getAsJsonObject();
+                for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
                     String childProperty = "textures".equalsIgnoreCase(property) ? "texture" : entry.getKey();
+                    if ("sprite".equals(childProperty) && isAtlasSource(object)) continue;
                     collectReferencedTextureKeys(entry.getValue(), childProperty, namespace, keys);
                 }
                 return;
@@ -333,6 +334,10 @@ public final class PackObfuscator {
                 JsonObject copy = new JsonObject();
                 for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
                     String childProperty = "textures".equalsIgnoreCase(property) ? "texture" : entry.getKey();
+                    if ("sprite".equals(childProperty) && isAtlasSource(object)) {
+                        copy.add(entry.getKey(), entry.getValue());
+                        continue;
+                    }
                     copy.add(entry.getKey(), rewriteElement(entry.getValue(), childProperty, namespace, soundsJson));
                 }
                 return copy;
@@ -399,7 +404,7 @@ public final class PackObfuscator {
         private void addAtlasSingles(JsonObject atlas, JsonElement originalAtlas, String namespace, boolean includeAll) {
             if (textureKeys.isEmpty()) return;
             Map<String, String> atlasSprites = includeAll
-                    ? collectAllAtlasSprites()
+                    ? new LinkedHashMap<>(textureKeys)
                     : collectAtlasSprites(originalAtlas, namespace);
             if (atlasSprites.isEmpty()) return;
 
@@ -419,14 +424,6 @@ public final class PackObfuscator {
             }
 
             atlas.add("sources", sources);
-        }
-
-        private Map<String, String> collectAllAtlasSprites() {
-            Map<String, String> sprites = new LinkedHashMap<>();
-            for (Map.Entry<String, String> entry : textureKeys.entrySet()) {
-                sprites.put(entry.getKey(), entry.getValue());
-            }
-            return sprites;
         }
 
         private Map<String, String> collectAtlasSprites(JsonElement atlas, String namespace) {
@@ -486,6 +483,13 @@ public final class PackObfuscator {
         private static String atlasProperty(JsonObject source, String property) {
             if (!source.has(property) || !source.get(property).isJsonPrimitive()) return null;
             return stripKnownExtension(source.get(property).getAsString());
+        }
+
+        private static boolean isAtlasSource(JsonObject object) {
+            if (!object.has("type") || !object.get("type").isJsonPrimitive()) return false;
+            String type = object.get("type").getAsString();
+            return (type.endsWith("single") || type.endsWith("directory"))
+                    && (object.has("resource") || object.has("source"));
         }
 
         private static String namespacedKey(String value, String namespace) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -213,15 +213,15 @@ public final class PackObfuscator {
                 if (replacement != null) return replacement;
             }
 
-            if (prop.equals("name")) {
+            if (prop.equals("name") || prop.equals("sounds")) {
                 String replacement = lookup(soundKeys, value, namespace);
                 if (replacement != null) return replacement;
             }
 
-            String texture = lookup(textureKeys, value, namespace);
-            if (texture != null) return texture;
             String model = lookup(modelKeys, value, namespace);
             if (model != null) return model;
+            String texture = lookup(textureKeys, value, namespace);
+            if (texture != null) return texture;
             String sound = lookup(soundKeys, value, namespace);
             return sound != null ? sound : value;
         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -407,7 +407,6 @@ public final class PackObfuscator {
                 keys.add(value);
             } else {
                 keys.add(namespace + ":" + value);
-                keys.add("minecraft:" + value);
             }
         }
 
@@ -508,7 +507,6 @@ public final class PackObfuscator {
                 return;
             }
             keys.add(namespace + ":" + stripped);
-            keys.add("minecraft:" + stripped);
         }
 
         private static void addSoundReference(String value, String namespace, Set<String> keys) {
@@ -519,7 +517,6 @@ public final class PackObfuscator {
                 return;
             }
             keys.add(namespace + ":" + stripped);
-            keys.add("minecraft:" + stripped);
         }
 
         private static String keyFromPackPath(String path, String marker, String suffix) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -372,9 +372,7 @@ public final class PackObfuscator {
             String model = lookup(modelKeys, value, namespace);
             if (model != null) return model;
             String texture = lookup(textureKeys, value, namespace);
-            if (texture != null) return texture;
-            String sound = lookup(soundKeys, value, namespace);
-            return sound != null ? sound : value;
+            return texture != null ? texture : value;
         }
 
         private String replaceOrOriginal(Map<String, String> map, String value, String namespace) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -268,7 +268,9 @@ public final class PackObfuscator {
         private void collectReferencedSoundKeys(JsonElement element, String property, String namespace, Set<String> keys) {
             if (element == null || element.isJsonNull()) return;
             if (element.isJsonObject()) {
-                for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                JsonObject object = element.getAsJsonObject();
+                for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+                    if ("name".equalsIgnoreCase(entry.getKey()) && isSoundEventReference(object)) continue;
                     collectReferencedSoundKeys(entry.getValue(), entry.getKey(), namespace, keys);
                 }
                 return;
@@ -610,16 +612,23 @@ public final class PackObfuscator {
 
         private static String keyFromPackPath(String path, String marker, String suffix) {
             String normalized = path.replace('\\', '/');
-            String namespace = normalized.substring("assets/".length(), normalized.indexOf('/', "assets/".length()));
-            String resourcePath = normalized.substring(normalized.indexOf(marker) + marker.length(), normalized.length() - suffix.length());
+            int namespaceEnd = normalized.indexOf('/', "assets/".length());
+            String namespace = normalized.substring("assets/".length(), namespaceEnd);
+            int resourceStart = normalized.indexOf(marker, namespaceEnd) + marker.length();
+            String resourcePath = normalized.substring(resourceStart, normalized.length() - suffix.length());
             return namespace + ":" + resourcePath;
         }
 
         private static String namespaceFromPath(String path) {
             String normalized = path.replace('\\', '/');
-            if (!normalized.startsWith("assets/")) return "minecraft";
-            int end = normalized.indexOf('/', "assets/".length());
-            return end == -1 ? "minecraft" : normalized.substring("assets/".length(), end);
+            if (normalized.startsWith("assets/")) return namespaceFromPath(normalized, "assets/");
+            if (normalized.startsWith("data/")) return namespaceFromPath(normalized, "data/");
+            return "minecraft";
+        }
+
+        private static String namespaceFromPath(String normalized, String root) {
+            int end = normalized.indexOf('/', root.length());
+            return end == -1 ? "minecraft" : normalized.substring(root.length(), end);
         }
 
         private static String modelPath(String key) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -176,8 +176,41 @@ public final class PackObfuscator {
                     continue;
                 }
                 collectReferencedTextureKeys(parsed, null, namespaceFromPath(file.path), keys);
+                if (isAtlas(file.path)) collectAtlasTextureKeys(parsed, namespaceFromPath(file.path), files, keys);
             }
             return keys;
+        }
+
+        private void collectAtlasTextureKeys(JsonElement atlas, String namespace, List<FileData> files, Set<String> keys) {
+            if (atlas == null || !atlas.isJsonObject()) return;
+            JsonObject object = atlas.getAsJsonObject();
+            if (!object.has("sources") || !object.get("sources").isJsonArray()) return;
+
+            for (JsonElement sourceElement : object.getAsJsonArray("sources")) {
+                if (!sourceElement.isJsonObject()) continue;
+                JsonObject source = sourceElement.getAsJsonObject();
+                String type = source.has("type") && source.get("type").isJsonPrimitive()
+                        ? source.get("type").getAsString()
+                        : "";
+                if (type.endsWith("single")) {
+                    addAtlasSingleReference(source, "resource", namespace, keys);
+                    addAtlasSingleReference(source, "sprite", namespace, keys);
+                } else if (type.endsWith("directory")) {
+                    addAtlasDirectoryReferences(source, namespace, files, keys);
+                }
+            }
+        }
+
+        private void addAtlasDirectoryReferences(JsonObject source, String namespace, List<FileData> files, Set<String> keys) {
+            if (!source.has("source") || !source.get("source").isJsonPrimitive()) return;
+            String directory = stripKnownExtension(source.get("source").getAsString());
+            String explicitNamespace = directory.contains(":") ? directory.substring(0, directory.indexOf(':')) : namespace;
+            String path = directory.contains(":") ? directory.substring(directory.indexOf(':') + 1) : directory;
+            for (FileData file : files) {
+                if (!isTexture(file.path)) continue;
+                String key = keyFromPackPath(file.path, "/textures/", ".png");
+                if (isKeyUnderDirectory(key, explicitNamespace, path)) keys.add(key);
+            }
         }
 
         private Set<String> collectReferencedSoundKeys(List<FileData> files) {
@@ -248,7 +281,9 @@ public final class PackObfuscator {
             String namespace = namespaceFromPath(file.path);
             boolean soundsJson = isSoundsJson(file.path);
             JsonElement rewritten = rewriteElement(parsed, null, namespace, soundsJson);
-            if (isBlocksAtlas(file.path) && rewritten.isJsonObject()) addAtlasSingles(rewritten.getAsJsonObject());
+            if (isAtlas(file.path) && rewritten.isJsonObject()) {
+                addAtlasSingles(rewritten.getAsJsonObject(), parsed, namespace, isBlocksAtlas(file.path));
+            }
             file.content = GSON.toJson(rewritten).getBytes(StandardCharsets.UTF_8);
         }
 
@@ -321,13 +356,18 @@ public final class PackObfuscator {
             return prop.equals("name") || prop.equals("sounds");
         }
 
-        private void addAtlasSingles(JsonObject atlas) {
+        private void addAtlasSingles(JsonObject atlas, JsonElement originalAtlas, String namespace, boolean includeAll) {
             if (textureKeys.isEmpty()) return;
+            Set<String> atlasTextureKeys = includeAll ? textureKeys.keySet() : collectAtlasTextureKeys(originalAtlas, namespace);
+            if (atlasTextureKeys.isEmpty()) return;
+
             JsonArray sources = atlas.has("sources") && atlas.get("sources").isJsonArray()
                     ? atlas.getAsJsonArray("sources")
                     : new JsonArray();
 
-            for (String obfuscatedKey : textureKeys.values()) {
+            for (String originalKey : atlasTextureKeys) {
+                String obfuscatedKey = textureKeys.get(originalKey);
+                if (obfuscatedKey == null) continue;
                 JsonObject source = new JsonObject();
                 source.addProperty("type", "single");
                 source.addProperty("resource", obfuscatedKey);
@@ -336,6 +376,57 @@ public final class PackObfuscator {
             }
 
             atlas.add("sources", sources);
+        }
+
+        private Set<String> collectAtlasTextureKeys(JsonElement atlas, String namespace) {
+            Set<String> keys = new HashSet<>();
+            if (atlas == null || !atlas.isJsonObject()) return keys;
+            JsonObject object = atlas.getAsJsonObject();
+            if (!object.has("sources") || !object.get("sources").isJsonArray()) return keys;
+
+            for (JsonElement sourceElement : object.getAsJsonArray("sources")) {
+                if (!sourceElement.isJsonObject()) continue;
+                JsonObject source = sourceElement.getAsJsonObject();
+                String type = source.has("type") && source.get("type").isJsonPrimitive()
+                        ? source.get("type").getAsString()
+                        : "";
+                if (type.endsWith("single")) {
+                    addAtlasSingleReference(source, "resource", namespace, keys);
+                    addAtlasSingleReference(source, "sprite", namespace, keys);
+                } else if (type.endsWith("directory")) {
+                    addAtlasDirectoryReferences(source, namespace, keys);
+                }
+            }
+            return keys;
+        }
+
+        private void addAtlasSingleReference(JsonObject source, String property, String namespace, Set<String> keys) {
+            if (!source.has(property) || !source.get(property).isJsonPrimitive()) return;
+            String value = stripKnownExtension(source.get(property).getAsString());
+            if (value.contains(":")) {
+                keys.add(value);
+            } else {
+                keys.add(namespace + ":" + value);
+                keys.add("minecraft:" + value);
+            }
+        }
+
+        private void addAtlasDirectoryReferences(JsonObject source, String namespace, Set<String> keys) {
+            if (!source.has("source") || !source.get("source").isJsonPrimitive()) return;
+            String directory = stripKnownExtension(source.get("source").getAsString());
+            String explicitNamespace = directory.contains(":") ? directory.substring(0, directory.indexOf(':')) : namespace;
+            String path = directory.contains(":") ? directory.substring(directory.indexOf(':') + 1) : directory;
+            for (String key : textureKeys.keySet()) {
+                if (isKeyUnderDirectory(key, explicitNamespace, path)) keys.add(key);
+            }
+        }
+
+        private static boolean isKeyUnderDirectory(String key, String namespace, String directory) {
+            int split = key.indexOf(':');
+            if (split < 0) return false;
+            String keyNamespace = key.substring(0, split);
+            String keyPath = key.substring(split + 1);
+            return keyNamespace.equals(namespace) && (keyPath.equals(directory) || keyPath.startsWith(directory + "/"));
         }
 
         private String lookup(Map<String, String> map, String value, String namespace) {
@@ -478,6 +569,10 @@ public final class PackObfuscator {
 
         private static boolean isSound(String path) {
             return path.startsWith("assets/") && path.contains("/sounds/") && path.endsWith(".ogg");
+        }
+
+        private static boolean isAtlas(String path) {
+            return path.startsWith("assets/") && path.contains("/atlases/") && path.endsWith(".json");
         }
 
         private static boolean isBlocksAtlas(String path) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -1,0 +1,352 @@
+package io.th0rgal.oraxen.pack.generation;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.VirtualFile;
+import io.th0rgal.oraxen.utils.logs.Logs;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class PackObfuscator {
+
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+    private PackObfuscator() {
+    }
+
+    public static void obfuscate(List<VirtualFile> output) {
+        Type type = Type.from(Settings.PACK_OBFUSCATION_TYPE.toString());
+        if (type == Type.NONE || output == null || output.isEmpty()) return;
+
+        try {
+            new Pass(type).run(output);
+        } catch (Exception exception) {
+            Logs.logError("Failed to obfuscate resource pack. Keeping readable pack output.");
+            if (Settings.DEBUG.toBool()) exception.printStackTrace();
+        }
+    }
+
+    private enum Type {
+        NONE,
+        SIMPLE,
+        FULL;
+
+        private static Type from(String raw) {
+            if (raw == null) return NONE;
+            String normalized = raw.trim().toUpperCase(Locale.ROOT);
+            if (normalized.equals("FALSE") || normalized.equals("OFF") || normalized.equals("DISABLED")) return NONE;
+            try {
+                return Type.valueOf(normalized);
+            } catch (IllegalArgumentException ignored) {
+                Logs.logWarning("Invalid pack obfuscation type <gold>" + raw + "</gold>; using NONE");
+                return NONE;
+            }
+        }
+    }
+
+    private static final class Pass {
+        private final Type type;
+        private final Map<String, String> namespaceMap = new LinkedHashMap<>();
+        private final Map<String, String> modelKeys = new LinkedHashMap<>();
+        private final Map<String, String> textureKeys = new LinkedHashMap<>();
+        private final Map<String, String> soundKeys = new LinkedHashMap<>();
+        private final Map<String, String> filePaths = new LinkedHashMap<>();
+
+        private Pass(Type type) {
+            this.type = type;
+        }
+
+        private void run(List<VirtualFile> output) throws Exception {
+            List<FileData> files = materialize(output);
+            collectRenames(files);
+            if (filePaths.isEmpty()) return;
+
+            for (FileData file : files) {
+                String originalPath = file.path;
+                file.path = filePaths.getOrDefault(file.path, file.path);
+                if (file.isJson()) rewriteJson(file);
+                if (!file.path.equals(originalPath)) file.virtualFile.setPath(file.path);
+                file.virtualFile.setInputStream(new ByteArrayInputStream(file.content));
+            }
+
+            Logs.logInfo("Obfuscated resource pack keys: " + modelKeys.size() + " models, "
+                    + textureKeys.size() + " textures, " + soundKeys.size() + " sounds");
+        }
+
+        private List<FileData> materialize(List<VirtualFile> output) throws Exception {
+            List<FileData> files = new ArrayList<>(output.size());
+            for (VirtualFile virtualFile : output) {
+                byte[] content;
+                InputStream inputStream = virtualFile.getInputStream();
+                if (inputStream == null) {
+                    content = new byte[0];
+                } else {
+                    try (inputStream) {
+                        content = inputStream.readAllBytes();
+                    }
+                }
+                virtualFile.setInputStream(new ByteArrayInputStream(content));
+                files.add(new FileData(virtualFile, virtualFile.getPath(), content));
+            }
+            return files;
+        }
+
+        private void collectRenames(List<FileData> files) {
+            for (FileData file : files) {
+                String path = file.path;
+
+                if (isTexture(path)) {
+                    String originalKey = keyFromPackPath(path, "/textures/", ".png");
+                    String obfuscatedKey = obfuscateKey(originalKey, "t");
+                    textureKeys.put(originalKey, obfuscatedKey);
+                    filePaths.put(path, texturePath(obfuscatedKey, ".png"));
+                    continue;
+                }
+
+                if (isTextureMetadata(path)) {
+                    String pngPath = path.substring(0, path.length() - ".mcmeta".length());
+                    String originalKey = keyFromPackPath(pngPath, "/textures/", ".png");
+                    String obfuscatedKey = obfuscateKey(originalKey, "t");
+                    textureKeys.put(originalKey, obfuscatedKey);
+                    filePaths.put(path, texturePath(obfuscatedKey, ".png.mcmeta"));
+                    continue;
+                }
+
+                if (isModel(path) && !isStableModelRoot(path)) {
+                    String originalKey = keyFromPackPath(path, "/models/", ".json");
+                    String obfuscatedKey = obfuscateKey(originalKey, "m");
+                    modelKeys.put(originalKey, obfuscatedKey);
+                    filePaths.put(path, modelPath(obfuscatedKey));
+                    continue;
+                }
+
+                if (isSound(path)) {
+                    String originalKey = keyFromPackPath(path, "/sounds/", ".ogg");
+                    String obfuscatedKey = obfuscateKey(originalKey, "s");
+                    soundKeys.put(originalKey, obfuscatedKey);
+                    filePaths.put(path, soundPath(obfuscatedKey));
+                }
+            }
+        }
+
+        private void rewriteJson(FileData file) {
+            JsonElement parsed;
+            try {
+                parsed = JsonParser.parseString(new String(file.content, StandardCharsets.UTF_8));
+            } catch (Exception ignored) {
+                return;
+            }
+
+            String namespace = namespaceFromPath(file.path);
+            JsonElement rewritten = rewriteElement(parsed, null, namespace);
+            if (isAtlas(file.path) && rewritten.isJsonObject()) addAtlasSingles(rewritten.getAsJsonObject());
+            file.content = GSON.toJson(rewritten).getBytes(StandardCharsets.UTF_8);
+        }
+
+        private JsonElement rewriteElement(JsonElement element, String property, String namespace) {
+            if (element == null || element.isJsonNull()) return element;
+            if (element.isJsonObject()) {
+                JsonObject object = element.getAsJsonObject();
+                JsonObject copy = new JsonObject();
+                for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+                    copy.add(entry.getKey(), rewriteElement(entry.getValue(), entry.getKey(), namespace));
+                }
+                return copy;
+            }
+            if (element.isJsonArray()) {
+                JsonArray array = element.getAsJsonArray();
+                JsonArray copy = new JsonArray();
+                for (JsonElement child : array) {
+                    copy.add(rewriteElement(child, property, namespace));
+                }
+                return copy;
+            }
+            if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) return element;
+
+            String value = element.getAsString();
+            String replacement = rewriteString(property, value, namespace);
+            return replacement.equals(value) ? element : new JsonPrimitive(replacement);
+        }
+
+        private String rewriteString(String property, String value, String namespace) {
+            if (value == null || value.isBlank() || value.startsWith("#")) return value;
+            String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
+
+            if (prop.equals("parent") || prop.equals("model") || prop.equals("base")) {
+                String replacement = lookup(modelKeys, value, namespace);
+                if (replacement != null) return replacement;
+            }
+
+            if (prop.equals("file") || prop.equals("texture") || prop.equals("resource") || prop.equals("sprite")
+                    || prop.equals("particle") || prop.startsWith("layer") || isTextureFace(prop)) {
+                String replacement = lookup(textureKeys, value, namespace);
+                if (replacement != null) return replacement;
+            }
+
+            if (prop.equals("name")) {
+                String replacement = lookup(soundKeys, value, namespace);
+                if (replacement != null) return replacement;
+            }
+
+            String model = lookup(modelKeys, value, namespace);
+            if (model != null) return model;
+            String texture = lookup(textureKeys, value, namespace);
+            if (texture != null) return texture;
+            String sound = lookup(soundKeys, value, namespace);
+            return sound != null ? sound : value;
+        }
+
+        private void addAtlasSingles(JsonObject atlas) {
+            if (textureKeys.isEmpty()) return;
+            JsonArray sources = atlas.has("sources") && atlas.get("sources").isJsonArray()
+                    ? atlas.getAsJsonArray("sources")
+                    : new JsonArray();
+
+            for (String obfuscatedKey : textureKeys.values()) {
+                JsonObject source = new JsonObject();
+                source.addProperty("type", "single");
+                source.addProperty("resource", obfuscatedKey);
+                source.addProperty("sprite", obfuscatedKey);
+                sources.add(source);
+            }
+
+            atlas.add("sources", sources);
+        }
+
+        private String lookup(Map<String, String> map, String value, String namespace) {
+            String direct = stripKnownExtension(value);
+            if (direct.contains(":")) return map.get(direct);
+
+            String local = namespace + ":" + direct;
+            String replacement = map.get(local);
+            if (replacement != null) return replacement;
+
+            return map.get("minecraft:" + direct);
+        }
+
+        private String obfuscateKey(String originalKey, String prefix) {
+            int split = originalKey.indexOf(':');
+            String namespace = split >= 0 ? originalKey.substring(0, split) : "minecraft";
+            String path = split >= 0 ? originalKey.substring(split + 1) : originalKey;
+            String targetNamespace = type == Type.FULL
+                    ? namespaceMap.computeIfAbsent(namespace, ignored -> "o" + hash("ns:" + namespace, 10))
+                    : namespace;
+            return targetNamespace + ":" + prefix + "/" + hash(namespace + ":" + path, 24);
+        }
+
+        private String hash(String value, int chars) {
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+                StringBuilder builder = new StringBuilder(bytes.length * 2);
+                for (byte b : bytes) builder.append(String.format("%02x", b));
+                return builder.substring(0, chars);
+            } catch (Exception ignored) {
+                return Integer.toHexString(value.hashCode());
+            }
+        }
+
+        private static boolean isTextureFace(String prop) {
+            return prop.equals("all") || prop.equals("top") || prop.equals("bottom") || prop.equals("side")
+                    || prop.equals("front") || prop.equals("back") || prop.equals("up") || prop.equals("down")
+                    || prop.equals("north") || prop.equals("south") || prop.equals("east") || prop.equals("west");
+        }
+
+        private static String stripKnownExtension(String value) {
+            String stripped = value;
+            if (stripped.endsWith(".json")) stripped = stripped.substring(0, stripped.length() - 5);
+            if (stripped.endsWith(".png")) stripped = stripped.substring(0, stripped.length() - 4);
+            if (stripped.endsWith(".ogg")) stripped = stripped.substring(0, stripped.length() - 4);
+            return stripped;
+        }
+
+        private static String keyFromPackPath(String path, String marker, String suffix) {
+            String normalized = path.replace('\\', '/');
+            String namespace = normalized.substring("assets/".length(), normalized.indexOf('/', "assets/".length()));
+            String resourcePath = normalized.substring(normalized.indexOf(marker) + marker.length(), normalized.length() - suffix.length());
+            return namespace + ":" + resourcePath;
+        }
+
+        private static String namespaceFromPath(String path) {
+            String normalized = path.replace('\\', '/');
+            if (!normalized.startsWith("assets/")) return "minecraft";
+            int end = normalized.indexOf('/', "assets/".length());
+            return end == -1 ? "minecraft" : normalized.substring("assets/".length(), end);
+        }
+
+        private static String modelPath(String key) {
+            int split = key.indexOf(':');
+            return "assets/" + key.substring(0, split) + "/models/" + key.substring(split + 1) + ".json";
+        }
+
+        private static String texturePath(String key, String suffix) {
+            int split = key.indexOf(':');
+            return "assets/" + key.substring(0, split) + "/textures/" + key.substring(split + 1) + suffix;
+        }
+
+        private static String soundPath(String key) {
+            int split = key.indexOf(':');
+            return "assets/" + key.substring(0, split) + "/sounds/" + key.substring(split + 1) + ".ogg";
+        }
+
+        private static boolean isJsonPath(String path) {
+            return path.endsWith(".json") || path.endsWith(".mcmeta");
+        }
+
+        private static boolean isTexture(String path) {
+            return path.startsWith("assets/") && path.contains("/textures/") && path.endsWith(".png");
+        }
+
+        private static boolean isTextureMetadata(String path) {
+            return path.startsWith("assets/") && path.contains("/textures/") && path.endsWith(".png.mcmeta");
+        }
+
+        private static boolean isModel(String path) {
+            return path.startsWith("assets/") && path.contains("/models/") && path.endsWith(".json");
+        }
+
+        private static boolean isSound(String path) {
+            return path.startsWith("assets/") && path.contains("/sounds/") && path.endsWith(".ogg");
+        }
+
+        private static boolean isAtlas(String path) {
+            return path.startsWith("assets/") && path.contains("/atlases/") && path.endsWith(".json");
+        }
+
+        private static boolean isStableModelRoot(String path) {
+            if (!path.startsWith("assets/minecraft/models/")) return false;
+            String modelPath = path.substring("assets/minecraft/models/".length());
+            return modelPath.matches("(item|block|entity|builtin)/[^/]+\\.json");
+        }
+    }
+
+    private static final class FileData {
+        private final VirtualFile virtualFile;
+        private String path;
+        private byte[] content;
+
+        private FileData(VirtualFile virtualFile, String path, byte[] content) {
+            this.virtualFile = virtualFile;
+            this.path = path;
+            this.content = content;
+        }
+
+        private boolean isJson() {
+            return Pass.isJsonPath(path);
+        }
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -123,6 +123,7 @@ public final class PackObfuscator {
 
         private void collectRenames(List<FileData> files) {
             Set<String> referencedTextureKeys = collectReferencedTextureKeys(files);
+            Set<String> referencedSoundKeys = collectReferencedSoundKeys(files);
 
             for (FileData file : files) {
                 String path = file.path;
@@ -156,6 +157,7 @@ public final class PackObfuscator {
 
                 if (isSound(path)) {
                     String originalKey = keyFromPackPath(path, "/sounds/", ".ogg");
+                    if (isUntrackedVanillaSound(originalKey, referencedSoundKeys)) continue;
                     String obfuscatedKey = obfuscateKey(originalKey, "s");
                     soundKeys.put(originalKey, obfuscatedKey);
                     filePaths.put(path, soundPath(obfuscatedKey));
@@ -176,6 +178,42 @@ public final class PackObfuscator {
                 collectReferencedTextureKeys(parsed, null, namespaceFromPath(file.path), keys);
             }
             return keys;
+        }
+
+        private Set<String> collectReferencedSoundKeys(List<FileData> files) {
+            Set<String> keys = new HashSet<>();
+            for (FileData file : files) {
+                if (!isSoundsJson(file.path)) continue;
+                JsonElement parsed;
+                try {
+                    parsed = JsonParser.parseString(new String(file.content, StandardCharsets.UTF_8));
+                } catch (Exception ignored) {
+                    continue;
+                }
+                collectReferencedSoundKeys(parsed, null, namespaceFromPath(file.path), keys);
+            }
+            return keys;
+        }
+
+        private void collectReferencedSoundKeys(JsonElement element, String property, String namespace, Set<String> keys) {
+            if (element == null || element.isJsonNull()) return;
+            if (element.isJsonObject()) {
+                for (Map.Entry<String, JsonElement> entry : element.getAsJsonObject().entrySet()) {
+                    collectReferencedSoundKeys(entry.getValue(), entry.getKey(), namespace, keys);
+                }
+                return;
+            }
+            if (element.isJsonArray()) {
+                for (JsonElement child : element.getAsJsonArray()) {
+                    collectReferencedSoundKeys(child, property, namespace, keys);
+                }
+                return;
+            }
+            if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) return;
+
+            String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
+            if (!isSoundProperty(prop)) return;
+            addSoundReference(element.getAsString(), namespace, keys);
         }
 
         private void collectReferencedTextureKeys(JsonElement element, String property, String namespace, Set<String> keys) {
@@ -208,18 +246,19 @@ public final class PackObfuscator {
             }
 
             String namespace = namespaceFromPath(file.path);
-            JsonElement rewritten = rewriteElement(parsed, null, namespace);
-            if (isAtlas(file.path) && rewritten.isJsonObject()) addAtlasSingles(rewritten.getAsJsonObject());
+            boolean soundsJson = isSoundsJson(file.path);
+            JsonElement rewritten = rewriteElement(parsed, null, namespace, soundsJson);
+            if (isBlocksAtlas(file.path) && rewritten.isJsonObject()) addAtlasSingles(rewritten.getAsJsonObject());
             file.content = GSON.toJson(rewritten).getBytes(StandardCharsets.UTF_8);
         }
 
-        private JsonElement rewriteElement(JsonElement element, String property, String namespace) {
+        private JsonElement rewriteElement(JsonElement element, String property, String namespace, boolean soundsJson) {
             if (element == null || element.isJsonNull()) return element;
             if (element.isJsonObject()) {
                 JsonObject object = element.getAsJsonObject();
                 JsonObject copy = new JsonObject();
                 for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
-                    copy.add(entry.getKey(), rewriteElement(entry.getValue(), entry.getKey(), namespace));
+                    copy.add(entry.getKey(), rewriteElement(entry.getValue(), entry.getKey(), namespace, soundsJson));
                 }
                 return copy;
             }
@@ -227,18 +266,18 @@ public final class PackObfuscator {
                 JsonArray array = element.getAsJsonArray();
                 JsonArray copy = new JsonArray();
                 for (JsonElement child : array) {
-                    copy.add(rewriteElement(child, property, namespace));
+                    copy.add(rewriteElement(child, property, namespace, soundsJson));
                 }
                 return copy;
             }
             if (!element.isJsonPrimitive() || !element.getAsJsonPrimitive().isString()) return element;
 
             String value = element.getAsString();
-            String replacement = rewriteString(property, value, namespace);
+            String replacement = rewriteString(property, value, namespace, soundsJson);
             return replacement.equals(value) ? element : new JsonPrimitive(replacement);
         }
 
-        private String rewriteString(String property, String value, String namespace) {
+        private String rewriteString(String property, String value, String namespace, boolean soundsJson) {
             if (value == null || value.isBlank() || value.startsWith("#")) return value;
             String prop = property == null ? "" : property.toLowerCase(Locale.ROOT);
 
@@ -247,7 +286,8 @@ public final class PackObfuscator {
                 String replacement = lookupTextureProperty(prop, value, namespace);
                 return replacement != null ? replacement : value;
             }
-            if (isSoundProperty(prop)) return replaceOrOriginal(soundKeys, value, namespace);
+            if (soundsJson && isSoundProperty(prop)) return replaceOrOriginal(soundKeys, value, namespace);
+            if (prop.equals("when")) return value;
 
             String model = lookup(modelKeys, value, namespace);
             if (model != null) return model;
@@ -365,8 +405,23 @@ public final class PackObfuscator {
             return key.startsWith("minecraft:") && !referencedTextureKeys.contains(key);
         }
 
+        private static boolean isUntrackedVanillaSound(String key, Set<String> referencedSoundKeys) {
+            return key.startsWith("minecraft:") && !referencedSoundKeys.contains(key);
+        }
+
         private static void addTextureReference(String value, String namespace, Set<String> keys) {
             if (value == null || value.isBlank() || value.startsWith("#")) return;
+            String stripped = stripKnownExtension(value);
+            if (stripped.contains(":")) {
+                keys.add(stripped);
+                return;
+            }
+            keys.add(namespace + ":" + stripped);
+            keys.add("minecraft:" + stripped);
+        }
+
+        private static void addSoundReference(String value, String namespace, Set<String> keys) {
+            if (value == null || value.isBlank()) return;
             String stripped = stripKnownExtension(value);
             if (stripped.contains(":")) {
                 keys.add(stripped);
@@ -425,8 +480,12 @@ public final class PackObfuscator {
             return path.startsWith("assets/") && path.contains("/sounds/") && path.endsWith(".ogg");
         }
 
-        private static boolean isAtlas(String path) {
-            return path.startsWith("assets/") && path.contains("/atlases/") && path.endsWith(".json");
+        private static boolean isBlocksAtlas(String path) {
+            return path.endsWith("/atlases/blocks.json");
+        }
+
+        private static boolean isSoundsJson(String path) {
+            return path.startsWith("assets/") && path.endsWith("/sounds.json");
         }
 
         private static boolean isStableModelRoot(String path) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -29,7 +29,8 @@ public final class PackObfuscator {
     }
 
     public static void obfuscate(List<VirtualFile> output) {
-        obfuscate(output, Settings.PACK_OBFUSCATION_TYPE.toString(), true);
+        Object rawType = Settings.PACK_OBFUSCATION_TYPE.getValue();
+        obfuscate(output, rawType == null ? null : rawType.toString(), true);
     }
 
     static void obfuscate(List<VirtualFile> output, String rawType) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -396,24 +396,56 @@ public final class PackObfuscator {
 
         private void addAtlasSingles(JsonObject atlas, JsonElement originalAtlas, String namespace, boolean includeAll) {
             if (textureKeys.isEmpty()) return;
-            Set<String> atlasTextureKeys = includeAll ? textureKeys.keySet() : collectAtlasTextureKeys(originalAtlas, namespace);
-            if (atlasTextureKeys.isEmpty()) return;
+            Map<String, String> atlasSprites = includeAll
+                    ? collectAllAtlasSprites()
+                    : collectAtlasSprites(originalAtlas, namespace);
+            if (atlasSprites.isEmpty()) return;
 
             JsonArray sources = atlas.has("sources") && atlas.get("sources").isJsonArray()
                     ? atlas.getAsJsonArray("sources")
                     : new JsonArray();
 
-            for (String originalKey : atlasTextureKeys) {
+            for (Map.Entry<String, String> entry : atlasSprites.entrySet()) {
+                String originalKey = entry.getKey();
                 String obfuscatedKey = textureKeys.get(originalKey);
                 if (obfuscatedKey == null) continue;
                 JsonObject source = new JsonObject();
                 source.addProperty("type", "single");
                 source.addProperty("resource", obfuscatedKey);
-                source.addProperty("sprite", obfuscatedKey);
+                source.addProperty("sprite", entry.getValue());
                 sources.add(source);
             }
 
             atlas.add("sources", sources);
+        }
+
+        private Map<String, String> collectAllAtlasSprites() {
+            Map<String, String> sprites = new LinkedHashMap<>();
+            for (Map.Entry<String, String> entry : textureKeys.entrySet()) {
+                sprites.put(entry.getKey(), entry.getValue());
+            }
+            return sprites;
+        }
+
+        private Map<String, String> collectAtlasSprites(JsonElement atlas, String namespace) {
+            Map<String, String> sprites = new LinkedHashMap<>();
+            if (atlas == null || !atlas.isJsonObject()) return sprites;
+            JsonObject object = atlas.getAsJsonObject();
+            if (!object.has("sources") || !object.get("sources").isJsonArray()) return sprites;
+
+            for (JsonElement sourceElement : object.getAsJsonArray("sources")) {
+                if (!sourceElement.isJsonObject()) continue;
+                JsonObject source = sourceElement.getAsJsonObject();
+                String type = source.has("type") && source.get("type").isJsonPrimitive()
+                        ? source.get("type").getAsString()
+                        : "";
+                if (type.endsWith("single")) {
+                    addAtlasSingleSprite(source, namespace, sprites);
+                } else if (type.endsWith("directory")) {
+                    addAtlasDirectorySprites(source, namespace, sprites);
+                }
+            }
+            return sprites;
         }
 
         private Set<String> collectAtlasTextureKeys(JsonElement atlas, String namespace) {
@@ -446,6 +478,38 @@ public final class PackObfuscator {
             } else {
                 keys.add(namespace + ":" + value);
             }
+        }
+
+        private void addAtlasSingleSprite(JsonObject source, String namespace, Map<String, String> sprites) {
+            String resource = atlasProperty(source, "resource");
+            if (resource == null) return;
+            String key = namespacedKey(resource, namespace);
+            String sprite = atlasProperty(source, "sprite");
+            sprites.put(key, namespacedKey(sprite != null ? sprite : resource, namespace));
+        }
+
+        private void addAtlasDirectorySprites(JsonObject source, String namespace, Map<String, String> sprites) {
+            String directory = atlasProperty(source, "source");
+            if (directory == null) return;
+            String explicitNamespace = directory.contains(":") ? directory.substring(0, directory.indexOf(':')) : namespace;
+            String path = directory.contains(":") ? directory.substring(directory.indexOf(':') + 1) : directory;
+            String prefix = atlasProperty(source, "prefix");
+            if (prefix == null) prefix = "";
+            for (String key : textureKeys.keySet()) {
+                if (!isKeyUnderDirectory(key, explicitNamespace, path)) continue;
+                String keyPath = key.substring(key.indexOf(':') + 1);
+                String relative = keyPath.equals(path) ? "" : keyPath.substring(path.length() + 1);
+                sprites.put(key, explicitNamespace + ":" + prefix + relative);
+            }
+        }
+
+        private static String atlasProperty(JsonObject source, String property) {
+            if (!source.has(property) || !source.get(property).isJsonPrimitive()) return null;
+            return stripKnownExtension(source.get(property).getAsString());
+        }
+
+        private static String namespacedKey(String value, String namespace) {
+            return value.contains(":") ? value : namespace + ":" + value;
         }
 
         private void addAtlasDirectoryReferences(JsonObject source, String namespace, Set<String> keys) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackObfuscator.java
@@ -404,7 +404,7 @@ public final class PackObfuscator {
         private void addAtlasSingles(JsonObject atlas, JsonElement originalAtlas, String namespace, boolean includeAll) {
             if (textureKeys.isEmpty()) return;
             Map<String, String> atlasSprites = includeAll
-                    ? new LinkedHashMap<>(textureKeys)
+                    ? collectAllAtlasSprites()
                     : collectAtlasSprites(originalAtlas, namespace);
             if (atlasSprites.isEmpty()) return;
 
@@ -424,6 +424,14 @@ public final class PackObfuscator {
             }
 
             atlas.add("sources", sources);
+        }
+
+        private Map<String, String> collectAllAtlasSprites() {
+            Map<String, String> sprites = new LinkedHashMap<>();
+            for (String key : textureKeys.keySet()) {
+                sprites.put(key, key);
+            }
+            return sprites;
         }
 
         private Map<String, String> collectAtlasSprites(JsonElement atlas, String namespace) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -214,7 +214,9 @@ public class ResourcePack {
 
             OraxenPackGeneratedEvent event = new OraxenPackGeneratedEvent(output);
             EventUtils.callEvent(event);
-            writeSinglePackAsync(packWorker, event.getOutput());
+            output = event.getOutput();
+            PackObfuscator.obfuscate(output);
+            writeSinglePackAsync(packWorker, output);
         } catch (Exception exception) {
             handleGenerationFailure(packWorker, "sync pack finalization", exception);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.packets;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import io.th0rgal.oraxen.utils.PluginUtils;
 import io.th0rgal.oraxen.utils.SnapshotVersion;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,7 +11,14 @@ import java.util.function.Consumer;
 
 public interface PacketAdapter {
     static boolean isPacketEventsEnabled() {
-        return PluginUtils.isEnabled("PacketEvents");
+        return getPacketEventsPlugin() != null;
+    }
+    @Nullable
+    static Plugin getPacketEventsPlugin() {
+        Plugin plugin = Bukkit.getPluginManager().getPlugin("PacketEvents");
+        if (plugin != null && plugin.isEnabled()) return plugin;
+        plugin = Bukkit.getPluginManager().getPlugin("packetevents");
+        return plugin != null && plugin.isEnabled() ? plugin : null;
     }
     static boolean isProtocolLibEnabled() {
         return PluginUtils.isEnabled("ProtocolLib");

--- a/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
@@ -12,7 +12,6 @@ import io.th0rgal.oraxen.packets.packetevents.ScoreboardPacketListener;
 import io.th0rgal.oraxen.packets.packetevents.TitlePacketListener;
 import io.th0rgal.oraxen.packets.packetevents.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
 import io.th0rgal.oraxen.utils.SnapshotVersion;
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -90,7 +89,7 @@ public class PacketEventsAdapter implements PacketAdapter {
     @Nullable
     @Override
     public Plugin getPlugin() {
-        return Bukkit.getPluginManager().getPlugin("PacketEvents");
+        return PacketAdapter.getPacketEventsPlugin();
     }
 
     private PacketListenerCommon register(PacketListener listener, PacketListenerPriority priority) {

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -157,6 +157,11 @@ Pack:
       type: "SPRITE" # "SPRITE" or "DIRECTORY"
     auto_generated_models_follow_texture_path: false
     compression: BEST_COMPRESSION # see Deflater.class
+    obfuscation:
+      # NONE keeps generated resource keys readable.
+      # SIMPLE renames pack-internal model, texture, and sound file paths while preserving namespaces.
+      # FULL also replaces namespaces used by renamed resources.
+      type: NONE
     # protection will use several methods to make your pack impossible to extract
     # with usual tools (native windows unzip, 7zip, winrar, etc) without altering
     # its integrity. Be careful if you activate this option to not try to extract

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -10,8 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PackObfuscatorTest {

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -213,6 +213,23 @@ class PackObfuscatorTest {
     }
 
     @Test
+    void vanillaModelOnlyOverridesKeepOriginalPathWhenUnreferenced() {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/models/custom/override.json", "{}"));
+        files.add(file("assets/oraxen/models/default/holder.json", """
+                {
+                  "model": "default/model"
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/model.json", "{}"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/models/custom/override.json")));
+        assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/oraxen/models/m/")));
+    }
+
+    @Test
     void namePropertiesOutsideSoundsJsonCanRewriteModelReferences() throws Exception {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/oraxen/models/default/holder.json", """

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -311,8 +311,11 @@ class PackObfuscatorTest {
                 .orElseThrow();
         String content = new String(atlasFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         JsonObject atlas = JsonParser.parseString(content).getAsJsonObject();
+        JsonObject addedSource = atlas.getAsJsonArray("sources").get(1).getAsJsonObject();
 
         assertEquals(2, atlas.getAsJsonArray("sources").size());
+        assertEquals("minecraft:painting/custom", addedSource.get("sprite").getAsString());
+        assertTrue(addedSource.get("resource").getAsString().startsWith("minecraft:t/"));
         assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/minecraft/textures/t/")));
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png")));
     }

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -1,0 +1,50 @@
+package io.th0rgal.oraxen.pack.generation;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.th0rgal.oraxen.utils.VirtualFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PackObfuscatorTest {
+
+    @Test
+    void textureValuesPreferTextureKeysWhenModelAndTextureSharePath() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/models/default/sword.json", """
+                {
+                  "parent": "item/generated",
+                  "textures": {
+                    "layer0": "default/sword"
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile modelFile = files.stream()
+                .filter(file -> file.getPath().contains("/models/"))
+                .findFirst()
+                .orElseThrow();
+        String modelContent = new String(modelFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject model = JsonParser.parseString(modelContent).getAsJsonObject();
+        String layer0 = model.getAsJsonObject("textures").get("layer0").getAsString();
+
+        assertTrue(layer0.startsWith("oraxen:t/"), layer0);
+        assertNotEquals("default/sword", layer0);
+    }
+
+    private static VirtualFile file(String path, String content) {
+        int slash = path.lastIndexOf('/');
+        return new VirtualFile(path.substring(0, slash), path.substring(slash + 1),
+                new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -265,6 +265,37 @@ class PackObfuscatorTest {
         assertEquals(0, paintingsSources);
     }
 
+    @Test
+    void nonBlockAtlasSinglesAreAddedForReferencedDirectories() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/atlases/paintings.json", """
+                {
+                  "sources": [
+                    {
+                      "type": "directory",
+                      "source": "painting",
+                      "prefix": "painting/"
+                    }
+                  ]
+                }
+                """));
+        files.add(file("assets/minecraft/textures/painting/custom.png", "png"));
+        files.add(file("assets/minecraft/textures/item/diamond_sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile atlasFile = files.stream()
+                .filter(file -> file.getPath().endsWith("/atlases/paintings.json"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(atlasFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject atlas = JsonParser.parseString(content).getAsJsonObject();
+
+        assertEquals(2, atlas.getAsJsonArray("sources").size());
+        assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/minecraft/textures/t/")));
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png")));
+    }
+
     private static VirtualFile file(String path, String content) {
         int slash = path.lastIndexOf('/');
         return new VirtualFile(path.substring(0, slash), path.substring(slash + 1),

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -151,6 +151,120 @@ class PackObfuscatorTest {
         assertEquals("default/model_only", layer0);
     }
 
+    @Test
+    void itemSelectWhenValuesAreNotRewrittenAsModelReferences() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/items/diamond_sword.json", """
+                {
+                  "model": {
+                    "type": "minecraft:select",
+                    "property": "minecraft:custom_model_data",
+                    "cases": [
+                      {
+                        "when": "oraxen:sword",
+                        "model": {
+                          "type": "minecraft:model",
+                          "model": "oraxen:sword"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/models/sword.json", "{}"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile itemFile = files.stream()
+                .filter(file -> file.getPath().equals("assets/minecraft/items/diamond_sword.json"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(itemFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject item = JsonParser.parseString(content).getAsJsonObject();
+        JsonObject selectCase = item.getAsJsonObject("model").getAsJsonArray("cases").get(0).getAsJsonObject();
+        String when = selectCase.get("when").getAsString();
+        String model = selectCase.getAsJsonObject("model").get("model").getAsString();
+
+        assertEquals("oraxen:sword", when);
+        assertTrue(model.startsWith("oraxen:m/"), model);
+    }
+
+    @Test
+    void vanillaSoundOnlyOverridesKeepOriginalPathWhenUnreferenced() {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/sounds/item/trident/throw.ogg", "ogg"));
+        files.add(file("assets/oraxen/sounds.json", """
+                {
+                  "custom.sound": {
+                    "sounds": ["custom/sound"]
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/sounds/custom/sound.ogg", "ogg"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/sounds/item/trident/throw.ogg")));
+        assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/oraxen/sounds/s/")));
+    }
+
+    @Test
+    void namePropertiesOutsideSoundsJsonCanRewriteModelReferences() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/models/default/holder.json", """
+                {
+                  "name": "default/model"
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/model.json", "{}"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        String name = null;
+        for (VirtualFile file : files) {
+            if (!file.getPath().contains("/models/")) continue;
+            String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            JsonObject json = JsonParser.parseString(content).getAsJsonObject();
+            if (json.has("name")) {
+                name = json.get("name").getAsString();
+                break;
+            }
+        }
+
+        assertTrue(name.startsWith("oraxen:m/"), name);
+    }
+
+    @Test
+    void atlasSinglesAreOnlyAddedToBlocksAtlas() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/atlases/blocks.json", "{\"sources\":[]}"));
+        files.add(file("assets/minecraft/atlases/paintings.json", "{\"sources\":[]}"));
+        files.add(file("assets/oraxen/models/default/sword.json", """
+                {
+                  "textures": {
+                    "layer0": "default/sword"
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        int blocksSources = -1;
+        int paintingsSources = -1;
+        for (VirtualFile file : files) {
+            String path = file.getPath();
+            if (!path.endsWith("/atlases/blocks.json") && !path.endsWith("/atlases/paintings.json")) continue;
+            String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            int sources = JsonParser.parseString(content).getAsJsonObject().getAsJsonArray("sources").size();
+            if (path.endsWith("/atlases/blocks.json")) blocksSources = sources;
+            if (path.endsWith("/atlases/paintings.json")) paintingsSources = sources;
+        }
+
+        assertEquals(1, blocksSources);
+        assertEquals(0, paintingsSources);
+    }
+
     private static VirtualFile file(String path, String content) {
         int slash = path.lastIndexOf('/');
         return new VirtualFile(path.substring(0, slash), path.substring(slash + 1),

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -253,6 +253,38 @@ class PackObfuscatorTest {
     }
 
     @Test
+    void soundEventIdsAreNotRewrittenAsRawSoundResources() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/sounds.json", """
+                {
+                  "custom.sound": {
+                    "sounds": ["custom/sound"]
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/sounds/custom/sound.ogg", "ogg"));
+        files.add(file("data/oraxen/jukebox_song/custom_sound.json", """
+                {
+                  "sound_event": {
+                    "sound_id": "oraxen:custom/sound"
+                  }
+                }
+                """));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile songFile = files.stream()
+                .filter(file -> file.getPath().equals("data/oraxen/jukebox_song/custom_sound.json"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(songFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject song = JsonParser.parseString(content).getAsJsonObject();
+        String soundId = song.getAsJsonObject("sound_event").get("sound_id").getAsString();
+
+        assertEquals("oraxen:custom/sound", soundId);
+    }
+
+    @Test
     void vanillaModelOnlyOverridesKeepOriginalPathWhenUnreferenced() {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/minecraft/models/custom/override.json", "{}"));

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -103,6 +103,54 @@ class PackObfuscatorTest {
         assertTrue(customModel.startsWith("oraxen:m/"), customModel);
     }
 
+    @Test
+    void vanillaTextureOnlyOverridesKeepOriginalPathWhenUnreferenced() {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/textures/item/diamond_sword.png", "png"));
+        files.add(file("assets/minecraft/textures/item/diamond_sword.png.mcmeta", "{}"));
+        files.add(file("assets/oraxen/models/default/sword.json", """
+                {
+                  "textures": {
+                    "layer0": "default/sword"
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png")));
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png.mcmeta")));
+    }
+
+    @Test
+    void knownTexturePropertyDoesNotFallBackToModelKey() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/models/default/holder.json", """
+                {
+                  "textures": {
+                    "layer0": "default/model_only"
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/model_only.json", "{}"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        String layer0 = null;
+        for (VirtualFile file : files) {
+            if (!file.getPath().contains("/models/")) continue;
+            String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            JsonObject json = JsonParser.parseString(content).getAsJsonObject();
+            if (json.has("textures")) {
+                layer0 = json.getAsJsonObject("textures").get("layer0").getAsString();
+                break;
+            }
+        }
+
+        assertEquals("default/model_only", layer0);
+    }
+
     private static VirtualFile file(String path, String content) {
         int slash = path.lastIndexOf('/');
         return new VirtualFile(path.substring(0, slash), path.substring(slash + 1),

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -313,16 +313,23 @@ class PackObfuscatorTest {
 
         int blocksSources = -1;
         int paintingsSources = -1;
+        JsonObject blocksSource = null;
         for (VirtualFile file : files) {
             String path = file.getPath();
             if (!path.endsWith("/atlases/blocks.json") && !path.endsWith("/atlases/paintings.json")) continue;
             String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
             int sources = JsonParser.parseString(content).getAsJsonObject().getAsJsonArray("sources").size();
-            if (path.endsWith("/atlases/blocks.json")) blocksSources = sources;
+            if (path.endsWith("/atlases/blocks.json")) {
+                JsonObject atlas = JsonParser.parseString(content).getAsJsonObject();
+                blocksSources = sources;
+                blocksSource = atlas.getAsJsonArray("sources").get(0).getAsJsonObject();
+            }
             if (path.endsWith("/atlases/paintings.json")) paintingsSources = sources;
         }
 
         assertEquals(1, blocksSources);
+        assertTrue(blocksSource.get("resource").getAsString().startsWith("oraxen:t/"));
+        assertEquals("oraxen:default/sword", blocksSource.get("sprite").getAsString());
         assertEquals(0, paintingsSources);
     }
 

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -44,6 +44,46 @@ class PackObfuscatorTest {
     }
 
     @Test
+    void arbitraryTextureObjectKeysPreferTextureKeys() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/models/default/sword.json", """
+                {
+                  "parent": "item/generated",
+                  "textures": {
+                    "end": "default/sword"
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/sword_ref.json", """
+                {
+                  "model": "default/sword"
+                }
+                """));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile modelFile = files.stream()
+                .filter(file -> file.getPath().contains("/models/"))
+                .filter(file -> {
+                    try {
+                        String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                        file.setInputStream(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+                        return content.contains("\"textures\"");
+                    } catch (Exception ignored) {
+                        return false;
+                    }
+                })
+                .findFirst()
+                .orElseThrow();
+        String modelContent = new String(modelFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject model = JsonParser.parseString(modelContent).getAsJsonObject();
+        String end = model.getAsJsonObject("textures").get("end").getAsString();
+
+        assertTrue(end.startsWith("oraxen:t/"), end);
+    }
+
+    @Test
     void soundArrayValuesPreferSoundKeysWhenAssetsSharePath() throws Exception {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/oraxen/sounds.json", """

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -459,7 +459,7 @@ class PackObfuscatorTest {
 
         assertEquals(1, blocksSources);
         assertTrue(blocksSource.get("resource").getAsString().startsWith("oraxen:t/"));
-        assertEquals("oraxen:default/sword", blocksSource.get("sprite").getAsString());
+        assertTrue(blocksSource.get("sprite").getAsString().startsWith("oraxen:t/"));
         assertEquals(0, paintingsSources);
     }
 
@@ -491,7 +491,7 @@ class PackObfuscatorTest {
         JsonObject addedSource = atlas.getAsJsonArray("sources").get(1).getAsJsonObject();
 
         assertEquals(2, atlas.getAsJsonArray("sources").size());
-        assertEquals("minecraft:painting/custom", addedSource.get("sprite").getAsString());
+        assertTrue(addedSource.get("sprite").getAsString().startsWith("minecraft:t/"));
         assertTrue(addedSource.get("resource").getAsString().startsWith("minecraft:t/"));
         assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/minecraft/textures/t/")));
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png")));

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -316,6 +316,25 @@ class PackObfuscatorTest {
     }
 
     @Test
+    void typeEventNamesDoNotMarkVanillaSoundOverridesAsReferenced() {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/sounds.json", """
+                {
+                  "custom.alias": {
+                    "sounds": [
+                      { "name": "minecraft:item/trident/throw", "type": "minecraft:event" }
+                    ]
+                  }
+                }
+                """));
+        files.add(file("assets/minecraft/sounds/item/trident/throw.ogg", "ogg"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/sounds/item/trident/throw.ogg")));
+    }
+
+    @Test
     void vanillaModelOnlyOverridesKeepOriginalPathWhenUnreferenced() {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/minecraft/models/custom/override.json", "{}"));
@@ -330,6 +349,54 @@ class PackObfuscatorTest {
 
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/models/custom/override.json")));
         assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/oraxen/models/m/")));
+    }
+
+    @Test
+    void namespaceNamesMatchingResourceDirectoriesUseCorrectResourcePath() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/textures/models/custom/item.json", """
+                {
+                  "textures": {
+                    "layer0": "custom/item"
+                  }
+                }
+                """));
+        files.add(file("assets/textures/textures/custom/item.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile modelFile = files.stream()
+                .filter(file -> file.getPath().contains("/models/"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(modelFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String layer0 = JsonParser.parseString(content).getAsJsonObject()
+                .getAsJsonObject("textures").get("layer0").getAsString();
+
+        assertTrue(layer0.startsWith("textures:t/"), layer0);
+    }
+
+    @Test
+    void dataPackJsonUsesDataNamespaceForBareResourceReferences() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("data/oraxen/custom/entry.json", """
+                {
+                  "model": "default/model"
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/model.json", "{}"));
+        files.add(file("assets/minecraft/models/default/model.json", "{}"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile dataFile = files.stream()
+                .filter(file -> file.getPath().equals("data/oraxen/custom/entry.json"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(dataFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String model = JsonParser.parseString(content).getAsJsonObject().get("model").getAsString();
+
+        assertTrue(model.startsWith("oraxen:m/"), model);
     }
 
     @Test

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -360,6 +360,40 @@ class PackObfuscatorTest {
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png")));
     }
 
+    @Test
+    void atlasSingleSpriteKeepsOriginalLookupName() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/minecraft/atlases/paintings.json", """
+                {
+                  "sources": [
+                    {
+                      "type": "single",
+                      "resource": "painting/custom",
+                      "sprite": "painting/lookup_name"
+                    }
+                  ]
+                }
+                """));
+        files.add(file("assets/minecraft/textures/painting/custom.png", "png"));
+        files.add(file("assets/minecraft/textures/painting/lookup_name.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile atlasFile = files.stream()
+                .filter(file -> file.getPath().endsWith("/atlases/paintings.json"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(atlasFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject atlas = JsonParser.parseString(content).getAsJsonObject();
+        JsonObject originalSource = atlas.getAsJsonArray("sources").get(0).getAsJsonObject();
+        JsonObject addedSource = atlas.getAsJsonArray("sources").get(1).getAsJsonObject();
+
+        assertTrue(originalSource.get("resource").getAsString().startsWith("minecraft:t/"));
+        assertEquals("painting/lookup_name", originalSource.get("sprite").getAsString());
+        assertEquals("minecraft:painting/lookup_name", addedSource.get("sprite").getAsString());
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/painting/lookup_name.png")));
+    }
+
     private static VirtualFile file(String path, String content) {
         int slash = path.lastIndexOf('/');
         return new VirtualFile(path.substring(0, slash), path.substring(slash + 1),

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -108,6 +108,7 @@ class PackObfuscatorTest {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/minecraft/textures/item/diamond_sword.png", "png"));
         files.add(file("assets/minecraft/textures/item/diamond_sword.png.mcmeta", "{}"));
+        files.add(file("assets/minecraft/textures/default/sword.png", "png"));
         files.add(file("assets/oraxen/models/default/sword.json", """
                 {
                   "textures": {
@@ -121,6 +122,7 @@ class PackObfuscatorTest {
 
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png")));
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/item/diamond_sword.png.mcmeta")));
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/default/sword.png")));
     }
 
     @Test
@@ -193,6 +195,7 @@ class PackObfuscatorTest {
     void vanillaSoundOnlyOverridesKeepOriginalPathWhenUnreferenced() {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/minecraft/sounds/item/trident/throw.ogg", "ogg"));
+        files.add(file("assets/minecraft/sounds/custom/sound.ogg", "ogg"));
         files.add(file("assets/oraxen/sounds.json", """
                 {
                   "custom.sound": {
@@ -205,6 +208,7 @@ class PackObfuscatorTest {
         PackObfuscator.obfuscate(files, "SIMPLE", false);
 
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/sounds/item/trident/throw.ogg")));
+        assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/sounds/custom/sound.ogg")));
         assertTrue(files.stream().anyMatch(file -> file.getPath().startsWith("assets/oraxen/sounds/s/")));
     }
 

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -531,6 +531,36 @@ class PackObfuscatorTest {
         assertTrue(files.stream().anyMatch(file -> file.getPath().equals("assets/minecraft/textures/painting/lookup_name.png")));
     }
 
+    @Test
+    void structuralTypeValuesAreNotRewrittenWhenTheyMatchResourceKeys() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/atlases/blocks.json", """
+                {
+                  "sources": [
+                    {
+                      "type": "single",
+                      "resource": "default/sword"
+                    }
+                  ]
+                }
+                """));
+        files.add(file("assets/oraxen/models/single.json", "{}"));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile atlasFile = files.stream()
+                .filter(file -> file.getPath().endsWith("/atlases/blocks.json"))
+                .findFirst()
+                .orElseThrow();
+        String content = new String(atlasFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject source = JsonParser.parseString(content).getAsJsonObject()
+                .getAsJsonArray("sources").get(0).getAsJsonObject();
+
+        assertEquals("single", source.get("type").getAsString());
+        assertTrue(source.get("resource").getAsString().startsWith("oraxen:t/"));
+    }
+
     private static VirtualFile file(String path, String content) {
         int slash = path.lastIndexOf('/');
         return new VirtualFile(path.substring(0, slash), path.substring(slash + 1),

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PackObfuscatorTest {
@@ -40,6 +41,66 @@ class PackObfuscatorTest {
 
         assertTrue(layer0.startsWith("oraxen:t/"), layer0);
         assertNotEquals("default/sword", layer0);
+    }
+
+    @Test
+    void soundArrayValuesPreferSoundKeysWhenAssetsSharePath() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/sounds.json", """
+                {
+                  "default.sword": {
+                    "sounds": [
+                      "default/sword",
+                      { "name": "default/sword" }
+                    ]
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/sword.json", "{}"));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+        files.add(file("assets/oraxen/sounds/default/sword.ogg", "ogg"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile soundsFile = files.stream()
+                .filter(file -> file.getPath().endsWith("/sounds.json"))
+                .findFirst()
+                .orElseThrow();
+        String soundsContent = new String(soundsFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject sounds = JsonParser.parseString(soundsContent).getAsJsonObject()
+                .getAsJsonObject("default.sword");
+        String arrayValue = sounds.getAsJsonArray("sounds").get(0).getAsString();
+        String objectValue = sounds.getAsJsonArray("sounds").get(1).getAsJsonObject().get("name").getAsString();
+
+        assertTrue(arrayValue.startsWith("oraxen:s/"), arrayValue);
+        assertEquals(arrayValue, objectValue);
+    }
+
+    @Test
+    void genericValuesPreferModelKeysWhenModelAndTextureSharePath() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/models/default/holder.json", """
+                {
+                  "custom_model": "default/sword"
+                }
+                """));
+        files.add(file("assets/oraxen/models/default/sword.json", "{}"));
+        files.add(file("assets/oraxen/textures/default/sword.png", "png"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        String customModel = null;
+        for (VirtualFile file : files) {
+            if (!file.getPath().contains("/models/")) continue;
+            String content = new String(file.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            JsonObject json = JsonParser.parseString(content).getAsJsonObject();
+            if (json.has("custom_model")) {
+                customModel = json.get("custom_model").getAsString();
+                break;
+            }
+        }
+
+        assertTrue(customModel.startsWith("oraxen:m/"), customModel);
     }
 
     private static VirtualFile file(String path, String content) {

--- a/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/generation/PackObfuscatorTest.java
@@ -285,6 +285,37 @@ class PackObfuscatorTest {
     }
 
     @Test
+    void soundsJsonTypeEventNamesAreNotRewrittenAsRawSoundResources() throws Exception {
+        List<VirtualFile> files = new ArrayList<>();
+        files.add(file("assets/oraxen/sounds.json", """
+                {
+                  "custom.alias": {
+                    "sounds": [
+                      { "name": "custom/sound", "type": "event" },
+                      { "name": "custom/sound" }
+                    ]
+                  }
+                }
+                """));
+        files.add(file("assets/oraxen/sounds/custom/sound.ogg", "ogg"));
+
+        PackObfuscator.obfuscate(files, "SIMPLE", false);
+
+        VirtualFile soundsFile = files.stream()
+                .filter(file -> file.getPath().endsWith("/sounds.json"))
+                .findFirst()
+                .orElseThrow();
+        String soundsContent = new String(soundsFile.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        JsonObject sounds = JsonParser.parseString(soundsContent).getAsJsonObject()
+                .getAsJsonObject("custom.alias");
+        JsonObject eventReference = sounds.getAsJsonArray("sounds").get(0).getAsJsonObject();
+        JsonObject rawSoundReference = sounds.getAsJsonArray("sounds").get(1).getAsJsonObject();
+
+        assertEquals("custom/sound", eventReference.get("name").getAsString());
+        assertTrue(rawSoundReference.get("name").getAsString().startsWith("oraxen:s/"));
+    }
+
+    @Test
     void vanillaModelOnlyOverridesKeepOriginalPathWhenUnreferenced() {
         List<VirtualFile> files = new ArrayList<>();
         files.add(file("assets/minecraft/models/custom/override.json", "{}"));

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
@@ -845,4 +845,53 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         }
     }
 
+    @Override
+    public boolean spawnTextDisplay(Player viewer, int entityId, UUID uuid, Location location,
+                                    net.kyori.adventure.text.Component text, byte billboard,
+                                    float viewRange, int backgroundArgb, byte flags) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+
+        ClientboundAddEntityPacket spawnPacket = new ClientboundAddEntityPacket(
+                entityId,
+                uuid,
+                location.getX(), location.getY(), location.getZ(),
+                location.getPitch(), location.getYaw(),
+                EntityType.TEXT_DISPLAY,
+                0,
+                Vec3.ZERO,
+                0.0
+        );
+        connection.send(spawnPacket);
+        sendTextDisplayMetadata(viewer, entityId, text, billboard, viewRange, backgroundArgb, flags);
+        return true;
+    }
+
+    @Override
+    public boolean sendTextDisplayMetadata(Player viewer, int entityId, net.kyori.adventure.text.Component text,
+                                           byte billboard, float viewRange, int backgroundArgb, byte flags) {
+        ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
+        Connection connection = serverPlayer.connection.connection;
+        List<SynchedEntityData.DataValue<?>> metadata = new ArrayList<>();
+
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(5, EntityDataSerializers.BOOLEAN), true));
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(15, EntityDataSerializers.BYTE), billboard));
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(17, EntityDataSerializers.FLOAT), viewRange));
+
+        net.minecraft.network.chat.Component vanillaText = io.papermc.paper.adventure.PaperAdventure.asVanilla(text);
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(23, EntityDataSerializers.COMPONENT), vanillaText));
+
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(25, EntityDataSerializers.INT), backgroundArgb));
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(27, EntityDataSerializers.BYTE), flags));
+
+        connection.send(new ClientboundSetEntityDataPacket(entityId, metadata));
+        return true;
+    }
+
 }

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
@@ -75,6 +75,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.components.FoodComponent;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
+import org.joml.Vector3f;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
@@ -847,8 +848,8 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
     @Override
     public boolean spawnTextDisplay(Player viewer, int entityId, UUID uuid, Location location,
-                                    net.kyori.adventure.text.Component text, byte billboard,
-                                    float viewRange, int backgroundArgb, byte flags) {
+                                    net.kyori.adventure.text.Component text, Vector3f scale, byte billboard,
+                                    float viewRange, int lineWidth, int backgroundArgb, byte textOpacity, byte flags) {
         ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
         Connection connection = serverPlayer.connection.connection;
 
@@ -863,19 +864,24 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
                 0.0
         );
         connection.send(spawnPacket);
-        sendTextDisplayMetadata(viewer, entityId, text, billboard, viewRange, backgroundArgb, flags);
+        sendTextDisplayMetadata(viewer, entityId, text, scale, billboard, viewRange, lineWidth, backgroundArgb, textOpacity, flags);
         return true;
     }
 
     @Override
     public boolean sendTextDisplayMetadata(Player viewer, int entityId, net.kyori.adventure.text.Component text,
-                                           byte billboard, float viewRange, int backgroundArgb, byte flags) {
+                                           Vector3f scale, byte billboard, float viewRange, int lineWidth,
+                                           int backgroundArgb, byte textOpacity, byte flags) {
         ServerPlayer serverPlayer = ((CraftPlayer) viewer).getHandle();
         Connection connection = serverPlayer.connection.connection;
         List<SynchedEntityData.DataValue<?>> metadata = new ArrayList<>();
 
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(5, EntityDataSerializers.BOOLEAN), true));
+        if (scale != null && (scale.x != 1f || scale.y != 1f || scale.z != 1f)) {
+            metadata.add(SynchedEntityData.DataValue.create(
+                    new EntityDataAccessor<>(12, EntityDataSerializers.VECTOR3), scale));
+        }
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(15, EntityDataSerializers.BYTE), billboard));
         metadata.add(SynchedEntityData.DataValue.create(
@@ -885,8 +891,16 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(23, EntityDataSerializers.COMPONENT), vanillaText));
 
+        if (lineWidth != 200) {
+            metadata.add(SynchedEntityData.DataValue.create(
+                    new EntityDataAccessor<>(24, EntityDataSerializers.INT), lineWidth));
+        }
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(25, EntityDataSerializers.INT), backgroundArgb));
+        if (textOpacity != (byte) -1) {
+            metadata.add(SynchedEntityData.DataValue.create(
+                    new EntityDataAccessor<>(26, EntityDataSerializers.BYTE), textOpacity));
+        }
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(27, EntityDataSerializers.BYTE), flags));
 

--- a/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
+++ b/v1_21_R6/src/main/java/io/th0rgal/oraxen/nms/v1_21_R6/NMSHandler.java
@@ -878,7 +878,7 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
 
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(5, EntityDataSerializers.BOOLEAN), true));
-        if (scale != null && (scale.x != 1f || scale.y != 1f || scale.z != 1f)) {
+        if (scale != null) {
             metadata.add(SynchedEntityData.DataValue.create(
                     new EntityDataAccessor<>(12, EntityDataSerializers.VECTOR3), scale));
         }
@@ -891,16 +891,12 @@ public class NMSHandler implements io.th0rgal.oraxen.nms.NMSHandler {
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(23, EntityDataSerializers.COMPONENT), vanillaText));
 
-        if (lineWidth != 200) {
-            metadata.add(SynchedEntityData.DataValue.create(
-                    new EntityDataAccessor<>(24, EntityDataSerializers.INT), lineWidth));
-        }
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(24, EntityDataSerializers.INT), lineWidth));
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(25, EntityDataSerializers.INT), backgroundArgb));
-        if (textOpacity != (byte) -1) {
-            metadata.add(SynchedEntityData.DataValue.create(
-                    new EntityDataAccessor<>(26, EntityDataSerializers.BYTE), textOpacity));
-        }
+        metadata.add(SynchedEntityData.DataValue.create(
+                new EntityDataAccessor<>(26, EntityDataSerializers.BYTE), textOpacity));
         metadata.add(SynchedEntityData.DataValue.create(
                 new EntityDataAccessor<>(27, EntityDataSerializers.BYTE), flags));
 


### PR DESCRIPTION
Summary:
- Adds disabled-by-default resource key obfuscation with NONE, SIMPLE, and FULL modes.
- Adds packet-only furniture text displays with load registration, passenger/destroy packet sync, and placeholder refresh support.
- Leaves trident sound behavior unchanged.

Checks:
- ./gradlew :core:compileJava :core:test --no-daemon
- CI=true ./gradlew shadowJar --no-daemon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pack generation output rewriting and introduces new packet-level entity spawning/metadata logic for furniture, which can cause hard-to-debug client-side or compatibility issues across versions/plugins if regressions slip in.
> 
> **Overview**
> Adds an **optional resource-pack obfuscation pass** (configurable via `Pack.generation.obfuscation.type`: `NONE`/`SIMPLE`/`FULL`) that renames model/texture/sound file paths and rewrites JSON references, and wires it into both single-pack (`ResourcePack`) and multi-version (`MultiVersionPackGenerator`) generation flows (with unit tests covering edge cases like atlases and `sounds.json`).
> 
> Introduces **packet-only furniture text displays**: furniture configs can now define `text_entity`/`text_entities`, which are registered on placement and on entity load, tracked in an in-memory registry, spawned/destroyed alongside the base furniture via PacketEvents interception, refreshed for placeholders, and cleaned up on unload/removal/rotation; this also extends `NMSHandler` with text-display spawn/metadata hooks (implemented for `v1_21_R6`) and makes PacketEvents detection more robust (`PacketEvents` vs `packetevents`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c673b90aad1896288dd788576f3717b4df97c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->