### PR TITLE
fix: custom block hardness mining desync

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/chorusblock/ChorusBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/chorusblock/ChorusBlockMechanicListener.java
@@ -70,10 +70,12 @@ public class ChorusBlockMechanicListener implements Listener {
                 if (mechanic == null) return 0;
                 final double hardness = mechanic.getHardness();
                 double modifier = 1;
-                if (mechanic.getDrop().canDrop(tool)) {
+                if (mechanic.getDrop().isToolEnough(tool)) {
                     modifier *= 0.4;
-                    final int diff = mechanic.getDrop().getDiff(tool);
-                    if (diff >= 1) modifier *= Math.pow(0.9, diff);
+                    if (mechanic.getDrop().isTypeEnough(tool)) {
+                        final int diff = mechanic.getDrop().getDiff(tool);
+                        if (diff >= 1) modifier *= Math.pow(0.9, diff);
+                    }
                 }
                 long period = (long) (hardness * modifier);
                 return period == 0 && mechanic.hasHardness() ? 1 : period;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -78,11 +78,13 @@ public class FurnitureListener implements Listener {
 
                 final long hardness = mechanic.getHardness();
                 double modifier = 1;
-                if (mechanic.getDrop().canDrop(tool)) {
+                if (mechanic.getDrop().isToolEnough(tool)) {
                     modifier *= 0.4;
-                    final int diff = mechanic.getDrop().getDiff(tool);
-                    if (diff >= 1)
-                        modifier *= Math.pow(0.9, diff);
+                    if (mechanic.getDrop().isTypeEnough(tool)) {
+                        final int diff = mechanic.getDrop().getDiff(tool);
+                        if (diff >= 1)
+                            modifier *= Math.pow(0.9, diff);
+                    }
                 }
                 long period = (long) (hardness * modifier);
                 return period == 0 && mechanic.hasHardness() ? 1 : period;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/noteblock/NoteBlockMechanicListener.java
@@ -73,10 +73,12 @@ public class NoteBlockMechanicListener implements Listener {
                     mechanic = mechanic.getDirectional().getParentMechanic();
                 final double hardness = mechanic.getHardness();
                 double modifier = 1;
-                if (mechanic.getDrop().canDrop(tool)) {
+                if (mechanic.getDrop().isToolEnough(tool)) {
                     modifier *= 0.4;
-                    final int diff = mechanic.getDrop().getDiff(tool);
-                    if (diff >= 1) modifier *= Math.pow(0.9, diff);
+                    if (mechanic.getDrop().isTypeEnough(tool)) {
+                        final int diff = mechanic.getDrop().getDiff(tool);
+                        if (diff >= 1) modifier *= Math.pow(0.9, diff);
+                    }
                 }
                 long period = (long) (hardness * modifier);
                 return period == 0 && mechanic.hasHardness() ? 1 : period;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/stringblock/StringBlockMechanicListener.java
@@ -70,10 +70,12 @@ public class StringBlockMechanicListener implements Listener {
                 if (mechanic == null) return 0;
                 final double hardness = mechanic.getHardness();
                 double modifier = 1;
-                if (mechanic.getDrop().canDrop(tool)) {
+                if (mechanic.getDrop().isToolEnough(tool)) {
                     modifier *= 0.4;
-                    final int diff = mechanic.getDrop().getDiff(tool);
-                    if (diff >= 1) modifier *= Math.pow(0.9, diff);
+                    if (mechanic.getDrop().isTypeEnough(tool)) {
+                        final int diff = mechanic.getDrop().getDiff(tool);
+                        if (diff >= 1) modifier *= Math.pow(0.9, diff);
+                    }
                 }
                 long period = (long) (hardness * modifier);
                 return period == 0 && mechanic.hasHardness() ? 1 : period;

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -57,7 +57,7 @@ public abstract class BreakerSystem {
 
     protected abstract void sendBlockBreak(final Player player, final Location location, final int stage) ;
 
-    protected void handleEvent(Player player, Block block, Location location, BlockFace blockFace, World world, Runnable cancel, boolean startedDigging) {
+    protected void handleEvent(Player player, Block block, Location location, BlockFace blockFace, World world, Runnable cancel, boolean startedDigging, boolean finishedDigging) {
         if (player.getGameMode() == GameMode.CREATIVE) return;
 
         final ItemStack item = player.getInventory().getItemInMainHand();
@@ -81,6 +81,11 @@ public abstract class BreakerSystem {
         if (block.getType() == Material.BARRIER && furnitureMechanic == null) return;
 
         cancel.run();
+
+        if (finishedDigging) {
+            SchedulerUtil.runForEntity(player, () -> player.sendBlockChange(location, block.getBlockData()));
+            return;
+        }
 
         if (startedDigging) {
             // Get these when block is started being broken to minimize checks & allow for proper damage checks later

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/CustomBlockMiningListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/CustomBlockMiningListener.java
@@ -139,11 +139,13 @@ public class CustomBlockMiningListener implements Listener {
 
     private double getToolSpeedMultiplier(final Player player, final Drop drop) {
         final ItemStack tool = player.getInventory().getItemInMainHand();
-        if (!drop.canDrop(tool)) return 1.0D;
+        if (!drop.isToolEnough(tool)) return 1.0D;
 
         double multiplier = 2.5D;
-        final int diff = drop.getDiff(tool);
-        if (diff >= 1) multiplier *= Math.pow(1.1D, diff);
+        if (drop.isTypeEnough(tool)) {
+            final int diff = drop.getDiff(tool);
+            if (diff >= 1) multiplier *= Math.pow(1.1D, diff);
+        }
 
         return multiplier;
     }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/CustomBlockMiningListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/CustomBlockMiningListener.java
@@ -4,6 +4,7 @@ import io.th0rgal.oraxen.api.OraxenBlocks;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.chorusblock.ChorusBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.stringblock.StringBlockMechanic;
+import io.th0rgal.oraxen.utils.drops.Drop;
 import io.th0rgal.oraxen.utils.wrappers.AttributeWrapper;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -23,6 +24,7 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
@@ -53,19 +55,20 @@ public class CustomBlockMiningListener implements Listener {
         if (player.getGameMode() == GameMode.CREATIVE) return;
 
         final Block block = event.getBlock();
-        final Double hardness = getHardness(block);
-        if (hardness == null) {
+        final MiningProfile miningProfile = getMiningProfile(block);
+        if (miningProfile == null) {
             removeTransientModifier(player);
             return;
         }
 
+        final double hardness = miningProfile.hardness();
         if (hardness <= 0.0D) {
             removeTransientModifier(player);
             event.setInstaBreak(true);
             return;
         }
 
-        final AttributeModifier modifier = createBreakingModifier(hardness);
+        final AttributeModifier modifier = createBreakingModifier(player, miningProfile);
         if (modifier == null) {
             removeTransientModifier(player);
             return;
@@ -100,7 +103,7 @@ public class CustomBlockMiningListener implements Listener {
     }
 
     @Nullable
-    private Double getHardness(final Block block) {
+    private MiningProfile getMiningProfile(final Block block) {
         if (block.getType() == Material.NOTE_BLOCK) {
             NoteBlockMechanic mechanic = OraxenBlocks.getNoteBlockMechanic(block);
             if (mechanic == null) return null;
@@ -108,31 +111,41 @@ public class CustomBlockMiningListener implements Listener {
                 mechanic = mechanic.getDirectional().getParentMechanic();
                 if (mechanic == null) return null;
             }
-            return mechanic.hasHardness() ? (double) mechanic.getHardness() : null;
+            return mechanic.hasHardness() ? new MiningProfile(mechanic.getHardness(), mechanic.getDrop()) : null;
         }
 
         if (block.getType() == Material.TRIPWIRE) {
             final StringBlockMechanic mechanic = OraxenBlocks.getStringMechanic(block);
-            return mechanic != null && mechanic.hasHardness() ? (double) mechanic.getHardness() : null;
+            return mechanic != null && mechanic.hasHardness() ? new MiningProfile(mechanic.getHardness(), mechanic.getDrop()) : null;
         }
 
         if (block.getType() == Material.CHORUS_PLANT) {
             final ChorusBlockMechanic mechanic = OraxenBlocks.getChorusMechanic(block);
-            return mechanic != null && mechanic.hasHardness() ? (double) mechanic.getHardness() : null;
+            return mechanic != null && mechanic.hasHardness() ? new MiningProfile(mechanic.getHardness(), mechanic.getDrop()) : null;
         }
 
         return null;
     }
 
     @Nullable
-    private AttributeModifier createBreakingModifier(final double hardness) {
+    private AttributeModifier createBreakingModifier(final Player player, final MiningProfile miningProfile) {
         final Attribute blockBreakSpeed = AttributeWrapper.BLOCK_BREAK_SPEED;
         if (BREAK_SPEED_KEY == null || blockBreakSpeed == null) return null;
 
-        // Rescale legacy Oraxen hardness values so 1 is close to normal mining speed and
-        // larger values stay usable without becoming excessively slow.
-        final double speedFactor = Math.max(0.05D, 1.2D / hardness);
+        final double speedFactor = Math.max(0.01D,
+                0.24D / miningProfile.hardness() * getToolSpeedMultiplier(player, miningProfile.drop()));
         return instantiateModifier(speedFactor - 1.0D);
+    }
+
+    private double getToolSpeedMultiplier(final Player player, final Drop drop) {
+        final ItemStack tool = player.getInventory().getItemInMainHand();
+        if (!drop.canDrop(tool)) return 1.0D;
+
+        double multiplier = 2.5D;
+        final int diff = drop.getDiff(tool);
+        if (diff >= 1) multiplier *= Math.pow(1.1D, diff);
+
+        return multiplier;
     }
 
     private void addTransientModifier(final Player player, final AttributeModifier modifier) {
@@ -204,4 +217,6 @@ public class CustomBlockMiningListener implements Listener {
             return null;
         }
     }
+
+    private record MiningProfile(double hardness, Drop drop) {}
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/PacketEventsBreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/PacketEventsBreakerSystem.java
@@ -38,7 +38,9 @@ public class PacketEventsBreakerSystem extends BreakerSystem {
             final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
             final Location location = block.getLocation();
 
-            handleEvent(player, block, location, blockFace, world, () -> event.setCancelled(true), wrapper.getAction() == DiggingAction.START_DIGGING);
+            handleEvent(player, block, location, blockFace, world, () -> event.setCancelled(true),
+                    wrapper.getAction() == DiggingAction.START_DIGGING,
+                    wrapper.getAction() == DiggingAction.FINISHED_DIGGING);
         }
     };
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/ProtocolLibBreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/ProtocolLibBreakerSystem.java
@@ -46,7 +46,9 @@ public class ProtocolLibBreakerSystem extends BreakerSystem {
                 BlockFace.valueOf(dataDirection.read(0).name()) :
                 BlockFace.UP;
 
-            handleEvent(player, block, location, blockFace, world, () -> event.setCancelled(true), type == EnumWrappers.PlayerDigType.START_DESTROY_BLOCK);
+            handleEvent(player, block, location, blockFace, world, () -> event.setCancelled(true),
+                    type == EnumWrappers.PlayerDigType.START_DESTROY_BLOCK,
+                    type == EnumWrappers.PlayerDigType.STOP_DESTROY_BLOCK);
         }
     };
 


### PR DESCRIPTION
## 🟠 fix: custom block hardness desync
- **Summary** - Fixed the custom block mining desync that could leave blocks invisible but still present after breaking.

- **Description** - The break-speed calculation for the modern attribute-based mining path was too aggressive and did not match the effective custom hardness rules, especially for bare hands and higher hardness values. The packet-based breaker path also treated client-side finished digging like an abort, which could cancel Oraxen’s custom break flow before the server actually removed the block.

- **Changes** - Updated `CustomBlockMiningListener` to use a `0.24 / hardness` break-speed baseline and apply Oraxen’s tool/drop speed modifiers, added a small `MiningProfile` helper to carry hardness and drop data together, and changed `BreakerSystem`, `ProtocolLibBreakerSystem`, and `PacketEventsBreakerSystem` so finished-digging packets resync the block instead of cancelling custom breaking.