### PR TITLE
feat: Support multiple furniture hitboxes

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenFurniture.java
@@ -266,9 +266,15 @@ public class OraxenFurniture {
         removeOrphanBarriers(baseEntity);
         removeOrphanSeat(baseEntity.getPersistentDataContainer());
 
+        List<UUID> interactionUUIDs = baseEntity.getPersistentDataContainer()
+                .getOrDefault(INTERACTIONS_KEY, DataType.asList(DataType.UUID), new ArrayList<>());
         UUID interactionUUID = baseEntity.getPersistentDataContainer().get(INTERACTION_KEY, DataType.UUID);
-        if (interactionUUID != null) {
-            Entity interactionEntity = Bukkit.getEntity(interactionUUID);
+        if (interactionUUID != null && !interactionUUIDs.contains(interactionUUID)) {
+            interactionUUIDs = new ArrayList<>(interactionUUIDs);
+            interactionUUIDs.add(interactionUUID);
+        }
+        for (UUID uuid : interactionUUIDs) {
+            Entity interactionEntity = Bukkit.getEntity(uuid);
             if (interactionEntity != null && !interactionEntity.isDead()) interactionEntity.remove();
         }
 
@@ -410,16 +416,14 @@ public class OraxenFurniture {
                 // Check if barriers changed, if so remove and place new
                 if (mechanic.getBarriers().equals(oldPdc.getOrDefault(BARRIER_KEY, DataType.asList(BlockLocation.dataType), new ArrayList<>()))) {
                     if (OraxenPlugin.supportsDisplayEntities) {
-                        Interaction interaction = mechanic.getInteractionEntity(entity);
+                        List<Interaction> interactions = mechanic.getInteractionEntities(entity);
                         // Check if interaction-hitbox changed, if so remove and place new
-                        if (interaction != null && mechanic.hasHitbox())
-                            if (interaction.getInteractionWidth() == mechanic.getHitbox().width())
-                                if (interaction.getInteractionHeight() == mechanic.getHitbox().height())
-                                    // Check if seat changed, if so remove and place new
-                                    if (oldPdc.has(SEAT_KEY, DataType.UUID) && mechanic.hasSeat())
-                                        // Check if any displayEntity properties changed, if so remove and place new
-                                        if (mechanic.hasDisplayEntityProperties() && mechanic.getDisplayEntityProperties().ensureSameDisplayProperties(entity))
-                                            return;
+                        if (!interactions.isEmpty() && mechanic.hasHitbox() && hasSameHitboxes(interactions, mechanic.getHitboxes()))
+                            // Check if seat changed, if so remove and place new
+                            if (oldPdc.has(SEAT_KEY, DataType.UUID) && mechanic.hasSeat())
+                                // Check if any displayEntity properties changed, if so remove and place new
+                                if (mechanic.hasDisplayEntityProperties() && mechanic.getDisplayEntityProperties().ensureSameDisplayProperties(entity))
+                                    return;
                     } else return;
                 }
             }
@@ -433,5 +437,16 @@ public class OraxenFurniture {
             serializedPdc.removeIf(map -> Stream.of(MUSIC_DISC_KEY, EVOLUTION_KEY, STORAGE_KEY, PERSONAL_STORAGE_KEY).map(NamespacedKey::toString).noneMatch(map::containsValue));
             PersistentDataSerializer.fromMapList(serializedPdc, newEntity.getPersistentDataContainer());
         }
+    }
+
+    private static boolean hasSameHitboxes(List<Interaction> interactions, List<FurnitureMechanic.FurnitureHitbox> hitboxes) {
+        if (interactions.size() != hitboxes.size()) return false;
+        for (int i = 0; i < hitboxes.size(); i++) {
+            Interaction interaction = interactions.get(i);
+            FurnitureMechanic.FurnitureHitbox hitbox = hitboxes.get(i);
+            if (interaction.getInteractionWidth() != hitbox.width()) return false;
+            if (interaction.getInteractionHeight() != hitbox.height()) return false;
+        }
+        return true;
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -55,6 +55,7 @@ public class FurnitureMechanic extends Mechanic {
     public static final NamespacedKey FURNITURE_KEY = new NamespacedKey(OraxenPlugin.get(), "furniture");
     public static final NamespacedKey BASE_ENTITY_KEY = new NamespacedKey(OraxenPlugin.get(), "base_entity");
     public static final NamespacedKey INTERACTION_KEY = new NamespacedKey(OraxenPlugin.get(), "interaction");
+    public static final NamespacedKey INTERACTIONS_KEY = new NamespacedKey(OraxenPlugin.get(), "interactions");
     public static final NamespacedKey MODELENGINE_KEY = new NamespacedKey(OraxenPlugin.get(), "modelengine");
     public static final NamespacedKey SEAT_KEY = new NamespacedKey(OraxenPlugin.get(), "seat");
     public static final NamespacedKey ROOT_KEY = new NamespacedKey(OraxenPlugin.get(), "root");
@@ -86,6 +87,7 @@ public class FurnitureMechanic extends Mechanic {
     private FurnitureType furnitureType;
     private final DisplayEntityProperties displayEntityProperties;
     private final FurnitureHitbox hitbox;
+    private final List<FurnitureHitbox> hitboxes;
     private final boolean isRotatable;
     private final boolean small;
     private final ArmorStandProperties armorStandProperties;
@@ -93,7 +95,15 @@ public class FurnitureMechanic extends Mechanic {
     private final RestrictedRotation restrictedRotation;
     private final List<FurnitureTextDefinition> textDefinitions;
 
-    public record FurnitureHitbox(float width, float height) {
+    public record FurnitureHitbox(double offsetX, double offsetY, double offsetZ, float width, float height) {
+
+        public FurnitureHitbox(float width, float height) {
+            this(0, 0, 0, width, height);
+        }
+
+        public Vector offset() {
+            return new Vector(offsetX, offsetY, offsetZ);
+        }
     }
 
     public enum RestrictedRotation {
@@ -198,11 +208,8 @@ public class FurnitureMechanic extends Mechanic {
                 }
         }
 
-        ConfigurationSection hitboxSection = section.getConfigurationSection("hitbox");
-        if (hitboxSection != null) {
-            float width = (float) hitboxSection.getDouble("width", 1.0), height = (float) hitboxSection.getDouble("height", 1.0);
-            hitbox = width > 0 && height > 0 ? new FurnitureHitbox(width, height) : null;
-        } else hitbox = !hasBarriers() ? new FurnitureHitbox(1.0f, 1.0f) : null;
+        hitboxes = parseHitboxes(section);
+        hitbox = hitboxes.isEmpty() ? null : hitboxes.get(0);
 
         ConfigurationSection seatSection = section.getConfigurationSection("seat");
         if (seatSection != null) {
@@ -277,6 +284,62 @@ public class FurnitureMechanic extends Mechanic {
         blockLocker = blockLockerSection != null ? new BlockLockerMechanic(blockLockerSection) : null;
 
         textDefinitions = parseTextDefinitions(section);
+    }
+
+    private List<FurnitureHitbox> parseHitboxes(ConfigurationSection section) {
+        List<FurnitureHitbox> parsedHitboxes = new ArrayList<>();
+        boolean hasHitboxesSection = section.isList("hitboxes");
+        if (hasHitboxesSection) {
+            for (Object hitboxObject : section.getList("hitboxes", new ArrayList<>())) {
+                FurnitureHitbox parsedHitbox = parseHitbox(hitboxObject);
+                if (parsedHitbox != null) parsedHitboxes.add(parsedHitbox);
+            }
+        }
+
+        if (hasHitboxesSection) return List.copyOf(parsedHitboxes);
+
+        ConfigurationSection hitboxSection = section.getConfigurationSection("hitbox");
+        if (hitboxSection != null) {
+            float width = (float) hitboxSection.getDouble("width", 1.0);
+            float height = (float) hitboxSection.getDouble("height", 1.0);
+            if (width > 0 && height > 0) return List.of(new FurnitureHitbox(width, height));
+            return List.of();
+        }
+
+        return !hasBarriers() ? List.of(new FurnitureHitbox(1.0f, 1.0f)) : List.of();
+    }
+
+    @Nullable
+    private FurnitureHitbox parseHitbox(Object hitboxObject) {
+        if (!(hitboxObject instanceof String string)) {
+            Logs.logError("Invalid hitbox entry for furniture: " + getItemID() + ". Expected '<x>,<y>,<z> <width>,<height>'.");
+            return null;
+        }
+
+        String[] parts = string.trim().split("\\s+");
+        if (parts.length != 2) {
+            Logs.logError("Invalid hitbox entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z> <width>,<height>'.");
+            return null;
+        }
+
+        String[] offsetParts = parts[0].split(",");
+        String[] sizeParts = parts[1].split(",");
+        if (offsetParts.length != 3 || sizeParts.length != 2) {
+            Logs.logError("Invalid hitbox entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z> <width>,<height>'.");
+            return null;
+        }
+
+        try {
+            double offsetX = Double.parseDouble(offsetParts[0]);
+            double offsetY = Double.parseDouble(offsetParts[1]);
+            double offsetZ = Double.parseDouble(offsetParts[2]);
+            float width = Float.parseFloat(sizeParts[0]);
+            float height = Float.parseFloat(sizeParts[1]);
+            return width > 0 && height > 0 ? new FurnitureHitbox(offsetX, offsetY, offsetZ, width, height) : null;
+        } catch (NumberFormatException exception) {
+            Logs.logError("Invalid hitbox entry '" + string + "' for furniture: " + getItemID() + ". Hitbox values must be numbers.");
+            return null;
+        }
     }
 
     private static List<FurnitureTextDefinition> parseTextDefinitions(ConfigurationSection section) {
@@ -425,6 +488,10 @@ public class FurnitureMechanic extends Mechanic {
 
     public FurnitureHitbox getHitbox() {
         return hitbox;
+    }
+
+    public List<FurnitureHitbox> getHitboxes() {
+        return hitboxes;
     }
 
     public boolean hasSeat() {
@@ -606,25 +673,25 @@ public class FurnitureMechanic extends Mechanic {
 
             if (hasBarriers()) setBarrierHitbox(entity, location, yaw);
             else {
-                float width = hasHitbox() ? hitbox.width : 1f;
-                float height = hasHitbox() ? hitbox.height : 1f;
-                Entity interaction = spawnInteractionEntity(frame, location, width, height);
+                List<Interaction> interactions = spawnInteractionEntities(frame, location, yaw, hitboxes);
+                Entity interaction = interactions.isEmpty() ? null : interactions.get(0);
 
                 Block block = location.getBlock();
                 if (hasSeat() && interaction != null) {
                     UUID seatUuid = spawnSeat(block, hasSeatYaw ? seatYaw : FurnitureMechanic.getFurnitureYaw(frame));
-                    interaction.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid);
+                    interactions.forEach(i -> i.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid));
                     frame.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid);
                 }
                 createInitialLight(block, entity);
             }
         } else if (entity instanceof ItemDisplay itemDisplay) {
             setItemDisplayData(itemDisplay, item, yaw, displayEntityProperties, facing);
-            float width = hasHitbox() ? hitbox.width : displayEntityProperties.getDisplayWidth();
-            float height = hasHitbox() ? hitbox.height : displayEntityProperties.getDisplayHeight();
+            FurnitureHitbox displayHitbox = hasHitbox() ? hitbox : new FurnitureHitbox(displayEntityProperties.getDisplayWidth(), displayEntityProperties.getDisplayHeight());
+            float height = displayHitbox.height;
             boolean isFixed = displayEntityProperties.getDisplayTransform() == ItemDisplay.ItemDisplayTransform.FIXED;
             Location interactionLoc = location.clone().subtract(0, (hasLimitedPlacing() && limitedPlacing.isRoof() && isFixed) ? 1.5 * (height - 1) : 0, 0);
-            Interaction interaction = spawnInteractionEntity(itemDisplay, interactionLoc, width, height);
+            List<Interaction> interactions = spawnInteractionEntities(itemDisplay, interactionLoc, yaw, hasHitbox() ? hitboxes : List.of(displayHitbox));
+            Interaction interaction = interactions.isEmpty() ? null : interactions.get(0);
             Location barrierLoc = EntityUtils.isNone(itemDisplay) && displayEntityProperties.hasScale()
                             ? location.clone().subtract(0, 0.5 * displayEntityProperties.getScale().y(), 0) : location;
 
@@ -632,7 +699,7 @@ public class FurnitureMechanic extends Mechanic {
             else {
                 if (hasSeat() && interaction != null) {
                     UUID seatUuid = spawnSeat(location.getBlock(), hasSeatYaw ? seatYaw : yaw);
-                    interaction.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid);
+                    interactions.forEach(i -> i.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid));
                     itemDisplay.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid);
                 }
                 createInitialLight(location.getBlock(), entity);
@@ -642,14 +709,13 @@ public class FurnitureMechanic extends Mechanic {
 
             if (hasBarriers()) setBarrierHitbox(entity, location, yaw);
             else {
-                float width = hasHitbox() ? hitbox.width : 1f;
-                float height = hasHitbox() ? hitbox.height : 1f;
-                Entity interaction = spawnInteractionEntity(armorStand, location, width, height);
+                List<Interaction> interactions = spawnInteractionEntities(armorStand, location, yaw, hitboxes);
+                Entity interaction = interactions.isEmpty() ? null : interactions.get(0);
 
                 Block block = location.getBlock();
                 if (hasSeat()) {
                     UUID seatUuid = spawnSeat(block, hasSeatYaw ? seatYaw : yaw);
-                    if (interaction != null) interaction.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid);
+                    interactions.forEach(i -> i.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid));
                     armorStand.getPersistentDataContainer().set(SEAT_KEY, DataType.UUID, seatUuid);
                 }
                 createInitialLight(block, entity);
@@ -666,17 +732,27 @@ public class FurnitureMechanic extends Mechanic {
         }
     }
 
-    private Interaction spawnInteractionEntity(Entity entity, Location location, float width, float height) {
-        if (!OraxenPlugin.supportsDisplayEntities || width <= 0f || height <= 0f) return null;
-        UUID existingInteractionUUID = entity.getPersistentDataContainer().get(INTERACTION_KEY, DataType.UUID);
-        if (existingInteractionUUID != null) {
-            Entity existingInteraction = Bukkit.getEntity(existingInteractionUUID);
-            if (existingInteraction instanceof Interaction interaction) return interaction;
+    private List<Interaction> spawnInteractionEntities(Entity entity, Location location, float yaw, List<FurnitureHitbox> hitboxes) {
+        if (!OraxenPlugin.supportsDisplayEntities || hitboxes.isEmpty()) return List.of();
+        List<Interaction> interactions = new ArrayList<>();
+        List<UUID> interactionUuids = new ArrayList<>();
+        for (FurnitureHitbox hitbox : hitboxes) {
+            Interaction interaction = spawnInteractionEntity(entity, location, yaw, hitbox);
+            interactions.add(interaction);
+            interactionUuids.add(interaction.getUniqueId());
         }
+        entity.getPersistentDataContainer().set(INTERACTION_KEY, DataType.UUID, interactionUuids.get(0));
+        entity.getPersistentDataContainer().set(INTERACTIONS_KEY, DataType.asList(DataType.UUID), interactionUuids);
+        return interactions;
+    }
 
-        Interaction interaction = EntityUtils.spawnEntity(BlockHelpers.toCenterBlockLocation(location), Interaction.class, (i) -> {
-            i.setInteractionWidth(width);
-            i.setInteractionHeight(height);
+    private Interaction spawnInteractionEntity(Entity entity, Location location, float yaw, FurnitureHitbox hitbox) {
+        Vector offset = rotateGroundOffset(hitbox.offset(), yaw);
+        Location hitboxLocation = BlockHelpers.toCenterBlockLocation(location).add(offset);
+
+        Interaction interaction = EntityUtils.spawnEntity(hitboxLocation, Interaction.class, (i) -> {
+            i.setInteractionWidth(hitbox.width);
+            i.setInteractionHeight(hitbox.height);
             i.setPersistent(true);
         });
 
@@ -1029,8 +1105,8 @@ public class FurnitureMechanic extends Mechanic {
         if (hasSeat) removeFurnitureSeat(baseEntity.getLocation());
 
         if (OraxenPlugin.supportsDisplayEntities) {
-            Interaction interaction = getInteractionEntity(baseEntity);
-            if (interaction != null && !interaction.isDead()) interaction.remove();
+            for (Interaction interaction : getInteractionEntities(baseEntity))
+                if (!interaction.isDead()) interaction.remove();
         }
     }
 
@@ -1172,9 +1248,33 @@ public class FurnitureMechanic extends Mechanic {
 
     @Nullable
     public Interaction getInteractionEntity(@NotNull Entity baseEntity) {
-        UUID interactionUUID = baseEntity.getPersistentDataContainer().get(INTERACTION_KEY, DataType.UUID);
-        return OraxenPlugin.supportsDisplayEntities && interactionUUID != null && Bukkit.getEntity(interactionUUID) instanceof Interaction interaction
-                ? interaction : getInteractionEntityAlter(baseEntity);
+        List<Interaction> interactions = getInteractionEntities(baseEntity);
+        return interactions.isEmpty() ? null : interactions.get(0);
+    }
+
+    public List<Interaction> getInteractionEntities(@NotNull Entity baseEntity) {
+        if (!OraxenPlugin.supportsDisplayEntities) return List.of();
+
+        PersistentDataContainer pdc = baseEntity.getPersistentDataContainer();
+        List<UUID> interactionUUIDs = pdc.getOrDefault(INTERACTIONS_KEY, DataType.asList(DataType.UUID), new ArrayList<>());
+        UUID legacyInteractionUUID = pdc.get(INTERACTION_KEY, DataType.UUID);
+        if (legacyInteractionUUID != null && !interactionUUIDs.contains(legacyInteractionUUID)) {
+            List<UUID> mergedInteractionUUIDs = new ArrayList<>();
+            mergedInteractionUUIDs.add(legacyInteractionUUID);
+            mergedInteractionUUIDs.addAll(interactionUUIDs);
+            interactionUUIDs = mergedInteractionUUIDs;
+        }
+
+        List<Interaction> interactions = new ArrayList<>();
+        for (UUID interactionUUID : interactionUUIDs) {
+            if (Bukkit.getEntity(interactionUUID) instanceof Interaction interaction)
+                interactions.add(interaction);
+        }
+
+        if (!interactions.isEmpty()) return interactions;
+
+        Interaction legacyInteraction = getInteractionEntityAlter(baseEntity);
+        return legacyInteraction != null ? List.of(legacyInteraction) : List.of();
     }
 
     /**


### PR DESCRIPTION
## 🟠 feat: Support multiple furniture hitboxes
- **Summary** - Added support for defining multiple furniture interaction hitboxes with per-hitbox offsets and sizes while preserving legacy single-hitbox configs.

- **Description** - The furniture mechanic now parses a new `hitboxes` list format like `x,y,z width,height`, rotates and places each interaction hitbox relative to the furniture, stores all spawned interaction entities, and updates cleanup and refresh logic to handle multiple hitboxes correctly.

- **Changes** - Extended `FurnitureHitbox` to include offsets, added parsing for `Mechanics.furniture.hitboxes`, kept `hitbox.width`/`height` compatibility, spawned one `Interaction` entity per configured hitbox, stored their UUIDs in a new `oraxen:interactions` PDC key while keeping the legacy `oraxen:interaction` key, and updated orphan removal plus experimental furniture refresh comparisons to work with multiple interaction entities.
- **Config**
```yaml
Mechanics:
  furniture:
    type: DISPLAY_ENTITY
    hitboxes:
      - 0,0,0 1,1
      - 1,0,0 1,2.0
      - -1,0,0 1,2.2
```

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/42ec97da-1eac-4508-a9b1-1ef30ce4b78f" />

