### PR TITLE
feat: Executable items drop integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -266,7 +266,8 @@ bukkit {
         "packetevents",
         "LightAPI", "PlaceholderAPI", "MythicMobs", "MMOItems", "MythicCrucible", "MythicMobs", "BossShopPro",
         "CrateReloaded", "ItemBridge", "WorldEdit", "WorldGuard", "Towny", "Factions", "Lands", "PlotSquared",
-        "NBTAPI", "ModelEngine", "ViaBackwards", "HuskClaims", "HuskTowns", "BentoBox", "Skript", "Iris"
+        "NBTAPI", "ModelEngine", "ViaBackwards", "HuskClaims", "HuskTowns", "BentoBox", "Skript", "Iris",
+        "ExecutableItems"
     )
     loadBefore = listOf("Realistic_World")
     permissions.create("oraxen.command") {

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/executableitems/WrappedExecutableItem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/executableitems/WrappedExecutableItem.java
@@ -1,0 +1,37 @@
+package io.th0rgal.oraxen.compatibilities.provided.executableitems;
+
+import com.ssomar.score.api.executableitems.ExecutableItemsAPI;
+import com.ssomar.score.api.executableitems.config.ExecutableItemInterface;
+import io.th0rgal.oraxen.utils.PluginUtils;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public class WrappedExecutableItem {
+    private final String id;
+
+    public WrappedExecutableItem(ConfigurationSection section) {
+        this.id = section.getString("id");
+    }
+
+    public WrappedExecutableItem(String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public ItemStack build() {
+        if (id == null || !PluginUtils.isEnabled("ExecutableItems")) return null;
+
+        Optional<ExecutableItemInterface> eiOpt = ExecutableItemsAPI
+                .getExecutableItemsManager()
+                .getExecutableItem(id);
+
+        if (eiOpt.isPresent()) {
+            return eiOpt.get().buildItem(1, Optional.empty(), Optional.empty());
+        }
+
+        return null;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.utils.drops;
 import io.th0rgal.oraxen.utils.IntegerRange;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
+import io.th0rgal.oraxen.compatibilities.provided.executableitems.WrappedExecutableItem;
 import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.utils.Utils;
@@ -61,6 +62,7 @@ public class Loot {
         String mmoItemsId = getConfigString("mmoitems_id");
         String mmoItemsType = getConfigString("mmoitems_type");
         String ecoItemId = getConfigString("ecoitem");
+        String executableItemId = getConfigString("executableitem");
         String minecraftType = getConfigString("minecraft_type");
 
         if (oraxenItemId != null) {
@@ -74,6 +76,8 @@ public class Loot {
             itemStack = MMOItems.plugin.getItem(type, id);
         } else if (ecoItemId != null) {
             itemStack = new WrappedEcoItem(ecoItemId).build();
+        } else if (executableItemId != null) {
+            itemStack = new WrappedExecutableItem(executableItemId).build();
         } else if (minecraftType != null) {
             Material material = Material.getMaterial(minecraftType);
             itemStack = material != null ? new ItemStack(material) : null;

--- a/gradle/oraxenLibs.versions.toml
+++ b/gradle/oraxenLibs.versions.toml
@@ -51,6 +51,10 @@ ecoitems = { module = "com.willfp:EcoItems", version = "5.64.0" }
 eco = { module = "com.willfp:eco", version = "6.73.0" }
 libreforge = { module = "com.willfp:libreforge", version = "4.36.0" }
 
+# ExecutableItems (SCore) https://github.com/Ssomar-Developement/SCore
+# Repo: JitPack
+score = { module = "com.github.Ssomar-Developement:SCore", version = "5.25.3.9" }
+
 # BlockLocker https://github.com/rutgerkok/BlockLocker
 # Repo: https://repo.codemc.org/repository/maven-public/
 blocklocker = { module = "nl.rutgerkok:blocklocker", version = "1.13-SNAPSHOT" }
@@ -190,4 +194,5 @@ plugins = [
     "blocklocker",      # BlockLocker
     "skript",           # Skript
     "iris",             # Iris World Generator
+    "score",            # ExecutableItems (SCore)
 ]

--- a/v1_21_R6_spigot/build.gradle.kts
+++ b/v1_21_R6_spigot/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 dependencies {
     compileOnly(project(":core"))
     // Use Spigot-mapped jar from BuildTools (via mavenLocal)
-    compileOnly("org.spigotmc:spigot:1.21.11-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot:1.21.11-R0.2-SNAPSHOT")
 }
 
 tasks {


### PR DESCRIPTION
_Forked Pull Request from https://github.com/oraxen/oraxen/pull/1816 but with changed base branch._ 

## Summary

Adds ExecutableItems integration for custom block drops, allowing server administrators to use ExecutableItems as loot from Oraxen noteblock custom blocks.

## Motivation

Many server administrators use both Oraxen and ExecutableItems together:
- **Oraxen** for custom blocks, furniture, and resource pack generation
- **ExecutableItems** for advanced custom items with complex behaviors and triggers

Previously, there was no way to configure ExecutableItems as drops from Oraxen custom blocks. Server owners had to choose between:
1. Using only Oraxen items in block drops (limiting item functionality)
2. Manually spawning ExecutableItems via commands/scripts (complex and error-prone)

This integration bridges the gap between both plugins, enabling seamless interoperability.

## Changes

- **Added `WrappedExecutableItem` class** — Wrapper for ExecutableItems (SCore) API following the existing pattern used by `WrappedEcoItem`, `WrappedCrucibleItem`, etc.
- **Added `executableitem` config key** in `Loot.getItemStack()` — Allows specifying ExecutableItems in drop configurations
- **Added SCore dependency** — Added `com.github.Ssomar-Developement:SCore:5.25.3.9` to `oraxenLibs.versions.toml`
- **Added ExecutableItems to softDepend** — Ensures proper plugin load order

## Usage Example

After this change, server administrators can configure ExecutableItems in noteblock drops:

```yaml
custom_ore:
  material: PAPER
  Pack:
    custom_model_data: 1001
  Mechanics:
    noteblock:
      custom_variation: 1
      drop:
        silktouch: true
        fortune: true
        minimal_type: IRON
        loots:
          - oraxen_item: custom_ore
            probability: 1.0
            amount: 1
          - executableitem: magic_sword  # ExecutableItem drop
            probability: 0.05
            amount: "1..2"
          - executableitem: rare_potion
            probability: 0.01
            amount: 1
```

## Implementation Details

- Follows the same pattern as existing third-party item integrations (EcoItems, MythicCrucible, MMOItems)
- Uses `Optional.empty()` for the creator parameter since items are dropped into the world
- Graceful degradation: returns `null` if ExecutableItems is not installed (no crashes)
- No event firing needed: ExecutableItems handles pickup detection automatically

## Testing

- Project builds successfully without errors
- SCore dependency resolves correctly via JitPack
- Code follows existing compatibility patterns
- No breaking changes to existing configurations

## Benefits

- **Better plugin interoperability** — Oraxen and ExecutableItems work together seamlessly
- **More flexibility for server owners** — Can use advanced ExecutableItems features in custom block drops
- **Consistent API** — Follows the same pattern as other third-party integrations
- **Zero overhead** — No performance impact when ExecutableItems is not installed