### PR TITLE
fix: Backpack Cosmetic Passenger Merging

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticListener.java
@@ -8,14 +8,15 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDismountEvent;
+import org.bukkit.event.entity.EntityMountEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.event.entity.EntityPickupItemEvent;
 
 /**
  * Listener for backpack cosmetic mechanics.
@@ -112,6 +113,27 @@ public class BackpackCosmeticListener implements Listener {
         if (distSq > POSITION_THRESHOLD * POSITION_THRESHOLD || yawDiff > YAW_THRESHOLD) {
             manager.updateBackpackPosition(player);
         }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityMount(EntityMountEvent event) {
+        if (!(event.getMount() instanceof Player player)) return;
+        if (!manager.hasBackpack(player)) return;
+
+        scheduleBackpackMountResync(player);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityDismount(EntityDismountEvent event) {
+        if (!(event.getDismounted() instanceof Player player)) return;
+        if (!manager.hasBackpack(player)) return;
+
+        scheduleBackpackMountResync(player);
+    }
+
+    private void scheduleBackpackMountResync(Player player) {
+        SchedulerUtil.runTaskLater(1L, () -> manager.resyncBackpackMount(player));
+        SchedulerUtil.runTaskLater(2L, () -> manager.resyncBackpackMount(player));
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticManager.java
@@ -1,14 +1,14 @@
 package io.th0rgal.oraxen.mechanics.provided.cosmetic.backpack;
 
-import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.nms.NMSHandlers;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -120,6 +120,23 @@ public class BackpackCosmeticManager {
     }
 
     /**
+     * Re-send the backpack mount packet using the owner's current passengers.
+     * This keeps the fake backpack passenger from replacing real passengers added by
+     * other plugins, such as sitting/riding plugins.
+     */
+    public void resyncBackpackMount(Player owner) {
+        BackpackData data = activeBackpacks.get(owner.getUniqueId());
+        if (data == null) return;
+
+        for (UUID viewerId : data.getViewers()) {
+            Player viewer = Bukkit.getPlayer(viewerId);
+            if (viewer != null && viewer.isOnline()) {
+                sendBackpackMountPacket(viewer, owner, data);
+            }
+        }
+    }
+
+    /**
      * Handle player entering view range of another player
      */
     public void onPlayerEnterViewRange(Player viewer, Player backpackOwner) {
@@ -193,6 +210,8 @@ public class BackpackCosmeticManager {
                 Player viewer = Bukkit.getPlayer(viewerId);
                 return viewer == null || !viewer.isOnline();
             });
+
+            resyncBackpackMount(owner);
         }
     }
 
@@ -228,13 +247,28 @@ public class BackpackCosmeticManager {
             mechanic.isSmallArmorStand()
         );
 
-        // Mount the armor stand to the player for instant position following
-        NMSHandlers.getHandler().sendMountPacket(viewer, owner.getEntityId(), data.getEntityId());
+        // Mount the armor stand to the player for instant position following.
+        sendBackpackMountPacket(viewer, owner, data);
 
         // Send initial head rotation to face the right direction
         NMSHandlers.getHandler().sendEntityHeadRotation(viewer, data.getEntityId(), owner.getBodyYaw());
 
         // Debug: io.th0rgal.oraxen.utils.logs.Logs.logSuccess("[Backpack] Spawned and mounted armor stand for " + owner.getName());
+    }
+
+    private void sendBackpackMountPacket(Player viewer, Player owner, BackpackData data) {
+        int[] passengerIds = getMergedPassengerIds(owner, data.getEntityId());
+        NMSHandlers.getHandler().sendMountPacket(viewer, owner.getEntityId(), passengerIds);
+    }
+
+    private int[] getMergedPassengerIds(Player owner, int backpackEntityId) {
+        Set<Integer> passengerIds = new LinkedHashSet<>();
+        for (Entity passenger : owner.getPassengers()) {
+            passengerIds.add(passenger.getEntityId());
+        }
+        passengerIds.add(backpackEntityId);
+
+        return passengerIds.stream().mapToInt(Integer::intValue).toArray();
     }
 
     private void destroyBackpackForViewers(BackpackData data) {


### PR DESCRIPTION
## 🟠 fix: Backpack Cosmetic Passenger Merging
- **Summary** - Prevent backpack cosmetics from detaching when another player rides the backpack owner.

- **Description** - Updated the backpack cosmetic mount handling so Oraxen preserves existing player passengers, such as GSit riders, when mounting the fake backpack armor stand. Added mount/dismount resyncs to recover from passenger list changes and avoid packet-order races.

- **Changes** - Modified `BackpackCosmeticManager` to send merged passenger lists and periodically resync backpack mounts. Modified `BackpackCosmeticListener` to listen for `EntityMountEvent` and `EntityDismountEvent` and schedule delayed mount resyncs.

- **Before**<br />
  <img width="320" height="180" alt="image" src="https://github.com/user-attachments/assets/1c16fde8-4c88-4eff-a2dd-047cafa442cc" />

- **After**<br />
   <img width="320" height="180" alt="2026-04-28_15 53 25" src="https://github.com/user-attachments/assets/9282dd45-fb00-44ff-bb82-e90ee297c82f" />
