### PR TITLE
fix: PacketEvents Adventure classloader crash

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/InventoryPacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/InventoryPacketListener.java
@@ -3,13 +3,12 @@ package io.th0rgal.oraxen.packets.packetevents;
 import com.github.retrooper.packetevents.event.PacketListener;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenWindow;
 import io.th0rgal.oraxen.utils.PacketHelpers;
 
 public class InventoryPacketListener implements PacketListener {
     @Override public void onPacketSend(PacketSendEvent event) {
         if(event.getPacketType() != PacketType.Play.Server.OPEN_WINDOW) return;
-        var wrapper = new WrapperPlayServerOpenWindow(event);
-        wrapper.setTitle(PacketHelpers.translateTitle(wrapper.getTitle()));
+        var wrapper = new WrapperPlayServerJsonOpenWindow(event);
+        wrapper.setTitleJson(PacketHelpers.translateJson(wrapper.getTitleJson()));
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/TitlePacketListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/TitlePacketListener.java
@@ -2,9 +2,6 @@ package io.th0rgal.oraxen.packets.packetevents;
 
 import com.github.retrooper.packetevents.event.PacketListener;
 import com.github.retrooper.packetevents.event.PacketSendEvent;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerActionBar;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleSubtitle;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetTitleText;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.PacketHelpers;
 
@@ -16,14 +13,14 @@ public class TitlePacketListener implements PacketListener {
     @Override
     public void onPacketSend(PacketSendEvent event) {
         if(event.getPacketType() == SET_TITLE_TEXT  && Settings.FORMAT_TITLES.toBool()) {
-            var wrapper = new WrapperPlayServerSetTitleText(event);
-            wrapper.setTitle(PacketHelpers.translateTitle(wrapper.getTitle()));
+            var wrapper = new WrapperPlayServerJsonComponent(event);
+            wrapper.setComponentJson(PacketHelpers.translateJson(wrapper.getComponentJson()));
         } else if(event.getPacketType() == SET_TITLE_SUBTITLE && Settings.FORMAT_SUBTITLES.toBool()) {
-            var wrapper = new WrapperPlayServerSetTitleSubtitle(event);
-            wrapper.setSubtitle(PacketHelpers.translateTitle(wrapper.getSubtitle()));
+            var wrapper = new WrapperPlayServerJsonComponent(event);
+            wrapper.setComponentJson(PacketHelpers.translateJson(wrapper.getComponentJson()));
         } else if(event.getPacketType() == ACTION_BAR && Settings.FORMAT_ACTION_BAR.toBool()) {
-            var wrapper = new WrapperPlayServerActionBar(event);
-            wrapper.setActionBarText(PacketHelpers.translateTitle(wrapper.getActionBarText()));
+            var wrapper = new WrapperPlayServerJsonComponent(event);
+            wrapper.setComponentJson(PacketHelpers.translateJson(wrapper.getComponentJson()));
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/WrapperPlayServerJsonComponent.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/WrapperPlayServerJsonComponent.java
@@ -1,0 +1,37 @@
+package io.th0rgal.oraxen.packets.packetevents;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+
+@SuppressWarnings("deprecation")
+class WrapperPlayServerJsonComponent extends PacketWrapper<WrapperPlayServerJsonComponent> {
+
+    private String componentJson;
+
+    WrapperPlayServerJsonComponent(PacketSendEvent event) {
+        super(event);
+    }
+
+    @Override
+    public void read() {
+        componentJson = readComponentJSON();
+    }
+
+    @Override
+    public void write() {
+        writeComponentJSON(componentJson);
+    }
+
+    @Override
+    public void copy(WrapperPlayServerJsonComponent wrapper) {
+        componentJson = wrapper.componentJson;
+    }
+
+    String getComponentJson() {
+        return componentJson;
+    }
+
+    void setComponentJson(String componentJson) {
+        this.componentJson = componentJson;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/WrapperPlayServerJsonOpenWindow.java
+++ b/core/src/main/java/io/th0rgal/oraxen/packets/packetevents/WrapperPlayServerJsonOpenWindow.java
@@ -1,0 +1,45 @@
+package io.th0rgal.oraxen.packets.packetevents;
+
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+
+@SuppressWarnings("deprecation")
+class WrapperPlayServerJsonOpenWindow extends PacketWrapper<WrapperPlayServerJsonOpenWindow> {
+
+    private int containerId;
+    private int type;
+    private String titleJson;
+
+    WrapperPlayServerJsonOpenWindow(PacketSendEvent event) {
+        super(event);
+    }
+
+    @Override
+    public void read() {
+        containerId = readVarInt();
+        type = readVarInt();
+        titleJson = readComponentJSON();
+    }
+
+    @Override
+    public void write() {
+        writeVarInt(containerId);
+        writeVarInt(type);
+        writeComponentJSON(titleJson);
+    }
+
+    @Override
+    public void copy(WrapperPlayServerJsonOpenWindow wrapper) {
+        containerId = wrapper.containerId;
+        type = wrapper.type;
+        titleJson = wrapper.titleJson;
+    }
+
+    String getTitleJson() {
+        return titleJson;
+    }
+
+    void setTitleJson(String titleJson) {
+        this.titleJson = titleJson;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PacketHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PacketHelpers.java
@@ -15,6 +15,10 @@ public class PacketHelpers {
         return AdventureUtils.GSON_SERIALIZER.serialize(AdventureUtils.MINI_MESSAGE.deserialize(text)).replaceAll(BACKSLASH_REMOVAL_REGEX, "");
     }
 
+    public static String translateJson(String json) {
+        return toJson(readJson(json));
+    }
+
     public static Component translateTitle(Component component) {
         return AdventureUtils.MINI_MESSAGE.deserialize(
             AdventureUtils.parseMiniMessageThroughLegacy(component)


### PR DESCRIPTION
## 🟠 fix: PacketEvents Adventure Classloader Crash
- **Summary** - Prevented PacketEvents inventory/title packet handling from resolving Adventure `Component` types across different plugin classloaders.
- **Description** - Replaced direct PacketEvents wrapper calls that returned or accepted `net.kyori.adventure.text.Component` with local JSON-based packet wrappers. This avoids the `LinkageError` seen when `/oraxen inventory` opens a GUI while PacketEvents and Oraxen load Adventure separately.

- **Changes** - Added JSON-only PacketEvents wrappers for component packets and open-window packets, updated inventory/title/actionbar listeners to translate JSON strings instead of Adventure components, and added `PacketHelpers.translateJson(...)`. 

- **Original Error** 
```vb
[10:52:06] [Server thread/INFO]: andrei_1058 issued server command: /oraxen inventory
[10:52:06] [Server thread/INFO]: andrei_1058 lost connection: Internal Exception: java.lang.LinkageError: loader constraint violation: when resolving method 'net.kyori.adventure.text.Component com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenWindow.getTitle()' the class loader org.bukkit.plugin.java.PluginClassLoader @1af66466 of the current class, io/th0rgal/oraxen/packets/packetevents/InventoryPacketListener, and the class loader org.bukkit.plugin.java.PluginClassLoader @610666f5 for the method's defining class, com/github/retrooper/packetevents/wrapper/play/server/WrapperPlayServerOpenWindow, have different Class objects for the type net/kyori/adventure/text/Component used in the signature (io.th0rgal.oraxen.packets.packetevents.InventoryPacketListener is in unnamed module of loader org.bukkit.plugin.java.PluginClassLoader @1af66466, parent loader java.net.URLClassLoader @5b480cf9; com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenWindow is in unnamed module of loader org.bukkit.plugin.java.PluginClassLoader @610666f5, parent loader java.net.URLClassLoader @5b480cf9)
[10:52:07] [Server thread/INFO]: andrei_1058 left the game
```