### PR TITLE
Update Hopper to 1.4.2

### DIFF
--- a/gradle/oraxenLibs.versions.toml
+++ b/gradle/oraxenLibs.versions.toml
@@ -3,7 +3,7 @@
 adventure = "4.17.0"
 adventure-platform = "4.3.4"
 commandapi = "11.0.0"
-hopper = "1.4.1"
+hopper = "1.4.2"
 
 actions = "1.0.0-SNAPSHOT"
 


### PR DESCRIPTION
Updates the Hopper runtime dependency loader from 1.4.1 to 1.4.2.

Validation: CI=true ./gradlew :core:compileJava --no-daemon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency version bump limited to the Gradle version catalog; impact is confined to builds/runtime dependency resolution for Hopper.
> 
> **Overview**
> Bumps the Hopper runtime dependency loader from `1.4.1` to `1.4.2` via `gradle/oraxenLibs.versions.toml`, updating the version used by `hopper-bukkit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 602716348a71099badfbf0d83274d54764d87487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->