### PR TITLE
feat: Add first-run introduction guide

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -273,6 +273,10 @@ bukkit {
         description = "Allows the player to use the /oraxen command"
         default = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission.Default.TRUE
     }
+    permissions.create("oraxen.introduction") {
+        description = "Allows the player to receive Oraxen's first-run introduction guide"
+        default = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.Permission.Default.OP
+    }
     libraries = oraxenLibs.bundles.libraries.bukkit.get().map { it.toString() }
 }
 

--- a/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/core/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -7,6 +7,7 @@ import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
 import io.th0rgal.oraxen.config.*;
 import io.th0rgal.oraxen.font.FontManager;
 import io.th0rgal.oraxen.hopper.OraxenHopper;
+import io.th0rgal.oraxen.introduction.IntroductionGuide;
 import io.th0rgal.oraxen.packets.PacketAdapter;
 import io.th0rgal.oraxen.packets.PacketEventsAdapter;
 import io.th0rgal.oraxen.packets.ProtocolLibAdapter;
@@ -166,6 +167,10 @@ public class OraxenPlugin extends JavaPlugin {
         CompatibilitiesManager.enableNativeCompatibilities();
         if (VersionUtil.isCompiled())
             NoticeUtils.compileNotice();
+
+        IntroductionGuide introductionGuide = new IntroductionGuide(this);
+        Bukkit.getPluginManager().registerEvents(introductionGuide, this);
+        introductionGuide.start();
     }
 
     private void postLoading() {

--- a/core/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -37,6 +37,7 @@ public enum Message {
     NOT_ENOUGH_SPACE("general.not_enough_space"),
     EXIT_MENU("general.exit_menu"),
     NO_EMOJIS("general.no_emojis"),
+    INTRODUCTION_GUIDE("general.introduction_guide"),
 
     // logs
     PLUGIN_LOADED("logs.loaded"),

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -14,6 +14,8 @@ public enum Settings {
     DEBUG("debug"),
     PLUGIN_LANGUAGE("Plugin.language"),
     KEEP_UP_TO_DATE("Plugin.keep_this_up_to_date"),
+    INTRODUCTION_CONSOLE_SENT("Plugin.introduction.console_sent"),
+    INTRODUCTION_PLAYER_PENDING("Plugin.introduction.player_pending"),
     REPAIR_COMMAND_ORAXEN_DURABILITY("Plugin.commands.repair.oraxen_durability_only"),
     AUTO_UPDATE_PAPER_CONFIG("Plugin.auto_update_paper_config"),
     GENERATE_DEFAULT_ASSETS("Plugin.generation.default_assets"),

--- a/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
+++ b/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
@@ -37,7 +37,6 @@ public class IntroductionGuide implements Listener {
         synchronized (lock) {
             if (!consoleSent) {
                 consoleSent = true;
-                playerPending = true;
                 sendConsoleMessage = true;
                 consoleSentSnapshot = consoleSent;
                 playerPendingSnapshot = playerPending;

--- a/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
+++ b/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
@@ -31,13 +32,20 @@ public class IntroductionGuide implements Listener {
 
     public void start() {
         boolean sendConsoleMessage = false;
+        boolean consoleSentSnapshot = false;
+        boolean playerPendingSnapshot = false;
         synchronized (lock) {
             if (!consoleSent) {
                 consoleSent = true;
                 playerPending = true;
-                saveState();
                 sendConsoleMessage = true;
+                consoleSentSnapshot = consoleSent;
+                playerPendingSnapshot = playerPending;
             }
+        }
+
+        if (sendConsoleMessage) {
+            saveState(consoleSentSnapshot, playerPendingSnapshot);
         }
 
         if (sendConsoleMessage) {
@@ -78,15 +86,28 @@ public class IntroductionGuide implements Listener {
     }
 
     private void sendToPlayer(Player player) {
+        boolean shouldSend;
+        boolean consoleSentSnapshot;
+        boolean playerPendingSnapshot;
         synchronized (lock) {
-            if (!playerPending || !player.isOnline() || !isEligible(player))
-                return;
-
-            playerPending = false;
-            saveState();
+            if (!playerPending || !player.isOnline() || !isEligible(player)) {
+                shouldSend = false;
+                consoleSentSnapshot = false;
+                playerPendingSnapshot = false;
+            } else {
+                playerPending = false;
+                shouldSend = true;
+                consoleSentSnapshot = consoleSent;
+                playerPendingSnapshot = playerPending;
+            }
         }
 
+        if (!shouldSend)
+            return;
+
+        saveState(consoleSentSnapshot, playerPendingSnapshot);
         Message.INTRODUCTION_GUIDE.send(player);
+        HandlerList.unregisterAll(this);
     }
 
     private boolean isEligible(Player player) {
@@ -94,11 +115,11 @@ public class IntroductionGuide implements Listener {
     }
 
     private void loadState() {
-        consoleSent = Settings.INTRODUCTION_CONSOLE_SENT.toBool();
-        playerPending = Settings.INTRODUCTION_PLAYER_PENDING.toBool();
+        consoleSent = Boolean.TRUE.equals(Settings.INTRODUCTION_CONSOLE_SENT.toBool());
+        playerPending = Boolean.TRUE.equals(Settings.INTRODUCTION_PLAYER_PENDING.toBool());
     }
 
-    private void saveState() {
+    private void saveState(boolean consoleSent, boolean playerPending) {
         YamlConfiguration settings = plugin.getConfigsManager().getSettings();
         settings.set(Settings.INTRODUCTION_CONSOLE_SENT.getPath(), consoleSent);
         settings.set(Settings.INTRODUCTION_PLAYER_PENDING.getPath(), playerPending);

--- a/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
+++ b/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
@@ -32,18 +32,18 @@ public class IntroductionGuide implements Listener {
 
     public void start() {
         boolean sendConsoleMessage = false;
-        boolean consoleSentSnapshot = false;
-        boolean playerPendingSnapshot = false;
+        boolean consoleSentSnapshot;
+        boolean playerPendingSnapshot;
         synchronized (lock) {
             if (!consoleSent) {
                 consoleSent = true;
                 sendConsoleMessage = true;
-                consoleSentSnapshot = consoleSent;
-                playerPendingSnapshot = playerPending;
             }
+            consoleSentSnapshot = consoleSent;
+            playerPendingSnapshot = playerPending;
         }
 
-        if (sendConsoleMessage) {
+        if (sendConsoleMessage || playerPendingSnapshot) {
             saveState(consoleSentSnapshot, playerPendingSnapshot);
         }
 
@@ -106,7 +106,7 @@ public class IntroductionGuide implements Listener {
 
         saveState(consoleSentSnapshot, playerPendingSnapshot);
         Message.INTRODUCTION_GUIDE.send(player);
-        HandlerList.unregisterAll(this);
+        SchedulerUtil.runTask(plugin, () -> HandlerList.unregisterAll(this));
     }
 
     private boolean isEligible(Player player) {

--- a/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
+++ b/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
@@ -51,6 +51,11 @@ public class IntroductionGuide implements Listener {
             Message.INTRODUCTION_GUIDE.log();
         }
 
+        if (consoleSentSnapshot && !playerPendingSnapshot) {
+            HandlerList.unregisterAll(this);
+            return;
+        }
+
         sendToFirstEligibleOnlinePlayer();
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
+++ b/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
@@ -43,7 +43,7 @@ public class IntroductionGuide implements Listener {
             playerPendingSnapshot = playerPending;
         }
 
-        if (sendConsoleMessage || playerPendingSnapshot) {
+        if (sendConsoleMessage) {
             saveState(consoleSentSnapshot, playerPendingSnapshot);
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
+++ b/core/src/main/java/io/th0rgal/oraxen/introduction/IntroductionGuide.java
@@ -1,0 +1,113 @@
+package io.th0rgal.oraxen.introduction;
+
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.config.Message;
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.io.IOException;
+
+public class IntroductionGuide implements Listener {
+
+    private static final String PERMISSION = "oraxen.introduction";
+
+    private final OraxenPlugin plugin;
+    private final Object lock = new Object();
+
+    private boolean consoleSent;
+    private boolean playerPending;
+
+    public IntroductionGuide(OraxenPlugin plugin) {
+        this.plugin = plugin;
+        loadState();
+    }
+
+    public void start() {
+        boolean sendConsoleMessage = false;
+        synchronized (lock) {
+            if (!consoleSent) {
+                consoleSent = true;
+                playerPending = true;
+                saveState();
+                sendConsoleMessage = true;
+            }
+        }
+
+        if (sendConsoleMessage) {
+            Message.INTRODUCTION_GUIDE.log();
+        }
+
+        sendToFirstEligibleOnlinePlayer();
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        if (!shouldSendToPlayer())
+            return;
+
+        Player player = event.getPlayer();
+        if (!isEligible(player))
+            return;
+
+        SchedulerUtil.runForEntityLater(plugin, player, 20L, () -> sendToPlayer(player), () -> {});
+    }
+
+    private void sendToFirstEligibleOnlinePlayer() {
+        if (!shouldSendToPlayer())
+            return;
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (!isEligible(player))
+                continue;
+            SchedulerUtil.runForEntityLater(plugin, player, 1L, () -> sendToPlayer(player), () -> {});
+            break;
+        }
+    }
+
+    private boolean shouldSendToPlayer() {
+        synchronized (lock) {
+            return playerPending;
+        }
+    }
+
+    private void sendToPlayer(Player player) {
+        synchronized (lock) {
+            if (!playerPending || !player.isOnline() || !isEligible(player))
+                return;
+
+            playerPending = false;
+            saveState();
+        }
+
+        Message.INTRODUCTION_GUIDE.send(player);
+    }
+
+    private boolean isEligible(Player player) {
+        return player.isOp() || player.hasPermission(PERMISSION);
+    }
+
+    private void loadState() {
+        consoleSent = Settings.INTRODUCTION_CONSOLE_SENT.toBool();
+        playerPending = Settings.INTRODUCTION_PLAYER_PENDING.toBool();
+    }
+
+    private void saveState() {
+        YamlConfiguration settings = plugin.getConfigsManager().getSettings();
+        settings.set(Settings.INTRODUCTION_CONSOLE_SENT.getPath(), consoleSent);
+        settings.set(Settings.INTRODUCTION_PLAYER_PENDING.getPath(), playerPending);
+
+        try {
+            settings.save(plugin.getConfigsManager().getSettingsFile());
+        } catch (IOException exception) {
+            Logs.logWarning("Failed to save introduction guide state");
+            Logs.debug(exception);
+        }
+    }
+}

--- a/core/src/main/resources/languages/czech.yml
+++ b/core/src/main/resources/languages/czech.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>Potřebuješ více místa pro položení tohoto nábytku"
   exit_menu: "<gradient:#FA7CBB:#F14658>Odejít"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Vítejte v Oraxenu... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen se poprvé úspěšně načetl, pojďme vás nastavit.<br>
+    <dark_gray> » <gray>Pro odstranění <yellow>výchozího brandingu</yellow> postupujte podle návodu na <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
+    <dark_gray> » <gray>Většinu vašich otázek a problémů lze vyřešit v naší <yellow>Dokumentaci</yellow>, nezapomeňte si projít <yellow>obě</yellow> dokumentace<gray> na </gray><blue>https://oraxen.mizius.com/</blue><gray> a <blue>https://docs.oraxen.com</blue><gray>.<br>
+    <dark_gray> » <gray>Pokud stále potřebujete pomoc, navštivte náš Discord na <blue>https://discord.gg/9EehAG54aU</blue>.<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>Datapack byl úspěšně vygenerován"
 
 logs:

--- a/core/src/main/resources/languages/czech.yml
+++ b/core/src/main/resources/languages/czech.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>No emojis found"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Vítejte v Oraxenu... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Vítejte v Oraxenu... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen se poprvé úspěšně načetl, pojďme vás nastavit.<br>
     <dark_gray> » <gray>Pro odstranění <yellow>výchozího brandingu</yellow> postupujte podle návodu na <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>Většinu vašich otázek a problémů lze vyřešit v naší <yellow>Dokumentaci</yellow>, nezapomeňte si projít <yellow>obě</yellow> dokumentace<gray> na </gray><blue>https://oraxen.mizius.com/</blue><gray> a <blue>https://docs.oraxen.com</blue><gray>.<br>
@@ -124,3 +124,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>Pro tohle potřebuješ více zkušeností"
   backpack_stacked: "<prefix><#fa4943>Nelze otevřít naskládaný batoh"
   jukebox_now_playing: "<dark_purple>Nyní se přehrává <disc>"
+

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>No emojis found"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Welcome to Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Welcome to Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen loaded successfully for the first time, let's get you started.<br>
     <dark_gray> » <gray>To remove the <yellow>default branding</yellow> please follow the tutorial at <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>Most of your questions and issues are resolvable via our <yellow>Documentation</yellow>, make sure to checkout <yellow>both</yellow> Documentations<gray> at </gray><blue>https://oraxen.mizius.com/</blue><gray> and <blue>https://docs.oraxen.com</blue><gray>.<br>
@@ -120,3 +120,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>You need more experience to do this"
   backpack_stacked: "<prefix><#fa4943>Cannot open stacked backpack"
   jukebox_now_playing: "<dark_purple>Now Playing <disc>"
+

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>You need more space to place this furniture"
   exit_menu: "<gradient:#FA7CBB:#F14658>Exit"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Welcome to Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen loaded successfully for the first time, lets get you started.<br>
+    <dark_gray> » <gray>To remove the <yellow>default branding</yellow> please follow the tutorial at <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
+    <dark_gray> » <gray>Most of your questions and issues are resolvable via our <yellow>Documentation</yellow>, make sure to checkout <yellow>both</yellow> Documentations<gray> at </gray><blue>https://oraxen.mizius.com/</blue><gray> and <blue>https://docs.oraxen.com</blue><gray>.<br>
+    <dark_gray> » <gray>If you still need help, please visit our discord at <blue>https://discord.gg/9EehAG54aU</blue>.<br>
+    <dark_gray><st>                                                                                                         </st><br>
 
 logs:
   # Log prefix colors:

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -28,7 +28,7 @@ general:
   introduction_guide:
     <br>
     <dark_gray><st>                      </st><gold><bold> Welcome to Oraxen... </bold><dark_gray><st>                      </st><br>
-    <gray> Oraxen loaded successfully for the first time, lets get you started.<br>
+    <gray> Oraxen loaded successfully for the first time, let's get you started.<br>
     <dark_gray> » <gray>To remove the <yellow>default branding</yellow> please follow the tutorial at <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>Most of your questions and issues are resolvable via our <yellow>Documentation</yellow>, make sure to checkout <yellow>both</yellow> Documentations<gray> at </gray><blue>https://oraxen.mizius.com/</blue><gray> and <blue>https://docs.oraxen.com</blue><gray>.<br>
     <dark_gray> » <gray>If you still need help, please visit our discord at <blue>https://discord.gg/9EehAG54aU</blue>.<br>

--- a/core/src/main/resources/languages/french.yml
+++ b/core/src/main/resources/languages/french.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>Vous avez besoin de plus de place pour placer cet équipement"
   exit_menu: "<gradient:#FA7CBB:#F14658>Quitter"
   no_emojis: "<prefix><#fa4943>Aucun émoji trouvé"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Bienvenue sur Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen s'est chargé avec succès pour la première fois, commençons.<br>
+    <dark_gray> » <gray>Pour supprimer le <yellow>branding par défaut</yellow>, veuillez suivre le tutoriel sur <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
+    <dark_gray> » <gray>La plupart de vos questions et problèmes peuvent être résolus via notre <yellow>Documentation</yellow>, assurez-vous de consulter les <yellow>deux</yellow> documentations<gray> sur </gray><blue>https://oraxen.mizius.com/</blue><gray> et <blue>https://docs.oraxen.com</blue><gray>.<br>
+    <dark_gray> » <gray>Si vous avez encore besoin d'aide, rejoignez notre Discord à l'adresse <blue>https://discord.gg/9EehAG54aU</blue>.<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>Le datapack a été généré avec succès"
 
 logs:

--- a/core/src/main/resources/languages/french.yml
+++ b/core/src/main/resources/languages/french.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>Aucun émoji trouvé"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Bienvenue sur Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Bienvenue sur Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen s'est chargé avec succès pour la première fois, commençons.<br>
     <dark_gray> » <gray>Pour supprimer le <yellow>branding par défaut</yellow>, veuillez suivre le tutoriel sur <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>La plupart de vos questions et problèmes peuvent être résolus via notre <yellow>Documentation</yellow>, assurez-vous de consulter les <yellow>deux</yellow> documentations<gray> sur </gray><blue>https://oraxen.mizius.com/</blue><gray> et <blue>https://docs.oraxen.com</blue><gray>.<br>
@@ -124,3 +124,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>Vous avez besoin de plus d'expérience pour faire ceci"
   backpack_stacked: "<prefix><#fa4943>Impossible d'ouvrir un sac à dos empilé"
   jukebox_now_playing: "<dark_purple>Lecture en cours <disc>"
+

--- a/core/src/main/resources/languages/german.yml
+++ b/core/src/main/resources/languages/german.yml
@@ -10,7 +10,7 @@ general:
   pack_uploaded: "<prefix><#55ffa4>Ressourcenpack auf Url <url> in <delay> ms hochgeladen"
   pack_regenerated: "<prefix><#55ffa4>Ressourcenpack erfolgreich regeneriert"
   updating_config: "<prefix><#facc43>Konfigurationsoption \"<option>\" nicht gefunden, wird hinzugefügt!"
-  removing_config: "<prefix><#facc43>Die Konfigurationsoption \"<option>" wurde zum Entfernen markiert, entfernen Sie sie!"
+  removing_config: "<prefix><#facc43>Die Konfigurationsoption \"<option>\" wurde zum Entfernen markiert, entfernen Sie sie!"
   configs_validation_failed: "<prefix><#fa4943>Validierung der Konfigurationen ist fehlgeschlagen, Plugin wurde automatisch deaktiviert!"
   repaired_items: "<prefix><#55ffa4><amount> Item(s) wurden erfolgreich repariert!"
   cannot_be_repaired: "<prefix><#fa4943>Dieses Item kann nicht repariert werden!"
@@ -25,12 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>Sie brauchen mehr Platz, um diese Möbel zu platzieren"
   exit_menu: "<gradient:#FA7CBB:#F14658>Beenden"
   no_emojis: "<prefix><#fa4943>Keine Emojis gefunden"
-  introduction_guide: |-
-    <dark_gray><st>                      </st><gold><bold> Oraxen Einführung </bold><dark_gray><st>                      </st>
-    <gray>Oraxen wurde zum ersten Mal erfolgreich geladen.
-    <dark_gray>» <gray>Nutze <yellow>/oraxen</yellow>, um die wichtigsten Befehle zu sehen.
-    <dark_gray>» <gray>Nutze <yellow>/oraxen pack send</yellow>, um das generierte Ressourcenpaket zu testen.
-    <dark_gray>» <gray>Deine Konfigurationen liegen in <yellow>plugins/Oraxen/</yellow> und können mit <yellow>/oraxen reload</yellow> neu geladen werden.
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Willkommen bei Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen wurde zum ersten Mal erfolgreich geladen, legen wir los.<br>
+    <dark_gray> » <gray>Um das <yellow>Standard-Branding</yellow> zu entfernen, folge bitte dem Tutorial unter <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
+    <dark_gray> » <gray>Die meisten deiner Fragen und Probleme lassen sich über unsere <yellow>Dokumentation</yellow> lösen, schau dir unbedingt <yellow>beide</yellow> Dokumentationen<gray> unter </gray><blue>https://oraxen.mizius.com/</blue><gray> und <blue>https://docs.oraxen.com</blue><gray> an.<br>
+    <dark_gray> » <gray>Wenn du weiterhin Hilfe brauchst, besuche unseren Discord unter <blue>https://discord.gg/9EehAG54aU</blue>.<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>Datapack wurde erfolgreich generiert"
 
 logs:

--- a/core/src/main/resources/languages/german.yml
+++ b/core/src/main/resources/languages/german.yml
@@ -25,6 +25,12 @@ general:
   not_enough_space: "<prefix><#fa4943>Sie brauchen mehr Platz, um diese Möbel zu platzieren"
   exit_menu: "<gradient:#FA7CBB:#F14658>Beenden"
   no_emojis: "<prefix><#fa4943>Keine Emojis gefunden"
+  introduction_guide: |-
+    <dark_gray><st>                      </st><gold><bold> Oraxen Einführung </bold><dark_gray><st>                      </st>
+    <gray>Oraxen wurde zum ersten Mal erfolgreich geladen.
+    <dark_gray>» <gray>Nutze <yellow>/oraxen</yellow>, um die wichtigsten Befehle zu sehen.
+    <dark_gray>» <gray>Nutze <yellow>/oraxen pack send</yellow>, um das generierte Ressourcenpaket zu testen.
+    <dark_gray>» <gray>Deine Konfigurationen liegen in <yellow>plugins/Oraxen/</yellow> und können mit <yellow>/oraxen reload</yellow> neu geladen werden.
   datapack_generated: "<prefix><#55ffa4>Datapack wurde erfolgreich generiert"
 
 logs:

--- a/core/src/main/resources/languages/german.yml
+++ b/core/src/main/resources/languages/german.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>Keine Emojis gefunden"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Willkommen bei Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Willkommen bei Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen wurde zum ersten Mal erfolgreich geladen, legen wir los.<br>
     <dark_gray> » <gray>Um das <yellow>Standard-Branding</yellow> zu entfernen, folge bitte dem Tutorial unter <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>Die meisten deiner Fragen und Probleme lassen sich über unsere <yellow>Dokumentation</yellow> lösen, schau dir unbedingt <yellow>beide</yellow> Dokumentationen<gray> unter </gray><blue>https://oraxen.mizius.com/</blue><gray> und <blue>https://docs.oraxen.com</blue><gray> an.<br>
@@ -121,3 +121,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>Sie brauchen mehr Erfahrung, um dies zu tun"
   backpack_stacked: "<prefix><#fa4943>Cannot open stacked backpack"
   jukebox_now_playing: "<dark_purple>Jetzt spielen <disc>"
+

--- a/core/src/main/resources/languages/jpn_JP.yml
+++ b/core/src/main/resources/languages/jpn_JP.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>絵文字が見つかりません"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Oraxen へようこそ... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Oraxen へようこそ... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen が初回起動で正常に読み込まれました。さっそく始めましょう。<br>
     <dark_gray> » <gray><yellow>デフォルトのブランディング</yellow>を削除するには、<blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray> のチュートリアルをご確認ください。<br>
     <dark_gray> » <gray>ほとんどの質問や問題は <yellow>ドキュメント</yellow> で解決できます。<yellow>両方</yellow>のドキュメント<gray>を </gray><blue>https://oraxen.mizius.com/</blue><gray> と <blue>https://docs.oraxen.com</blue><gray> で必ず確認してください。<br>
@@ -123,3 +123,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>これを行うにはもっと経験験値が必要です"
   backpack_stacked: "<prefix><#fa4943>スタックされたバックパックを開くことができません"
   jukebox_now_playing: "<dark_purple>再生中 <disc>"
+

--- a/core/src/main/resources/languages/jpn_JP.yml
+++ b/core/src/main/resources/languages/jpn_JP.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>この家具を置くためのスペースが足りません"
   exit_menu: "<gradient:#FA7CBB:#F14658>終了"
   no_emojis: "<prefix><#fa4943>絵文字が見つかりません"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Oraxen へようこそ... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen が初回起動で正常に読み込まれました。さっそく始めましょう。<br>
+    <dark_gray> » <gray><yellow>デフォルトのブランディング</yellow>を削除するには、<blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray> のチュートリアルをご確認ください。<br>
+    <dark_gray> » <gray>ほとんどの質問や問題は <yellow>ドキュメント</yellow> で解決できます。<yellow>両方</yellow>のドキュメント<gray>を </gray><blue>https://oraxen.mizius.com/</blue><gray> と <blue>https://docs.oraxen.com</blue><gray> で必ず確認してください。<br>
+    <dark_gray> » <gray>それでもサポートが必要な場合は、<blue>https://discord.gg/9EehAG54aU</blue> の Discord に参加してください。<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>データパックが正常に生成されました"
 
 logs:

--- a/core/src/main/resources/languages/korean.yml
+++ b/core/src/main/resources/languages/korean.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>가구를 놓을 공간이 부족합니다"
   exit_menu: "<gradient:#FA7CBB:#F14658>나가기"
   no_emojis: "<prefix><#fa4943>이모지를 찾을 수 없습니다"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Oraxen에 오신 것을 환영합니다... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen이 처음으로 성공적으로 로드되었습니다. 이제 시작해봅시다.<br>
+    <dark_gray> » <gray><yellow>기본 브랜딩</yellow>을 제거하려면 <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray> 튜토리얼을 따라주세요.<br>
+    <dark_gray> » <gray>대부분의 질문과 문제는 <yellow>문서</yellow>를 통해 해결할 수 있습니다. <yellow>두 개의</yellow> 문서<gray>를 </gray><blue>https://oraxen.mizius.com/</blue><gray> 및 <blue>https://docs.oraxen.com</blue><gray>에서 꼭 확인해 주세요.<br>
+    <dark_gray> » <gray>그래도 도움이 필요하면 <blue>https://discord.gg/9EehAG54aU</blue>의 디스코드를 방문해 주세요.<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>데이터팩이 성공적으로 생성되었습니다"
 
 logs:

--- a/core/src/main/resources/languages/korean.yml
+++ b/core/src/main/resources/languages/korean.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>이모지를 찾을 수 없습니다"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Oraxen에 오신 것을 환영합니다... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Oraxen에 오신 것을 환영합니다... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen이 처음으로 성공적으로 로드되었습니다. 이제 시작해봅시다.<br>
     <dark_gray> » <gray><yellow>기본 브랜딩</yellow>을 제거하려면 <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray> 튜토리얼을 따라주세요.<br>
     <dark_gray> » <gray>대부분의 질문과 문제는 <yellow>문서</yellow>를 통해 해결할 수 있습니다. <yellow>두 개의</yellow> 문서<gray>를 </gray><blue>https://oraxen.mizius.com/</blue><gray> 및 <blue>https://docs.oraxen.com</blue><gray>에서 꼭 확인해 주세요.<br>
@@ -121,3 +121,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>이 작업을 수행하려면 더 많은 경험치가 필요합니다"
   backpack_stacked: "<prefix><#fa4943>풀 스택된 백팩을 열 수 없습니다"
   jukebox_now_playing: "<dark_purple>지금 재생 중 <disc>"
+

--- a/core/src/main/resources/languages/pt-BR.yml
+++ b/core/src/main/resources/languages/pt-BR.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>Nenhum emoji encontrado."
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Bem-vindo ao Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Bem-vindo ao Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen foi carregado com sucesso pela primeira vez, vamos começar.<br>
     <dark_gray> » <gray>Para remover a <yellow>identidade visual padrão</yellow>, siga o tutorial em <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>A maioria das suas dúvidas e problemas pode ser resolvida pela nossa <yellow>Documentação</yellow>, não deixe de conferir <yellow>as duas</yellow> documentações<gray> em </gray><blue>https://oraxen.mizius.com/</blue><gray> e <blue>https://docs.oraxen.com</blue><gray>.<br>
@@ -120,3 +120,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>Você precisa de mais experiência para realizar esta ação."
   backpack_stacked: "<prefix><#fa4943>Não é possível abrir mochilas empilhadas!"
   jukebox_now_playing: "<dark_purple>Tocando agora: <disc>"
+

--- a/core/src/main/resources/languages/pt-BR.yml
+++ b/core/src/main/resources/languages/pt-BR.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>Você precisa de mais espaço para colocar este móvel!"
   exit_menu: "<gradient:#FA7CBB:#F14658>Sair"
   no_emojis: "<prefix><#fa4943>Nenhum emoji encontrado."
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Bem-vindo ao Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen foi carregado com sucesso pela primeira vez, vamos começar.<br>
+    <dark_gray> » <gray>Para remover a <yellow>identidade visual padrão</yellow>, siga o tutorial em <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
+    <dark_gray> » <gray>A maioria das suas dúvidas e problemas pode ser resolvida pela nossa <yellow>Documentação</yellow>, não deixe de conferir <yellow>as duas</yellow> documentações<gray> em </gray><blue>https://oraxen.mizius.com/</blue><gray> e <blue>https://docs.oraxen.com</blue><gray>.<br>
+    <dark_gray> » <gray>Se ainda precisar de ajuda, visite nosso Discord em <blue>https://discord.gg/9EehAG54aU</blue>.<br>
+    <dark_gray><st>                                                                                                         </st><br>
 
 logs:
   # Log prefix colors:

--- a/core/src/main/resources/languages/ru-RU.yml
+++ b/core/src/main/resources/languages/ru-RU.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>Вам нужно больше места, чтобы разместить эту декорацию"
   exit_menu: "<gradient:#FA7CBB:#F14658>Выход"
   no_emojis: "<prefix><#fa4943>Эмодзи не найдены"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> Добро пожаловать в Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen впервые успешно загружен, давайте начнем.<br>
+    <dark_gray> » <gray>Чтобы убрать <yellow>стандартный брендинг</yellow>, следуйте руководству на <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
+    <dark_gray> » <gray>Большинство ваших вопросов и проблем можно решить через нашу <yellow>Документацию</yellow>, обязательно ознакомьтесь <yellow>с обеими</yellow> документациями<gray> на </gray><blue>https://oraxen.mizius.com/</blue><gray> и <blue>https://docs.oraxen.com</blue><gray>.<br>
+    <dark_gray> » <gray>Если вам все еще нужна помощь, посетите наш Discord: <blue>https://discord.gg/9EehAG54aU</blue>.<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>Датапак успешно сгенерирован"
 
 logs:

--- a/core/src/main/resources/languages/ru-RU.yml
+++ b/core/src/main/resources/languages/ru-RU.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>Эмодзи не найдены"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> Добро пожаловать в Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> Добро пожаловать в Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen впервые успешно загружен, давайте начнем.<br>
     <dark_gray> » <gray>Чтобы убрать <yellow>стандартный брендинг</yellow>, следуйте руководству на <blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>.<br>
     <dark_gray> » <gray>Большинство ваших вопросов и проблем можно решить через нашу <yellow>Документацию</yellow>, обязательно ознакомьтесь <yellow>с обеими</yellow> документациями<gray> на </gray><blue>https://oraxen.mizius.com/</blue><gray> и <blue>https://docs.oraxen.com</blue><gray>.<br>
@@ -121,3 +121,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>Вам нужно больше очков опыта, чтобы сделать это"
   backpack_stacked: "<prefix><#fa4943>Невозможно открыть стакнутый рюкзак"
   jukebox_now_playing: "<dark_purple>Сейчас играет: <disc>"
+

--- a/core/src/main/resources/languages/zh-CN.yml
+++ b/core/src/main/resources/languages/zh-CN.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>你需要更多的空间来放置这个家具"
   exit_menu: "<gradient:#FA7CBB:#F14658>退出"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> 欢迎使用 Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen 已首次成功加载，让我们开始吧。<br>
+    <dark_gray> » <gray>如需移除<yellow>默认品牌标识</yellow>，请参考教程：<blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>。<br>
+    <dark_gray> » <gray>你的大多数问题都可以通过我们的<yellow>文档</yellow>解决，请务必查看<yellow>两份</yellow>文档<gray>：</gray><blue>https://oraxen.mizius.com/</blue><gray> 和 <blue>https://docs.oraxen.com</blue><gray>。<br>
+    <dark_gray> » <gray>如果你仍需要帮助，请加入我们的 Discord：<blue>https://discord.gg/9EehAG54aU</blue>。<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>数据包生成成功"
 
 logs:

--- a/core/src/main/resources/languages/zh-CN.yml
+++ b/core/src/main/resources/languages/zh-CN.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>No emojis found"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> 欢迎使用 Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> 欢迎使用 Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen 已首次成功加载，让我们开始吧。<br>
     <dark_gray> » <gray>如需移除<yellow>默认品牌标识</yellow>，请参考教程：<blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>。<br>
     <dark_gray> » <gray>你的大多数问题都可以通过我们的<yellow>文档</yellow>解决，请务必查看<yellow>两份</yellow>文档<gray>：</gray><blue>https://oraxen.mizius.com/</blue><gray> 和 <blue>https://docs.oraxen.com</blue><gray>。<br>
@@ -126,3 +126,4 @@ mechanics:
   jukebox_now_playing: "<dark_purple>正在播放 <disc>"
 # The author can laugh!
 # -- Translator
+

--- a/core/src/main/resources/languages/zh-TW.yml
+++ b/core/src/main/resources/languages/zh-TW.yml
@@ -25,6 +25,14 @@ general:
   not_enough_space: "<prefix><#fa4943>你需要更多的空間來放置這個傢俱"
   exit_menu: "<gradient:#FA7CBB:#F14658>退出"
   no_emojis: "<prefix><#fa4943>No emojis found"
+  introduction_guide:
+    <br>
+    <dark_gray><st>                      </st><gold><bold> 歡迎使用 Oraxen... </bold><dark_gray><st>                      </st><br>
+    <gray> Oraxen 已首次成功載入，讓我們開始吧。<br>
+    <dark_gray> » <gray>如需移除<yellow>預設品牌標示</yellow>，請依照教學：<blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>。<br>
+    <dark_gray> » <gray>你大多數的問題都可透過我們的<yellow>文件</yellow>解決，請務必查看<yellow>兩份</yellow>文件<gray>：</gray><blue>https://oraxen.mizius.com/</blue><gray> 與 <blue>https://docs.oraxen.com</blue><gray>。<br>
+    <dark_gray> » <gray>如果你仍需要協助，請加入我們的 Discord：<blue>https://discord.gg/9EehAG54aU</blue>。<br>
+    <dark_gray><st>                                                                                                         </st><br>
   datapack_generated: "<prefix><#55ffa4>資料包生成成功"
 
 logs:

--- a/core/src/main/resources/languages/zh-TW.yml
+++ b/core/src/main/resources/languages/zh-TW.yml
@@ -27,7 +27,7 @@ general:
   no_emojis: "<prefix><#fa4943>No emojis found"
   introduction_guide:
     <br>
-    <dark_gray><st>                      </st><gold><bold> 歡迎使用 Oraxen... </bold><dark_gray><st>                      </st><br>
+    <dark_gray><st>                                         </st><gold><bold> 歡迎使用 Oraxen... </bold><dark_gray><st>                                         </st><br>
     <gray> Oraxen 已首次成功載入，讓我們開始吧。<br>
     <dark_gray> » <gray>如需移除<yellow>預設品牌標示</yellow>，請依照教學：<blue>https://oraxen.mizius.com/usage/tutorials/d017g<gray>。<br>
     <dark_gray> » <gray>你大多數的問題都可透過我們的<yellow>文件</yellow>解決，請務必查看<yellow>兩份</yellow>文件<gray>：</gray><blue>https://oraxen.mizius.com/</blue><gray> 與 <blue>https://docs.oraxen.com</blue><gray>。<br>
@@ -124,3 +124,4 @@ mechanics:
   not_enough_exp: "<prefix><#fa4943>你需要更多經驗欸"
   backpack_stacked: "<prefix><#fa4943>無法打開堆疊的背包"
   jukebox_now_playing: "<dark_purple>正在播放 <disc>"
+

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -2,6 +2,9 @@ debug: false
 Plugin:
   keep_this_up_to_date: true # Oraxen will delete old settings
   language: "english" # Valid options are "czech", "english", "french", "german",  "jpn_JP", "korean", "ru-RU", "zh-CN", "zh-TW"
+  introduction:
+    console_sent: false
+    player_pending: false
   commands:
     repair:
       oraxen_durability_only: false # will not repair vanilla items if set to true

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -4,7 +4,7 @@ Plugin:
   language: "english" # Valid options are "czech", "english", "french", "german",  "jpn_JP", "korean", "ru-RU", "zh-CN", "zh-TW"
   introduction:
     console_sent: false
-    player_pending: false
+    player_pending: true
   commands:
     repair:
       oraxen_durability_only: false # will not repair vanilla items if set to true


### PR DESCRIPTION
## 🟠 feat: Introduction Guide
- **Summary** - Added a first-load introduction flow that announces successful startup once in console and once to the first eligible player.
- **Description** - Oraxen now registers an `IntroductionGuide` listener after successful enable, tracks delivery state inside `settings.yml`, and uses the existing translatable message system plus a new `oraxen.introduction` permission.

- **Changes** - Restored and wired `IntroductionGuide.java`; kept startup registration in `OraxenPlugin.java`; added `INTRODUCTION_GUIDE` to `Message.java`; added `Plugin.introduction.console_sent` and `Plugin.introduction.player_pending` settings keys in `Settings.java` and `settings.yml`; declared the `oraxen.introduction` permission in `build.gradle.kts`.

### 🔵 note: Review
- **Review** - This PR is being reviewed in another repository (due to Apps / Integrations for this Repo) at https://github.com/pxlarified/oraxen/pull/7.