### PR TITLE
fix: recipe page arrow stack counts

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/RecipesView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/RecipesView.java
@@ -50,7 +50,6 @@ public class RecipesView {
             pane.addItem(new GuiItem((OraxenItems.getItemById("arrow_previous_icon") == null
                     ? new ItemBuilder(Material.ARROW)
                     : OraxenItems.getItemById("arrow_previous_icon"))
-                    .setAmount(page)
                     .setDisplayName(ChatColor.YELLOW + "Open page " + page)
                     .build(),
                     event -> create(page - 1,
@@ -62,7 +61,6 @@ public class RecipesView {
             pane.addItem(new GuiItem((OraxenItems.getItemById("arrow_next_icon") == null
                     ? new ItemBuilder(Material.ARROW)
                     : OraxenItems.getItemById("arrow_next_icon"))
-                    .setAmount(page + 2)
                     .setDisplayName(ChatColor.YELLOW + "Open page " + (page + 2))
                     .build(),
                     event -> create(page + 1, filteredRecipes)


### PR DESCRIPTION
## 🟠 fix: Recipe Menu Pagination Arrow
- **Summary** - Removed the page-number stack amount from the recipe showcase pagination arrows.
- **Description** - The `/oraxen recipes show all` menu showed the next-page arrow with a visible item count, making it look like two items.

- **Changes** - Updated `RecipesView.java` so previous/next arrow buttons no longer call `setAmount(...)`.
