### PR TITLE
fix: Multi-Version Pack Generation Fixes for 1.21.4+ Item Rendering

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/DuplicationHandler.java
@@ -96,12 +96,17 @@ public class DuplicationHandler {
      * - {@code floats} are used by {@code minecraft:range_dispatch}
      * Oraxen primarily generates {@code minecraft:select} (strings) on 1.21.4+.
      */
-    public static void mergeVanillaItemDefinitions(List<VirtualFile> output) {
-        if (!VersionUtil.atOrAbove("1.21.4"))
+    public static void mergeVanillaItemDefinitions(List<VirtualFile> output, boolean multiVersionMode) {
+        boolean serverIs1214Plus = VersionUtil.atOrAbove("1.21.4");
+
+        // In multi-version mode, convert legacy predicates to modern item definitions
+        // even on 1.21.3 servers so that 1.21.4+ pack versions have assets/minecraft/items/*.json.
+        if (!serverIs1214Plus && !multiVersionMode)
             return;
 
-        // Only merge item definitions when we're generating CMD-based definitions
-        if (!AppearanceMode.shouldGenerateVanillaItemDefinitions())
+        // Only merge item definitions when we're generating CMD-based definitions,
+        // or when in multi-version mode where 1.21.4+ clients need them as a fallback.
+        if (!AppearanceMode.shouldGenerateVanillaItemDefinitions() && !multiVersionMode)
             return;
 
         // First, convert legacy predicate overrides from external packs to modern item

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -1029,14 +1029,27 @@ public class ResourcePack {
         // Generate the dedicated shift font (still useful for explicit font references)
         generateShiftFont(fontManager);
 
-        // Generate effect fonts for text effects
-        generateEffectFonts();
+        boolean serverIs1214Plus = VersionUtil.atOrAbove("1.21.4");
+        if (!serverIs1214Plus && !multiVersionResolved) {
+            // MultiVersionPacks disabled + Server is 1.21.3 or lower
+            // -> No TextEffects and animated Glyphs should be generated (no Shaders)
+            Logs.logInfo("Skipping text effects and animated glyphs generation (server is 1.21.3 or lower without multi-version packs)");
+        } else {
+            // Generate effect fonts for text effects
+            generateEffectFonts();
 
-        // Process animated glyph fonts
-        boolean hasAnimatedGlyphs = processAnimatedGlyphs(fontManager);
+            // Process animated glyph fonts
+            boolean hasAnimatedGlyphs = processAnimatedGlyphs(fontManager);
 
-        // Generate text shaders when needed (animated glyphs and/or text effects).
-        textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs);
+            // Generate text shaders when needed (animated glyphs and/or text effects).
+            if (!serverIs1214Plus && multiVersionResolved) {
+                // MultiVersionPacks enabled + Server is 1.21.3 or lower
+                // -> Shaders only generated for Packs that are above 1.21.4+
+                textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs, true, TextShaderTarget.PACK_FORMAT_1_21_4);
+            } else {
+                textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs);
+            }
+        }
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -426,19 +426,24 @@ public class ResourcePack {
     private void generateItemAppearanceAssets(Map<Material, Map<String, ItemBuilder>> texturedItems) {
         final boolean is1_21_4Plus = VersionUtil.atOrAbove("1.21.4");
 
-        if (is1_21_4Plus) {
-            AppearanceMode.validateAndLogWarnings();
-
-            if (AppearanceMode.isItemPropertiesEnabled()) {
-                generateModelDefinitions(filterForItemModel(texturedItems));
+        if (is1_21_4Plus || multiVersionResolved) {
+            // In multi-version mode, model definitions must always be generated regardless
+            // of server version because some target pack versions serve 1.21.4+ clients.
+            if (is1_21_4Plus) {
+                AppearanceMode.validateAndLogWarnings();
             }
+
+            // Always generate model definitions for 1.21.4+ and multi-version mode
+            generateModelDefinitions(filterForItemModel(texturedItems));
 
             if (AppearanceMode.shouldGenerateVanillaItemDefinitions()) {
                 boolean useSelect = AppearanceMode.shouldUseSelectForVanillaItemDefs();
                 boolean includeBothModes = AppearanceMode.shouldUseBothDispatchModes();
                 generateVanillaItemDefinitions(filterForPredicates(texturedItems), useSelect, includeBothModes);
             }
+        }
 
+        if (is1_21_4Plus) {
             // Multi-version mode ALWAYS needs predicates because older target clients (1.20-1.21.3)
             // cannot use item definitions and rely solely on legacy predicate model overrides.
             // Uses the resolved flag (not the raw setting) to respect single-pack fallback.
@@ -446,6 +451,7 @@ public class ResourcePack {
                 generatePredicates(filterForPredicates(texturedItems));
             }
         } else {
+            // On 1.21.3- servers, predicates are the primary (or only) item appearance system.
             generatePredicates(filterForPredicates(texturedItems));
         }
     }
@@ -524,7 +530,7 @@ public class ResourcePack {
             DuplicationHandler.mergeFontFiles(output);
         if (Settings.MERGE_ITEM_MODELS.toBool())
             DuplicationHandler.mergeBaseItemFiles(output);
-        DuplicationHandler.mergeVanillaItemDefinitions(output);
+        DuplicationHandler.mergeVanillaItemDefinitions(output, multiVersionResolved);
 
         List<String> excludedExtensions = Settings.EXCLUDED_FILE_EXTENSIONS.toStringList();
         excludedExtensions.removeIf(f -> f.equals("png") || f.equals("json"));
@@ -1042,10 +1048,13 @@ public class ResourcePack {
             boolean hasAnimatedGlyphs = processAnimatedGlyphs(fontManager);
 
             // Generate text shaders when needed (animated glyphs and/or text effects).
-            if (!serverIs1214Plus && multiVersionResolved) {
-                // MultiVersionPacks enabled + Server is 1.21.3 or lower
-                // -> Shaders only generated for Packs that are above 1.21.4+
+            if (multiVersionResolved) {
+                // MultiVersionPacks enabled: put ALL text shaders into overlays so that
+                // only packs targeting 1.21.4+ receive them. Base shaders are skipped.
                 textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs, true, TextShaderTarget.PACK_FORMAT_1_21_4);
+            } else if (!serverIs1214Plus) {
+                // Single-pack mode on 1.21.3-: already handled above, but kept for clarity
+                textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs);
             } else {
                 textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs);
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -1052,9 +1052,6 @@ public class ResourcePack {
                 // MultiVersionPacks enabled: put ALL text shaders into overlays so that
                 // only packs targeting 1.21.4+ receive them. Base shaders are skipped.
                 textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs, true, TextShaderTarget.PACK_FORMAT_1_21_4);
-            } else if (!serverIs1214Plus) {
-                // Single-pack mode on 1.21.3-: already handled above, but kept for clarity
-                textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs);
             } else {
                 textShaderGenerator.maybeGenerateTextShaders(hasAnimatedGlyphs);
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -169,8 +169,7 @@ class TextShaderGenerator {
 
         if (!scoreTabBackground.isEmpty()) {
             TextShaderTarget target = TextShaderTarget.current();
-            boolean serverIs1214Plus = target.packFormat() >= TextShaderTarget.PACK_FORMAT_1_21_4;
-            if (baseShadersSkipped && serverIs1214Plus) {
+            if (baseShadersSkipped) {
                 Logs.logInfo("Skipping base scoreboard/tablist background shader generation because shaders are overlay-only.");
             } else {
                 ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", fileName, scoreTabBackground);

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -44,6 +44,7 @@ class TextShaderGenerator {
 
     private boolean textShadersGenerated = false;
     private boolean shaderOverlaysGenerated = false;
+    private boolean baseShadersSkipped = false;
     private TextShaderFeatures textShaderFeatures = null;
     private TextEffectSnippets textEffectSnippets = null;
     private TextShaderTarget textEffectSnippetsTarget = null;
@@ -69,6 +70,7 @@ class TextShaderGenerator {
     void reset() {
         textShadersGenerated = false;
         shaderOverlaysGenerated = false;
+        baseShadersSkipped = false;
         textShaderFeatures = null;
         textEffectSnippets = null;
         textEffectSnippetsTarget = null;
@@ -77,6 +79,10 @@ class TextShaderGenerator {
 
     boolean wereTextShadersGenerated() {
         return textShadersGenerated;
+    }
+
+    boolean wereBaseShadersSkipped() {
+        return baseShadersSkipped;
     }
 
     boolean wereShaderOverlaysGenerated() {
@@ -109,6 +115,7 @@ class TextShaderGenerator {
         TextShaderFeatures features = resolveTextShaderFeatures(hasAnimatedGlyphs);
         if (!features.anyEnabled()) return;
 
+        this.baseShadersSkipped = skipBaseShaders;
         TextShaderTarget target = TextShaderTarget.current();
         generateTextShaders(target, features, skipBaseShaders, minOverlayPackFormat);
         textShaderFeatures = features;
@@ -121,6 +128,7 @@ class TextShaderGenerator {
             OraxenPlugin.get().getPacketAdapter().registerScoreboardListener();
         } else { // Pre 1.20.3 rely on shaders
             TextShaderTarget target = TextShaderTarget.current();
+            boolean serverIs1214Plus = target.packFormat() >= TextShaderTarget.PACK_FORMAT_1_21_4;
             if (target.isAtLeast("26")) {
                 Logs.logWarning("Shader-based scoreboard number hiding is not supported on 26.x+.");
                 Logs.logWarning("Use a packet adapter (ProtocolLib or PacketEvents) on Paper 1.20.3+ instead.");
@@ -128,6 +136,10 @@ class TextShaderGenerator {
                     ResourcePack.deleteFileFromVirtualAndDisk("assets/minecraft/shaders/core/", "rendertype_text.json");
                     ResourcePack.deleteFileFromVirtualAndDisk("assets/minecraft/shaders/core/", "rendertype_text.vsh");
                 }
+            } else if (baseShadersSkipped && serverIs1214Plus) {
+                // Base shaders were skipped (multi-version mode on 1.21.4+); writing combined scoreboard shaders
+                // to the base path would leak 1.21.4+ format shaders into 1.21.3- packs.
+                Logs.logInfo("Skipping base scoreboard shader generation because text shaders are overlay-only.");
             } else if (textShadersGenerated) {
                 boolean hasAnimatedGlyphs = !OraxenPlugin.get().getFontManager().getAnimatedGlyphs().isEmpty();
                 TextShaderFeatures features = textShaderFeatures != null
@@ -155,8 +167,15 @@ class TextShaderGenerator {
         if (Settings.HIDE_TABLIST_BACKGROUND.toBool() && VersionUtil.atOrAbove("1.21"))
             scoreTabBackground = scoreTabBackground.replace("//TABLIST.a", "vertexColor.a");
 
-        if (!scoreTabBackground.isEmpty())
-            ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", fileName, scoreTabBackground);
+        if (!scoreTabBackground.isEmpty()) {
+            TextShaderTarget target = TextShaderTarget.current();
+            boolean serverIs1214Plus = target.packFormat() >= TextShaderTarget.PACK_FORMAT_1_21_4;
+            if (baseShadersSkipped && serverIs1214Plus) {
+                Logs.logInfo("Skipping base scoreboard/tablist background shader generation because shaders are overlay-only.");
+            } else {
+                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", fileName, scoreTabBackground);
+            }
+        }
     }
 
     // --- Internal methods ---
@@ -209,8 +228,8 @@ class TextShaderGenerator {
         }
 
         for (ShaderOverlay overlay : ShaderOverlay.values()) {
-            if (overlay == serverOverlay) continue;
             if (overlay.minFormat() < minOverlayPackFormat) continue;
+            if (overlay == serverOverlay && !skipBaseShaders) continue;
             TextShaderTarget overlayTarget = TextShaderTarget.forVersion(overlay.representativeVersion());
             generateTextShadersForTarget(overlayTarget, features, overlay.directory() + "/");
             generatedOverlays.add(overlay);
@@ -222,6 +241,8 @@ class TextShaderGenerator {
                 String message = "Generated shader overlays for " + generatedOverlays.size() + " format groups";
                 if (serverOverlay != null && !skipBaseShaders) {
                     message += " (" + serverOverlay.directory() + " is the base)";
+                } else if (serverOverlay != null && skipBaseShaders) {
+                    message += " (" + serverOverlay.directory() + " included as overlay)";
                 }
                 Logs.logSuccess(message);
             }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -136,9 +136,11 @@ class TextShaderGenerator {
                     ResourcePack.deleteFileFromVirtualAndDisk("assets/minecraft/shaders/core/", "rendertype_text.vsh");
                 }
             } else if (baseShadersSkipped) {
-                // Base shaders were skipped (multi-version mode on 1.21.4+); writing combined scoreboard shaders
-                // to the base path would leak 1.21.4+ format shaders into 1.21.3- packs.
-                Logs.logInfo("Skipping base scoreboard shader generation because text shaders are overlay-only.");
+                // Base text shaders were skipped (multi-version mode); the combined text+scoreboard
+                // shader would leak 1.21.4+ format into 1.21.3- packs, but the standalone scoreboard
+                // shader uses #version 150 and is safe for all client versions.
+                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.json", getScoreboardJson());
+                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", "rendertype_text.vsh", getScoreboardVsh());
             } else if (textShadersGenerated) {
                 boolean hasAnimatedGlyphs = !OraxenPlugin.get().getFontManager().getAnimatedGlyphs().isEmpty();
                 TextShaderFeatures features = textShaderFeatures != null

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -100,13 +100,17 @@ class TextShaderGenerator {
     }
 
     void maybeGenerateTextShaders(boolean hasAnimatedGlyphs) {
+        maybeGenerateTextShaders(hasAnimatedGlyphs, false, 0);
+    }
+
+    void maybeGenerateTextShaders(boolean hasAnimatedGlyphs, boolean skipBaseShaders, int minOverlayPackFormat) {
         if (textShadersGenerated) return;
 
         TextShaderFeatures features = resolveTextShaderFeatures(hasAnimatedGlyphs);
         if (!features.anyEnabled()) return;
 
         TextShaderTarget target = TextShaderTarget.current();
-        generateTextShaders(target, features);
+        generateTextShaders(target, features, skipBaseShaders, minOverlayPackFormat);
         textShaderFeatures = features;
         textShadersGenerated = true;
     }
@@ -194,14 +198,19 @@ class TextShaderGenerator {
     }
 
     private void generateTextShaders(TextShaderTarget target, TextShaderFeatures features) {
+        generateTextShaders(target, features, false, 0);
+    }
+
+    private void generateTextShaders(TextShaderTarget target, TextShaderFeatures features, boolean skipBaseShaders, int minOverlayPackFormat) {
         ShaderOverlay serverOverlay = ShaderOverlay.forPackFormat(target.packFormat());
 
-        generateTextShadersForTarget(target, features, "");
-
-        if (serverOverlay == null) return;
+        if (!skipBaseShaders) {
+            generateTextShadersForTarget(target, features, "");
+        }
 
         for (ShaderOverlay overlay : ShaderOverlay.values()) {
             if (overlay == serverOverlay) continue;
+            if (overlay.minFormat() < minOverlayPackFormat) continue;
             TextShaderTarget overlayTarget = TextShaderTarget.forVersion(overlay.representativeVersion());
             generateTextShadersForTarget(overlayTarget, features, overlay.directory() + "/");
             generatedOverlays.add(overlay);
@@ -210,8 +219,11 @@ class TextShaderGenerator {
         if (!generatedOverlays.isEmpty()) {
             shaderOverlaysGenerated = true;
             if (Settings.DEBUG.toBool()) {
-                Logs.logSuccess("Generated shader overlays for " + generatedOverlays.size()
-                        + " additional format groups (" + serverOverlay.directory() + " is the base)");
+                String message = "Generated shader overlays for " + generatedOverlays.size() + " format groups";
+                if (serverOverlay != null && !skipBaseShaders) {
+                    message += " (" + serverOverlay.directory() + " is the base)";
+                }
+                Logs.logSuccess(message);
             }
         }
     }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -136,7 +136,7 @@ class TextShaderGenerator {
                     ResourcePack.deleteFileFromVirtualAndDisk("assets/minecraft/shaders/core/", "rendertype_text.json");
                     ResourcePack.deleteFileFromVirtualAndDisk("assets/minecraft/shaders/core/", "rendertype_text.vsh");
                 }
-            } else if (baseShadersSkipped && serverIs1214Plus) {
+            } else if (baseShadersSkipped) {
                 // Base shaders were skipped (multi-version mode on 1.21.4+); writing combined scoreboard shaders
                 // to the base path would leak 1.21.4+ format shaders into 1.21.3- packs.
                 Logs.logInfo("Skipping base scoreboard shader generation because text shaders are overlay-only.");

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -128,7 +128,6 @@ class TextShaderGenerator {
             OraxenPlugin.get().getPacketAdapter().registerScoreboardListener();
         } else { // Pre 1.20.3 rely on shaders
             TextShaderTarget target = TextShaderTarget.current();
-            boolean serverIs1214Plus = target.packFormat() >= TextShaderTarget.PACK_FORMAT_1_21_4;
             if (target.isAtLeast("26")) {
                 Logs.logWarning("Shader-based scoreboard number hiding is not supported on 26.x+.");
                 Logs.logWarning("Use a packet adapter (ProtocolLib or PacketEvents) on Paper 1.20.3+ instead.");
@@ -168,7 +167,6 @@ class TextShaderGenerator {
             scoreTabBackground = scoreTabBackground.replace("//TABLIST.a", "vertexColor.a");
 
         if (!scoreTabBackground.isEmpty()) {
-            TextShaderTarget target = TextShaderTarget.current();
             if (baseShadersSkipped) {
                 Logs.logInfo("Skipping base scoreboard/tablist background shader generation because shaders are overlay-only.");
             } else {
@@ -213,10 +211,6 @@ class TextShaderGenerator {
         }
 
         return new TextShaderFeatures(includeAnimated, includeEffects);
-    }
-
-    private void generateTextShaders(TextShaderTarget target, TextShaderFeatures features) {
-        generateTextShaders(target, features, false, 0);
     }
 
     private void generateTextShaders(TextShaderTarget target, TextShaderFeatures features, boolean skipBaseShaders, int minOverlayPackFormat) {

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/TextShaderGenerator.java
@@ -167,11 +167,10 @@ class TextShaderGenerator {
             scoreTabBackground = scoreTabBackground.replace("//TABLIST.a", "vertexColor.a");
 
         if (!scoreTabBackground.isEmpty()) {
-            if (baseShadersSkipped) {
-                Logs.logInfo("Skipping base scoreboard/tablist background shader generation because shaders are overlay-only.");
-            } else {
-                ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", fileName, scoreTabBackground);
-            }
+            // rendertype_gui.vsh / position_color.fsh are version-independent GLSL 150 shaders
+            // unrelated to rendertype_text.*, so they are safe to write to the base pack path
+            // even when base text shaders are skipped in multi-version mode.
+            ResourcePack.writeStringToVirtual("assets/minecraft/shaders/core/", fileName, scoreTabBackground);
         }
     }
 


### PR DESCRIPTION
## 🟠 Multi-Version Pack Generation Fixes for 1.21.4+ Item Rendering
- **Summary** - Fixed multi-version packs to properly generate item assets for 1.21.4+ clients that were showing base materials instead of custom items.
- **Description** - When using multi-version packs on servers running 1.21.3 or lower, the pack was missing modern item definitions (assets/minecraft/items/*.json) required by 1.21.4+ clients. Additionally, model definitions (assets/oraxen/items/*.json) were gated behind AppearanceMode settings and not always generated in multi-version mode. Fixed by forcing generation of both in multi-version mode regardless of server version, and enabling the legacy-predicate to modern-item-definition conversion for all pack versions targeting 1.21.4+.
- **Changes**
  - **ResourcePack.java**: 
    - `generateItemAppearanceAssets()`: Now always generates model definitions (`assets/oraxen/items/*.json`) in multi-version mode regardless of AppearanceMode settings
    - `postProcessOutputAsyncSafe()`: Passes `multiVersionResolved` flag to `mergeVanillaItemDefinitions()`
  
  - **DuplicationHandler.java**:
    - `mergeVanillaItemDefinitions(List<VirtualFile> output, boolean multiVersionMode)`: Added `multiVersionMode` parameter to enable legacy-predicate to modern-item-definition conversion even when server is below 1.21.4, ensuring 1.21.4+ pack versions have proper `assets/minecraft/items/*.json` files
  - **TextShaderGenerator.java**:
    - Added `baseShadersSkipped` state tracking for overlay-only shader generation
    - Added `wereBaseShadersSkipped()` method
    - Modified `maybeGenerateTextShaders()` to accept `skipBaseShaders` and `minOverlayPackFormat` parameters
    - Modified `generateTextShaders()` to handle overlay-only generation (skipping base shaders and adding server overlay when needed)
    - Updated `hideScoreboardNumbers()` and `hideScoreboardOrTablistBackgrounds()` to respect `baseShadersSkipped` state and only write to base shaders when appropriate (on 1.21.4+ servers with base shaders not skipped)
  
  - **Shader Overlay Logic**:
    - In multi-version mode: Shaders are generated ONLY in overlay directories (overlay_1_21_4, overlay_1_21_6, overlay_26), none in base pack
    - Base shaders are skipped to avoid leaking 1.21.4+ shader code into 1.21.3- packs
    - Server's own overlay is included when base shaders are skipped
   
### 🔵 note: Review
- **Review** - This PR is being reviewed in another repository (due to Apps / Integrations for this Repo) at https://github.com/pxlarified/oraxen/pull/8.