### PR TITLE
feat(font): support multi-character glyphs and improve glyph handling

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     }
     
     // Test dependencies
+    testImplementation("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.mockito:mockito-core:5.11.0")

--- a/core/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
@@ -59,7 +59,7 @@ public class GlyphCommand {
                             }
 
                             pages = pages.append(AdventureUtils.MINI_MESSAGE.deserialize("<glyph:" + emoji.getName() + ">")
-                                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, emoji.getCharacters()))
+                                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, emoji.getFormattedUnicodes()))
                                     .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.text(finalString + permissionMessage))));
                         }
                     }

--- a/core/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/GlyphCommand.java
@@ -59,7 +59,7 @@ public class GlyphCommand {
                             }
 
                             pages = pages.append(AdventureUtils.MINI_MESSAGE.deserialize("<glyph:" + emoji.getName() + ">")
-                                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, String.valueOf(emoji.getCharacter())))
+                                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, emoji.getCharacters()))
                                     .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.text(finalString + permissionMessage))));
                         }
                     }

--- a/core/src/main/java/io/th0rgal/oraxen/commands/GlyphInfoCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/GlyphInfoCommand.java
@@ -36,7 +36,7 @@ public class GlyphInfoCommand {
                                         .append(Component.newline())
                                         .append(glyph.getGlyphComponent().color(NamedTextColor.WHITE)
                                                .hoverEvent(HoverEvent.showText(AdventureUtils.MINI_MESSAGE.deserialize("<gold>Click to copy to clipboard.")))
-                                               .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, glyph.getCharacters())))
+                                               .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, glyph.getFormattedUnicodes())))
                                         .append(Component.newline())
                         );
                     }

--- a/core/src/main/java/io/th0rgal/oraxen/commands/GlyphInfoCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/GlyphInfoCommand.java
@@ -7,8 +7,10 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.font.Glyph;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 public class GlyphInfoCommand {
 
@@ -21,12 +23,22 @@ public class GlyphInfoCommand {
                     Glyph glyph = OraxenPlugin.get().getFontManager().getGlyphFromID(glyphId);
                     Audience audience = OraxenPlugin.get().getAudience().sender(sender);
                     if (glyph == null) {
-                        audience.sendMessage(AdventureUtils.MINI_MESSAGE.deserialize("<red>No glyph found with glyph-id <i><dark_red>" + glyphId));
+                        audience.sendMessage(AdventureUtils.MINI_MESSAGE.deserialize("<prefix><red>No glyph found with glyph-id <white>" + glyphId + "<red>."));
                     } else {
-                        audience.sendMessage(AdventureUtils.MINI_MESSAGE.deserialize("<dark_aqua>GlyphID: <aqua>" + glyphId));
-                        audience.sendMessage(AdventureUtils.MINI_MESSAGE.deserialize("<dark_aqua>Texture: <aqua>" + glyph.getTexture()));
-                        audience.sendMessage(AdventureUtils.MINI_MESSAGE.deserialize("<dark_aqua>Bitmap: <aqua>" + glyph.isBitMap()));
-                        audience.sendMessage(AdventureUtils.MINI_MESSAGE.deserialize("<dark_aqua>Unicode: <white>" + glyph.getCharacter()).hoverEvent(HoverEvent.showText(AdventureUtils.MINI_MESSAGE.deserialize("<gold>Click to copy to clipboard!"))).clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, glyph.getCharacter())));
+                        audience.sendMessage(
+                                Component.empty()
+                                        .append(Component.newline())
+                                        .append(AdventureUtils.MINI_MESSAGE.deserialize("<gray>GlyphID ⏵ <white>" + glyphId))
+                                        .append(Component.newline())
+                                        .append(AdventureUtils.MINI_MESSAGE.deserialize("<gray>Texture ⏵ <white>" + glyph.getTexture()))
+                                        .append(Component.newline())
+                                        .append(AdventureUtils.MINI_MESSAGE.deserialize("<gray>Unicode(s) ⏵ <white>"))
+                                        .append(Component.newline())
+                                        .append(glyph.getGlyphComponent().color(NamedTextColor.WHITE)
+                                               .hoverEvent(HoverEvent.showText(AdventureUtils.MINI_MESSAGE.deserialize("<gold>Click to copy to clipboard.")))
+                                               .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, glyph.getCharacters())))
+                                        .append(Component.newline())
+                        );
                     }
                 })
         );

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
@@ -66,7 +66,7 @@ public class OraxenExpansion extends PlaceholderExpansion {
 
         final Glyph glyph = plugin.getFontManager().getGlyphFromName(params);
         if (glyph != null)
-            return DEFAULT_FONT.equals(glyph.getFont()) ? glyph.getFormattedUnicodes() : glyph.getGlyphTag();
+            return DEFAULT_FONT.equals(glyph.getFont()) ? glyph.getCharacters() : glyph.getGlyphTag();
         return null; // Placeholder is unknown by the Expansion
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
@@ -3,11 +3,13 @@ package io.th0rgal.oraxen.compatibilities.provided.placeholderapi;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.font.Glyph;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import net.kyori.adventure.key.Key;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 
 public class OraxenExpansion extends PlaceholderExpansion {
 
+    private static final Key DEFAULT_FONT = Key.key("minecraft", "default");
     private final OraxenPlugin plugin;
 
     public OraxenExpansion(final OraxenPlugin plugin) {
@@ -64,7 +66,7 @@ public class OraxenExpansion extends PlaceholderExpansion {
 
         final Glyph glyph = plugin.getFontManager().getGlyphFromName(params);
         if (glyph != null)
-            return glyph.getCharacter();
+            return DEFAULT_FONT.equals(glyph.getFont()) ? glyph.getFormattedUnicodes() : glyph.getGlyphTag();
         return null; // Placeholder is unknown by the Expansion
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
+++ b/core/src/main/java/io/th0rgal/oraxen/compatibilities/provided/placeholderapi/OraxenExpansion.java
@@ -64,9 +64,9 @@ public class OraxenExpansion extends PlaceholderExpansion {
             }
         }
 
-        final Glyph glyph = plugin.getFontManager().getGlyphFromName(params);
+        final Glyph glyph = plugin.getFontManager().getGlyphFromID(params);
         if (glyph != null)
-            return DEFAULT_FONT.equals(glyph.getFont()) ? glyph.getCharacters() : glyph.getGlyphTag();
+            return DEFAULT_FONT.equals(glyph.getFont()) ? glyph.getFormattedUnicodes() : glyph.getGlyphTag();
         return null; // Placeholder is unknown by the Expansion
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -20,6 +20,7 @@ import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -369,32 +370,33 @@ public class ConfigsManager {
      * Also handles legacy 'code' field migration during collection.
      */
     private void collectCodepointsFromSection(String key, ConfigurationSection section, GlyphParseContext ctx) {
-        if (section.isList("chars")) {
-            List<String> charsList = section.getStringList("chars");
-            for (String row : charsList) {
+        List<String> unicodeRows = getDefinedUnicodeRows(section);
+        if (unicodeRows != null) {
+            for (String row : unicodeRows) {
                 for (char c : row.toCharArray()) {
                     ctx.usedCodepoints.add((int) c);
                 }
             }
-            if (!charsList.isEmpty() && !charsList.get(0).isEmpty()) {
-                ctx.charPerGlyph.put(key, charsList.get(0).charAt(0));
+            if (!unicodeRows.isEmpty() && !unicodeRows.get(0).isEmpty()) {
+                ctx.charPerGlyph.put(key, unicodeRows.get(0).charAt(0));
             }
-        } else {
-            // Check for legacy 'code' field first (integer codepoint)
-            // This ensures correct character is used before glyph creation
-            if (section.contains("code") && section.isInt("code")) {
-                char character = (char) section.getInt("code");
-                ctx.charPerGlyph.put(key, character);
-                ctx.usedCodepoints.add((int) character);
-                return;
-            }
+            return;
+        }
 
-            String characterString = section.getString("char", "");
-            if (!characterString.isBlank()) {
-                char character = characterString.charAt(0);
-                ctx.charPerGlyph.put(key, character);
-                ctx.usedCodepoints.add((int) character);
-            }
+        // Check for legacy 'code' field first (integer codepoint)
+        // This ensures correct character is used before glyph creation
+        if (section.contains("code") && section.isInt("code")) {
+            char character = (char) section.getInt("code");
+            ctx.charPerGlyph.put(key, character);
+            ctx.usedCodepoints.add((int) character);
+            return;
+        }
+
+        String characterString = section.getString("char", "");
+        if (!characterString.isBlank()) {
+            char character = characterString.charAt(0);
+            ctx.charPerGlyph.put(key, character);
+            ctx.usedCodepoints.add((int) character);
         }
     }
 
@@ -443,10 +445,11 @@ public class ConfigsManager {
      * Creates a glyph from a configuration section.
      */
     private GlyphParseResult createGlyph(String key, ConfigurationSection section, GlyphParseContext ctx) {
-        GlyphGrid grid = GlyphGrid.fromConfig(section.getConfigurationSection("grid"));
+        GlyphGrid grid = GlyphGrid.fromGlyphConfig(section);
+        List<String> configuredUnicodes = getDefinedUnicodeRows(section);
 
-        if (section.isList("chars")) {
-            return createMultiCharGlyph(key, section, grid);
+        if (configuredUnicodes != null) {
+            return createConfiguredGlyph(key, section, configuredUnicodes, grid);
         } else if (grid.isMultiCell()) {
             return createGridGlyph(key, section, grid, ctx);
         } else {
@@ -454,10 +457,14 @@ public class ConfigsManager {
         }
     }
 
-    private GlyphParseResult createMultiCharGlyph(String key, ConfigurationSection section, GlyphGrid grid) {
-        List<String> unicodeRows = section.getStringList("chars");
-        Glyph glyph = new Glyph(key, section, unicodeRows, grid);
-        return new GlyphParseResult(glyph, false);
+    private GlyphParseResult createConfiguredGlyph(String key, ConfigurationSection section,
+            List<String> unicodeRows, GlyphGrid configuredGrid) {
+        boolean fileChanged = migrateLegacyUnicodeKeys(section, unicodeRows);
+        GlyphGrid effectiveGrid = configuredGrid.merge(GlyphGrid.fromUnicodeRows(unicodeRows));
+
+        Glyph glyph = new Glyph(key, section, unicodeRows, effectiveGrid);
+        glyph.setFileChanged(fileChanged);
+        return new GlyphParseResult(glyph, fileChanged);
     }
 
     private GlyphParseResult createGridGlyph(String key, ConfigurationSection section, GlyphGrid grid,
@@ -484,15 +491,15 @@ public class ConfigsManager {
             if (Settings.DISABLE_AUTOMATIC_GLYPH_CODE.toBool()) {
                 // Cache for future reloads within this server session
                 GRID_GLYPH_UNICODE_CACHE.put(key, unicodeRows);
-                Logs.logWarning("Grid glyph '" + key + "' has no 'chars' list defined but " +
+                Logs.logWarning("Grid glyph '" + key + "' has no 'char' list defined but " +
                         Settings.DISABLE_AUTOMATIC_GLYPH_CODE.getPath() + " is enabled.");
                 Logs.logWarning(
                         "Characters will be preserved within this server session, but will change on server restart.");
                 Logs.logWarning("To ensure consistent characters across restarts, either disable " +
                         Settings.DISABLE_AUTOMATIC_GLYPH_CODE.getPath() +
-                        " or manually add a 'chars' list to this glyph's configuration.", true);
+                        " or manually add a 'char' list to this glyph's configuration.", true);
             } else {
-                section.set("chars", unicodeRows);
+                setConfiguredUnicodeRows(section, unicodeRows);
                 fileChanged = true;
             }
         }
@@ -563,6 +570,63 @@ public class ConfigsManager {
         }
 
         return rows;
+    }
+
+    @Nullable
+    private List<String> getDefinedUnicodeRows(ConfigurationSection section) {
+        List<String> unicodeRows = null;
+
+        if (section.isList("char")) {
+            unicodeRows = sanitizeUnicodeRows(section.getStringList("char"));
+        } else if (section.isString("char")) {
+            String unicode = section.getString("char", "");
+            if (!unicode.isBlank()) {
+                unicodeRows = List.of(unicode);
+            }
+        }
+
+        if (unicodeRows != null && !unicodeRows.isEmpty()) {
+            return unicodeRows;
+        }
+
+        if (section.isList("chars")) {
+            unicodeRows = sanitizeUnicodeRows(section.getStringList("chars"));
+        } else if (section.isString("chars")) {
+            String unicode = section.getString("chars", "");
+            if (!unicode.isBlank()) {
+                unicodeRows = List.of(unicode);
+            }
+        }
+
+        return unicodeRows == null || unicodeRows.isEmpty() ? null : unicodeRows;
+    }
+
+    private List<String> sanitizeUnicodeRows(List<String> unicodeRows) {
+        return unicodeRows.stream()
+                .filter(Objects::nonNull)
+                .filter(row -> !row.isBlank())
+                .toList();
+    }
+
+    private boolean migrateLegacyUnicodeKeys(ConfigurationSection section, List<String> unicodeRows) {
+        boolean fileChanged = false;
+
+        if (!section.contains("char") || section.contains("chars")) {
+            setConfiguredUnicodeRows(section, unicodeRows);
+            fileChanged = true;
+        }
+
+        if (section.contains("chars")) {
+            section.set("chars", null);
+            fileChanged = true;
+        }
+
+        return fileChanged;
+    }
+
+    private void setConfiguredUnicodeRows(ConfigurationSection section, List<String> unicodeRows) {
+        boolean multiBitmap = unicodeRows.size() > 1 || unicodeRows.stream().anyMatch(row -> row.length() > 1);
+        section.set("char", multiBitmap ? unicodeRows : unicodeRows.get(0));
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -625,6 +625,7 @@ public class ConfigsManager {
     }
 
     private void setConfiguredUnicodeRows(ConfigurationSection section, List<String> unicodeRows) {
+        if (unicodeRows.isEmpty()) return;
         boolean multiBitmap = unicodeRows.size() > 1 || unicodeRows.stream().anyMatch(row -> row.length() > 1);
         section.set("char", multiBitmap ? unicodeRows : unicodeRows.get(0));
     }

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -449,7 +449,7 @@ public class ConfigsManager {
         List<String> configuredUnicodes = getDefinedUnicodeRows(section);
 
         if (configuredUnicodes != null) {
-            return createConfiguredGlyph(key, section, configuredUnicodes, grid);
+            return createConfiguredGlyph(key, section, configuredUnicodes);
         } else if (grid.isMultiCell()) {
             return createGridGlyph(key, section, grid, ctx);
         } else {
@@ -458,9 +458,9 @@ public class ConfigsManager {
     }
 
     private GlyphParseResult createConfiguredGlyph(String key, ConfigurationSection section,
-            List<String> unicodeRows, GlyphGrid configuredGrid) {
+            List<String> unicodeRows) {
         boolean fileChanged = migrateLegacyUnicodeKeys(section, unicodeRows);
-        GlyphGrid effectiveGrid = configuredGrid.merge(GlyphGrid.fromUnicodeRows(unicodeRows));
+        GlyphGrid effectiveGrid = GlyphGrid.fromUnicodeRows(unicodeRows);
 
         Glyph glyph = new Glyph(key, section, unicodeRows, effectiveGrid);
         glyph.setFileChanged(fileChanged);

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -131,7 +131,7 @@ public class FontEvents implements Listener {
             if (i == 0) continue;
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-                String unicode = String.valueOf(entry.getValue().getCharacter());
+                String unicode = entry.getValue().getFormattedUnicodes();
                 if (entry.getValue().hasPermission(player))
                     page = (manager.permsChatcolor == null)
                             ? page.replace(entry.getKey(), ChatColor.WHITE + unicode + ChatColor.BLACK)
@@ -172,7 +172,7 @@ public class FontEvents implements Listener {
             }
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-                String unicode = String.valueOf(entry.getValue().getCharacter());
+                String unicode = entry.getValue().getFormattedUnicodes();
                 if (entry.getValue().hasPermission(player))
                     line = (manager.permsChatcolor == null)
                             ? line.replace(entry.getKey(), ChatColor.WHITE + unicode + ChatColor.BLACK)
@@ -239,8 +239,8 @@ public class FontEvents implements Listener {
         for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
             if (!entry.getValue().hasPermission(player)) continue;
             String replacement = (manager.permsChatcolor == null)
-                    ? String.valueOf(entry.getValue().getCharacter())
-                    : ChatColor.WHITE + String.valueOf(entry.getValue().getCharacter())
+                    ? entry.getValue().getFormattedUnicodes()
+                    : ChatColor.WHITE + entry.getValue().getFormattedUnicodes()
                             + PapiAliases.setPlaceholders(player, manager.permsChatcolor);
             displayName = displayName.replace(entry.getKey(), replacement);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -131,7 +131,7 @@ public class FontEvents implements Listener {
             if (i == 0) continue;
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-                String unicode = entry.getValue().getFormattedUnicodes();
+                String unicode = entry.getValue().getCharacters();
                 if (entry.getValue().hasPermission(player))
                     page = (manager.permsChatcolor == null)
                             ? page.replace(entry.getKey(), ChatColor.WHITE + unicode + ChatColor.BLACK)
@@ -172,7 +172,7 @@ public class FontEvents implements Listener {
             }
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-                String unicode = entry.getValue().getFormattedUnicodes();
+                String unicode = entry.getValue().getCharacters();
                 if (entry.getValue().hasPermission(player))
                     line = (manager.permsChatcolor == null)
                             ? line.replace(entry.getKey(), ChatColor.WHITE + unicode + ChatColor.BLACK)
@@ -239,8 +239,8 @@ public class FontEvents implements Listener {
         for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
             if (!entry.getValue().hasPermission(player)) continue;
             String replacement = (manager.permsChatcolor == null)
-                    ? entry.getValue().getFormattedUnicodes()
-                    : ChatColor.WHITE + entry.getValue().getFormattedUnicodes()
+                    ? entry.getValue().getCharacters()
+                    : ChatColor.WHITE + entry.getValue().getCharacters()
                             + PapiAliases.setPlaceholders(player, manager.permsChatcolor);
             displayName = displayName.replace(entry.getKey(), replacement);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontEvents.java
@@ -131,7 +131,7 @@ public class FontEvents implements Listener {
             if (i == 0) continue;
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-                String unicode = entry.getValue().getCharacters();
+                String unicode = entry.getValue().getFormattedUnicodes();
                 if (entry.getValue().hasPermission(player))
                     page = (manager.permsChatcolor == null)
                             ? page.replace(entry.getKey(), ChatColor.WHITE + unicode + ChatColor.BLACK)
@@ -172,7 +172,7 @@ public class FontEvents implements Listener {
             }
 
             for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
-                String unicode = entry.getValue().getCharacters();
+                String unicode = entry.getValue().getFormattedUnicodes();
                 if (entry.getValue().hasPermission(player))
                     line = (manager.permsChatcolor == null)
                             ? line.replace(entry.getKey(), ChatColor.WHITE + unicode + ChatColor.BLACK)
@@ -239,8 +239,8 @@ public class FontEvents implements Listener {
         for (Map.Entry<String, Glyph> entry : manager.getGlyphByPlaceholderMap().entrySet()) {
             if (!entry.getValue().hasPermission(player)) continue;
             String replacement = (manager.permsChatcolor == null)
-                    ? entry.getValue().getCharacters()
-                    : ChatColor.WHITE + entry.getValue().getCharacters()
+                    ? entry.getValue().getFormattedUnicodes()
+                    : ChatColor.WHITE + entry.getValue().getFormattedUnicodes()
                             + PapiAliases.setPlaceholders(player, manager.permsChatcolor);
             displayName = displayName.replace(entry.getKey(), replacement);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -136,7 +136,9 @@ public class FontManager {
             if (glyph.getCharacter().isBlank())
                 continue;
             glyphMap.put(glyph.getName(), glyph);
-            reverse.put(glyph.getCharacter().charAt(0), glyph.getName());
+            for (char character : glyph.getAllChars()) {
+                reverse.put(character, glyph.getName());
+            }
             for (final String placeholder : glyph.getPlaceholders())
                 glyphByPlaceholder.put(placeholder, glyph);
         }
@@ -339,8 +341,9 @@ public class FontManager {
         List<String> completions = getGlyphByPlaceholderMap().values().stream()
                 .filter(Glyph::hasTabCompletion)
                 .flatMap(glyph -> Settings.UNICODE_COMPLETIONS.toBool()
-                        ? Stream.of(glyph.getCharacter())
+                        ? Stream.of(glyph.getFormattedUnicodes())
                         : Arrays.stream(glyph.getPlaceholders()))
+                .distinct()
                 .toList();
 
         if (VersionUtil.atOrAbove("1.19.4")) {

--- a/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/FontManager.java
@@ -341,7 +341,7 @@ public class FontManager {
         List<String> completions = getGlyphByPlaceholderMap().values().stream()
                 .filter(Glyph::hasTabCompletion)
                 .flatMap(glyph -> Settings.UNICODE_COMPLETIONS.toBool()
-                        ? Stream.of(glyph.getFormattedUnicodes())
+                        ? Stream.of(glyph.getCharacters())
                         : Arrays.stream(glyph.getPlaceholders()))
                 .distinct()
                 .toList();

--- a/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -170,6 +170,20 @@ public class Glyph {
     }
 
     /**
+     * Returns all assigned characters flattened into a single string.
+     *
+     * @return All assigned characters in row-major order
+     */
+    @NotNull
+    public String getCharacters() {
+        StringBuilder sb = new StringBuilder();
+        for (String row : unicodeRows) {
+            sb.append(row);
+        }
+        return sb.toString();
+    }
+
+    /**
      * Returns all unicode rows for multi-character glyphs.
      *
      * @return Unmodifiable list of unicode strings (one per row)
@@ -185,11 +199,7 @@ public class Glyph {
      * @return All characters from all rows
      */
     public char[] getAllChars() {
-        StringBuilder sb = new StringBuilder();
-        for (String row : unicodeRows) {
-            sb.append(row);
-        }
-        return sb.toString().toCharArray();
+        return getCharacters().toCharArray();
     }
 
     /**
@@ -465,7 +475,9 @@ public class Glyph {
 
     public Component getGlyphComponent() {
         return Component.textOfChildren(
-                Component.text(getCharacter(), NamedTextColor.WHITE).font(getFont()).hoverEvent(getGlyphHoverText()));
+                Component.text(getFormattedUnicodes(), NamedTextColor.WHITE)
+                        .font(getFont())
+                        .hoverEvent(getGlyphHoverText()));
     }
 
     @Nullable

--- a/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -475,7 +475,7 @@ public class Glyph {
 
     public Component getGlyphComponent() {
         return Component.textOfChildren(
-                Component.text(getFormattedUnicodes(), NamedTextColor.WHITE)
+                Component.text(getCharacters(), NamedTextColor.WHITE)
                         .font(getFont())
                         .hoverEvent(getGlyphHoverText()));
     }

--- a/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -466,7 +466,7 @@ public class Glyph {
      * Useful to easily get the MiniMessage-tag for a glyph
      */
     public String getGlyphTag() {
-        return '<' + "glyph;" + name + '>';
+        return "<glyph:" + name + '>';
     }
 
     public String getShortGlyphTag() {
@@ -475,7 +475,7 @@ public class Glyph {
 
     public Component getGlyphComponent() {
         return Component.textOfChildren(
-                Component.text(getCharacters(), NamedTextColor.WHITE)
+                Component.text(getFormattedUnicodes(), NamedTextColor.WHITE)
                         .font(getFont())
                         .hoverEvent(getGlyphHoverText()));
     }

--- a/core/src/main/java/io/th0rgal/oraxen/font/GlyphGrid.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/GlyphGrid.java
@@ -4,6 +4,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 /**
  * Encapsulates the grid configuration for multi-character glyphs.
  * Supports rows/columns for sprite sheets and large textures.
@@ -36,6 +38,64 @@ public record GlyphGrid(int rows, int columns) {
         if (columns < 1)
             columns = 1;
         return new GlyphGrid(rows, columns);
+    }
+
+    /**
+     * Creates a GlyphGrid from a glyph configuration section.
+     * Supports the canonical top-level keys as well as the legacy nested
+     * {@code grid.rows}/{@code grid.columns} layout.
+     *
+     * @param section The glyph configuration section
+     * @return The configured grid, or SINGLE if no grid keys are present
+     */
+    @NotNull
+    public static GlyphGrid fromGlyphConfig(@Nullable ConfigurationSection section) {
+        if (section == null)
+            return SINGLE;
+
+        boolean hasTopLevelRows = section.contains("rows");
+        boolean hasTopLevelColumns = section.contains("columns") || section.contains("cols");
+        if (hasTopLevelRows || hasTopLevelColumns) {
+            int rows = section.getInt("rows", 1);
+            int columns = section.contains("columns") ? section.getInt("columns", 1) : section.getInt("cols", 1);
+            return normalize(rows, columns);
+        }
+
+        return fromConfig(section.getConfigurationSection("grid"));
+    }
+
+    /**
+     * Infers a glyph grid from the configured unicode rows.
+     *
+     * @param unicodeRows The glyph unicode rows
+     * @return A grid matching the unicode row count and the widest row
+     */
+    @NotNull
+    public static GlyphGrid fromUnicodeRows(@Nullable List<String> unicodeRows) {
+        if (unicodeRows == null || unicodeRows.isEmpty())
+            return SINGLE;
+
+        int rows = unicodeRows.size();
+        int columns = unicodeRows.stream().mapToInt(row -> row != null ? row.length() : 0).max().orElse(1);
+        return normalize(rows, columns);
+    }
+
+    /**
+     * Returns a grid large enough for both this grid and the provided grid.
+     *
+     * @param other Another grid
+     * @return A merged grid using the max rows/columns of both inputs
+     */
+    @NotNull
+    public GlyphGrid merge(@Nullable GlyphGrid other) {
+        if (other == null)
+            return this;
+        return normalize(Math.max(rows, other.rows), Math.max(columns, other.columns));
+    }
+
+    @NotNull
+    private static GlyphGrid normalize(int rows, int columns) {
+        return new GlyphGrid(Math.max(rows, 1), Math.max(columns, 1));
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/font/GlyphTag.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/GlyphTag.java
@@ -68,7 +68,8 @@ public class GlyphTag {
         // Build base component
         Component glyphComponent = Component.text(chars)
                 .font(glyph.getFont())
-                .style(Style.empty());
+                .style(Style.empty())
+                .hoverEvent(glyph.getGlyphHoverText());
 
         // Apply color (null if colorable, WHITE otherwise)
         glyphComponent = glyphComponent.color(options.colorable ? null : NamedTextColor.WHITE);

--- a/core/src/main/java/io/th0rgal/oraxen/font/ReferenceGlyph.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/ReferenceGlyph.java
@@ -283,7 +283,7 @@ public class ReferenceGlyph {
 
     public Component getGlyphComponent() {
         return Component.textOfChildren(
-                Component.text(getCharacter(), NamedTextColor.WHITE)
+                Component.text(getCharacters(), NamedTextColor.WHITE)
                         .font(getFont())
                         .hoverEvent(getGlyphHoverText()));
     }

--- a/core/src/main/java/io/th0rgal/oraxen/nms/GlyphHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/GlyphHandlers.java
@@ -50,18 +50,21 @@ public class GlyphHandlers {
     private static Component escapeGlyphs(Component component, @NotNull Player player) {
         component = GlobalTranslator.render(component, player.locale());
         String serialized = AdventureUtils.MINI_MESSAGE.serialize(component);
+        Glyph requiredGlyph = OraxenPlugin.get().getFontManager().getGlyphFromName("required");
 
         // Replace raw unicode usage of non-permissed Glyphs with random font
         // This will always show a white square
         for (Glyph glyph : OraxenPlugin.get().getFontManager().getGlyphs()) {
             if (glyph.hasPermission(player)) continue;
 
-            component = component.replaceText(
-                    TextReplacementConfig.builder()
-                            .matchLiteral(glyph.getCharacter())
-                            .replacement(glyph.getGlyphComponent().font(randomKey))
-                            .build()
-            );
+            for (char character : glyph.getAllChars()) {
+                component = component.replaceText(
+                        TextReplacementConfig.builder()
+                                .matchLiteral(String.valueOf(character))
+                                .replacement(requiredGlyph.getGlyphComponent().font(randomKey))
+                                .build()
+                );
+            }
 
             // Escape all glyph-tags
             Matcher matcher = glyph.baseRegex.matcher(serialized);

--- a/core/src/main/java/io/th0rgal/oraxen/nms/GlyphHandlers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/nms/GlyphHandlers.java
@@ -51,6 +51,7 @@ public class GlyphHandlers {
         component = GlobalTranslator.render(component, player.locale());
         String serialized = AdventureUtils.MINI_MESSAGE.serialize(component);
         Glyph requiredGlyph = OraxenPlugin.get().getFontManager().getGlyphFromName("required");
+        if (requiredGlyph == null) return component;
 
         // Replace raw unicode usage of non-permissed Glyphs with random font
         // This will always show a white square

--- a/core/src/test/java/io/th0rgal/oraxen/font/GlyphTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/font/GlyphTest.java
@@ -1,0 +1,50 @@
+package io.th0rgal.oraxen.font;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GlyphTest {
+
+    @Test
+    void glyphTagUsesMiniMessageColonSyntax() {
+        Glyph glyph = createGlyph("example", List.of("\ue001"));
+
+        assertEquals("<glyph:example>", glyph.getGlyphTag());
+    }
+
+    @Test
+    void exposesFlattenedAndFormattedCharactersSeparately() {
+        Glyph glyph = createGlyph("example", List.of("AB", "CD"));
+
+        assertEquals("ABCD", glyph.getCharacters());
+        assertEquals("AB\nCD", glyph.getFormattedUnicodes());
+    }
+
+    @Test
+    void jsonUsesConfiguredUnicodeRows() {
+        Glyph glyph = createGlyph("example", List.of("AB", "CD"));
+
+        JsonObject json = glyph.toJson();
+        JsonArray chars = json.getAsJsonArray("chars");
+
+        assertEquals(2, chars.size());
+        assertEquals("AB", chars.get(0).getAsString());
+        assertEquals("CD", chars.get(1).getAsString());
+    }
+
+    private Glyph createGlyph(String name, List<String> unicodeRows) {
+        ConfigurationSection section = mock(ConfigurationSection.class);
+        when(section.getString("texture", "required/exit_icon.png")).thenReturn("example.png");
+        when(section.getInt("ascent", 8)).thenReturn(8);
+        when(section.getInt("height", 8)).thenReturn(8);
+        return new Glyph(name, section, unicodeRows, GlyphGrid.fromUnicodeRows(unicodeRows));
+    }
+}


### PR DESCRIPTION
## 🟠 feat(font): support multi-character glyphs and improve glyph handling
- **Summary** - Add full support for multi-character glyph definitions and update all glyph-facing paths to use complete Unicode strings instead of single characters.
- **Description** - The font pipeline now treats glyphs as multi-character values end to end: config parsing, grid handling, placeholder output, command feedback, tab completions, and NMS escaping were updated to work with the full assigned glyph string. Legacy `chars` config data is migrated to the unified `char` key, and glyph tags/UI now expose hover and copy behavior consistently.
- **Changes** - Added `getCharacters()` and switched consumers to `getCharacters()` / `getFormattedUnicodes()`, improved glyph grid parsing and merging utilities, updated glyph info and glyph commands for full-string display/copy, fixed NMS escaping across all characters in multi-char glyphs, added hover events to glyph tags, migrated legacy `chars` to `char`, and deduplicated completions while preserving correct PlaceholderAPI output.
- **Notes** - Placeholders aren't fully supported yet (e.g. for chat), they will be added later on.
- **Config** - _(Chars are generated automatically)._
```yaml
edna:
  texture: edna
  ascent: 8
  height: 8
  cols: 1
  rows: 5
  char:
  - ꐟ
  - ꐠ
  - ꐡ
  - ꐢ
  - ꐣ
```


<img width="262" height="170" alt="image" src="https://github.com/user-attachments/assets/f468612f-38db-4e42-a90b-e25ce1a5fb1d" />
