### PR TITLE
feat: Make config sections and materials case-insensitive

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java
+++ b/core/src/main/java/io/th0rgal/oraxen/api/OraxenItems.java
@@ -109,8 +109,9 @@ public class OraxenItems {
                     if (foodComponent == null)
                         continue;
 
-                    ConfigurationSection section = OraxenYaml.loadConfiguration(entry.getKey())
-                            .getConfigurationSection(itemId + ".Components.food.replacement");
+                    ConfigurationSection section = OraxenYaml.getConfigurationSection(
+                            OraxenYaml.loadConfiguration(entry.getKey()),
+                            itemId + ".Components.food.replacement");
                     ItemStack replacementItem = parseFoodComponentReplacement(section);
                     // foodComponent.setUsingConvertsTo(replacementItem);
                     itemBuilder.setFoodComponent(foodComponent).regen();
@@ -125,7 +126,7 @@ public class OraxenItems {
 
         ItemStack replacementItem;
         if (section.isString("minecraft_type")) {
-            Material material = Material.getMaterial(Objects.requireNonNull(section.getString("minecraft_type")));
+            Material material = OraxenYaml.getMaterial(Objects.requireNonNull(section.getString("minecraft_type")));
             if (material == null) {
                 Message.INVALID_MATERIAL.log(AdventureUtils.tagResolver("item", section.getString("minecraft_type")));
                 replacementItem = null;

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -598,8 +598,8 @@ public class ConfigsManager {
                 ConfigurationSection itemSection = configuration.getConfigurationSection(key);
                 if (itemSection == null)
                     continue;
-                ConfigurationSection packSection = itemSection.getConfigurationSection("Pack");
-                Material material = Material.getMaterial(itemSection.getString("material", ""));
+                ConfigurationSection packSection = OraxenYaml.getConfigurationSection(itemSection, "Pack");
+                Material material = OraxenYaml.getMaterial(itemSection.getString("material", ""));
                 if (packSection == null || material == null)
                     continue;
                 int modelData = packSection.getInt("custom_model_data", -1);

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemParser.java
@@ -65,9 +65,9 @@ public class ItemParser {
         if (section.isString("template"))
             templateItem = ItemTemplate.getParserTemplate(section.getString("template"));
 
-        final ConfigurationSection crucibleSection = section.getConfigurationSection("crucible");
-        final ConfigurationSection mmoSection = section.getConfigurationSection("mmoitem");
-        final ConfigurationSection ecoItemSection = section.getConfigurationSection("ecoitem");
+        final ConfigurationSection crucibleSection = OraxenYaml.getConfigurationSection(section, "crucible");
+        final ConfigurationSection mmoSection = OraxenYaml.getConfigurationSection(section, "mmoitem");
+        final ConfigurationSection ecoItemSection = OraxenYaml.getConfigurationSection(section, "ecoitem");
         if (crucibleSection != null)
             crucibleItem = new WrappedCrucibleItem(crucibleSection);
         else if (section.isString("crucible_id"))
@@ -79,14 +79,14 @@ public class ItemParser {
         else if (mmoSection != null)
             mmoItem = new WrappedMMOItem(mmoSection);
 
-        Material material = Material.getMaterial(section.getString("material", ""));
+        Material material = OraxenYaml.getMaterial(section.getString("material", ""));
         if (material == null)
             material = usesTemplate() ? templateItem.type : Material.PAPER;
         type = material;
 
         oraxenMeta = templateItem != null ? templateItem.oraxenMeta : new OraxenMeta();
-        if (section.isConfigurationSection("Pack")) {
-            final ConfigurationSection packSection = section.getConfigurationSection("Pack");
+        if (OraxenYaml.isConfigurationSection(section, "Pack")) {
+            final ConfigurationSection packSection = OraxenYaml.getConfigurationSection(section, "Pack");
             oraxenMeta.setPackInfos(packSection);
             assert packSection != null;
             if (packSection.isInt("custom_model_data"))
@@ -179,7 +179,7 @@ public class ItemParser {
         else if (section.contains("displayname"))
             item.setItemName(section.getString("displayname"));
 
-        final ConfigurationSection components = section.getConfigurationSection("Components");
+        final ConfigurationSection components = OraxenYaml.getConfigurationSection(section, "Components");
         if (components == null || !VersionUtil.atOrAbove("1.20.5"))
             return;
 
@@ -203,16 +203,16 @@ public class ItemParser {
 
     private void handleLegacyComponents(final ItemBuilder item, final ConfigurationSection components) {
 
-        if (components.contains("durability")) {
+        if (OraxenYaml.contains(components, "durability")) {
             item.setDamagedOnBlockBreak(components.getBoolean("durability.damage_block_break"));
             item.setDamagedOnEntityHit(components.getBoolean("durability.damage_entity_hit"));
             item.setDurability(Math.max(components.getInt("durability.value"), components.getInt("durability", 1)));
         }
-        if (components.contains("fire_resistant"))
+        if (OraxenYaml.contains(components, "fire_resistant"))
             item.setFireResistant(components.getBoolean("fire_resistant"));
-        if (components.contains("hide_tooltip"))
+        if (OraxenYaml.contains(components, "hide_tooltip"))
             item.setHideToolTip(components.getBoolean("hide_tooltip"));
-        if (components.contains("max_stack_size"))
+        if (OraxenYaml.contains(components, "max_stack_size"))
             item.setMaxStackSize(components.getInt("max_stack_size"));
 
         final NMSHandler nmsHandler = NMSHandlers.getHandler();
@@ -222,17 +222,17 @@ public class ItemParser {
                 Logs.logError("Item parsing: " + (section != null ? section.getName() : "unknown section"));
             }
         } else {
-            Optional.ofNullable(components.getConfigurationSection("food"))
+            Optional.ofNullable(OraxenYaml.getConfigurationSection(components, "food"))
                     .ifPresent(food -> nmsHandler.foodComponent(item, food));
         }
 
-        Optional.ofNullable(components.getConfigurationSection("tool"))
+        Optional.ofNullable(OraxenYaml.getConfigurationSection(components, "tool"))
                 .ifPresent(toolSection -> parseToolComponent(item, toolSection));
 
         if (!VersionUtil.atOrAbove("1.21"))
             return;
 
-        final ConfigurationSection jukeboxSection = components.getConfigurationSection("jukebox_playable");
+        final ConfigurationSection jukeboxSection = OraxenYaml.getConfigurationSection(components, "jukebox_playable");
         if (jukeboxSection != null && VersionUtil.isPaperServer()) {
             try {
                 final JukeboxPlayableComponent jukeboxPlayable = new ItemStack(Material.MUSIC_DISC_CREATOR)
@@ -266,10 +266,10 @@ public class ItemParser {
 
         if (!VersionUtil.atOrAbove("1.21.2"))
             return;
-        Optional.ofNullable(components.getConfigurationSection("equippable"))
+        Optional.ofNullable(OraxenYaml.getConfigurationSection(components, "equippable"))
                 .ifPresent(equippable -> parseEquippableComponent(item, equippable));
 
-        Optional.ofNullable(components.getConfigurationSection("use_cooldown")).ifPresent((cooldownSection) -> {
+        Optional.ofNullable(OraxenYaml.getConfigurationSection(components, "use_cooldown")).ifPresent((cooldownSection) -> {
             try {
                 final UseCooldownComponent useCooldownComponent = new ItemStack(Material.PAPER).getItemMeta()
                         .getUseCooldown();
@@ -287,7 +287,7 @@ public class ItemParser {
             }
         });
 
-        Optional.ofNullable(components.getConfigurationSection("use_remainder"))
+        Optional.ofNullable(OraxenYaml.getConfigurationSection(components, "use_remainder"))
                 .ifPresent(useRemainder -> parseUseRemainderComponent(item, useRemainder));
 
         Optional.ofNullable(components.getString("tooltip_style")).map(NamespacedKey::fromString)
@@ -296,25 +296,26 @@ public class ItemParser {
                 .ifPresent(item::setItemModel);
 
         if (nmsHandler != null) {
-            Optional.ofNullable(components.getConfigurationSection("consumable"))
+            Optional.ofNullable(OraxenYaml.getConfigurationSection(components, "consumable"))
                     .ifPresent(consumableSection -> nmsHandler.consumableComponent(item, consumableSection));
         }
     }
 
     private boolean isLegacyComponent(final String key) {
-        return key.equals("durability") ||
-                key.equals("fire_resistant") ||
-                key.equals("hide_tooltip") ||
-                key.equals("max_stack_size") ||
-                key.equals("food") ||
-                key.equals("tool") ||
-                key.equals("jukebox_playable") ||
-                key.equals("equippable") ||
-                key.equals("use_cooldown") ||
-                key.equals("use_remainder") ||
-                key.equals("tooltip_style") ||
-                key.equals("item_model") ||
-                key.equals("consumable");
+        final String normalizedKey = key.toLowerCase(Locale.ROOT);
+        return normalizedKey.equals("durability") ||
+                normalizedKey.equals("fire_resistant") ||
+                normalizedKey.equals("hide_tooltip") ||
+                normalizedKey.equals("max_stack_size") ||
+                normalizedKey.equals("food") ||
+                normalizedKey.equals("tool") ||
+                normalizedKey.equals("jukebox_playable") ||
+                normalizedKey.equals("equippable") ||
+                normalizedKey.equals("use_cooldown") ||
+                normalizedKey.equals("use_remainder") ||
+                normalizedKey.equals("tooltip_style") ||
+                normalizedKey.equals("item_model") ||
+                normalizedKey.equals("consumable");
     }
 
     private void parseUseRemainderComponent(final ItemBuilder item,
@@ -333,7 +334,7 @@ public class ItemParser {
         else if (useRemainderSection.contains("ecoitem_id"))
             result = new WrappedEcoItem(useRemainderSection.getString("ecoitem_id")).build();
         else if (useRemainderSection.contains("minecraft_type")) {
-            final Material material = Material.getMaterial(useRemainderSection.getString("minecraft_type", "AIR"));
+            final Material material = OraxenYaml.getMaterial(useRemainderSection.getString("minecraft_type", "AIR"));
             if (material == null || material.isAir())
                 return;
             result = new ItemStack(material);
@@ -359,7 +360,9 @@ public class ItemParser {
 
             if (ruleEntry.containsKey("material")) {
                 try {
-                    final Material material = Material.valueOf(String.valueOf(ruleEntry.get("material")));
+                    final Material material = OraxenYaml.getMaterial(String.valueOf(ruleEntry.get("material")));
+                    if (material == null)
+                        throw new IllegalArgumentException("Unknown material");
                     if (material.isBlock())
                         materials.add(material);
                 } catch (final Exception e) {
@@ -373,7 +376,9 @@ public class ItemParser {
                 try {
                     final List<String> materialIds = (List<String>) ruleEntry.get("materials");
                     for (final String materialId : materialIds) {
-                        final Material material = Material.valueOf(materialId);
+                        final Material material = OraxenYaml.getMaterial(materialId);
+                        if (material == null)
+                            throw new IllegalArgumentException("Unknown material");
                         if (material.isBlock())
                             materials.add(material);
                     }
@@ -479,10 +484,10 @@ public class ItemParser {
     private void applyArmorStandModelProperties(ConfigurationSection section) {
         oraxenMeta.setArmorStandHeadScale(null);
 
-        ConfigurationSection mechanicsSection = section.getConfigurationSection("Mechanics");
+        ConfigurationSection mechanicsSection = OraxenYaml.getConfigurationSection(section, "Mechanics");
         if (mechanicsSection == null) return;
 
-        ConfigurationSection furnitureSection = mechanicsSection.getConfigurationSection("furniture");
+        ConfigurationSection furnitureSection = OraxenYaml.getConfigurationSection(mechanicsSection, "furniture");
         if (furnitureSection == null) return;
 
         FurnitureMechanic.FurnitureType furnitureType = furnitureSection.isSet("type")
@@ -490,9 +495,9 @@ public class ItemParser {
                 : FurnitureFactory.defaultFurnitureType;
         if (furnitureType != FurnitureMechanic.FurnitureType.ARMOR_STAND) return;
 
-        ConfigurationSection armorStandSection = furnitureSection.getConfigurationSection("armor_stand_properties");
+        ConfigurationSection armorStandSection = OraxenYaml.getConfigurationSection(furnitureSection, "armor_stand_properties");
         if (armorStandSection == null)
-            armorStandSection = furnitureSection.getConfigurationSection("display_entity_properties");
+            armorStandSection = OraxenYaml.getConfigurationSection(furnitureSection, "display_entity_properties");
         if (armorStandSection == null) return;
 
         ArmorStandProperties properties = new ArmorStandProperties(armorStandSection);
@@ -549,7 +554,7 @@ public class ItemParser {
         parseAttributeModifiers(item, section);
 
         if (section.contains("Enchantments")) {
-            final ConfigurationSection enchantSection = section.getConfigurationSection("Enchantments");
+            final ConfigurationSection enchantSection = OraxenYaml.getConfigurationSection(section, "Enchantments");
             if (enchantSection == null)
                 return;
             for (final String enchant : enchantSection.getKeys(false)) {
@@ -603,14 +608,14 @@ public class ItemParser {
     @SuppressWarnings("unchecked")
     private void parseAttributeModifiers(final ItemBuilder item, final ConfigurationSection section) {
         // Try modern ConfigurationSection format first (requires 1.20.5+ for EquipmentSlotGroup)
-        final ConfigurationSection attrSection = section.getConfigurationSection("AttributeModifiers");
+        final ConfigurationSection attrSection = OraxenYaml.getConfigurationSection(section, "AttributeModifiers");
         if (attrSection != null) {
             if (!VersionUtil.atOrAbove("1.20.5")) {
                 Logs.logWarning("Modern AttributeModifiers config format requires server 1.20.5+, skipping for item: " + section.getName());
                 return;
             }
             for (final String key : attrSection.getKeys(false)) {
-                final ConfigurationSection modifierSection = attrSection.getConfigurationSection(key);
+                final ConfigurationSection modifierSection = OraxenYaml.getConfigurationSection(attrSection, key);
                 if (modifierSection == null) continue;
                 try {
                     final AttributeModifierEntry entry =
@@ -663,7 +668,7 @@ public class ItemParser {
 
     private void applyMechanics(ItemBuilder item) {
         final ConfigurationSection merged = mergeWithTemplateSection();
-        final ConfigurationSection mechanicsSection = merged.getConfigurationSection("Mechanics");
+        final ConfigurationSection mechanicsSection = OraxenYaml.getConfigurationSection(merged, "Mechanics");
         if (mechanicsSection == null)
             return;
 
@@ -672,7 +677,7 @@ public class ItemParser {
             if (factory == null)
                 continue;
 
-            final ConfigurationSection mechanicSection = mechanicsSection.getConfigurationSection(mechanicID);
+            final ConfigurationSection mechanicSection = OraxenYaml.getConfigurationSection(mechanicsSection, mechanicID);
             if (mechanicSection == null)
                 continue;
 
@@ -778,7 +783,7 @@ public class ItemParser {
         configUpdated = true;
 
         if (!Settings.DISABLE_AUTOMATIC_MODEL_DATA.toBool()) {
-            Optional.ofNullable(section.getConfigurationSection("Pack"))
+            Optional.ofNullable(OraxenYaml.getConfigurationSection(section, "Pack"))
                     .ifPresent(c -> c.set("custom_model_data", customModelData));
         }
         return customModelData;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -44,6 +44,7 @@ import io.th0rgal.oraxen.mechanics.provided.misc.itemtype.ItemTypeMechanicFactor
 import io.th0rgal.oraxen.mechanics.provided.misc.misc.MiscMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.misc.music_disc.MusicDiscMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.misc.soulbound.SoulBoundMechanicFactory;
+import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -169,7 +170,7 @@ public class MechanicsManager {
         final Entry<File, YamlConfiguration> mechanicsEntry = OraxenPlugin.get().getResourceManager().getMechanicsEntry();
         final YamlConfiguration mechanicsConfig = mechanicsEntry.getValue();
         final boolean updated = false;
-        ConfigurationSection factorySection = mechanicsConfig.getConfigurationSection(mechanicId);
+        ConfigurationSection factorySection = OraxenYaml.getConfigurationSection(mechanicsConfig, mechanicId);
         if (factorySection != null && factorySection.getBoolean("enabled"))
             FACTORIES_BY_MECHANIC_ID.put(mechanicId, constructor.create(factorySection));
 
@@ -237,11 +238,19 @@ public class MechanicsManager {
     }
 
     public static boolean isMechanicEnabled(String mechanicId) {
-        return FACTORIES_BY_MECHANIC_ID.containsKey(mechanicId);
+        return getMechanicFactory(mechanicId) != null;
     }
 
     public static MechanicFactory getMechanicFactory(final String mechanicID) {
-        return FACTORIES_BY_MECHANIC_ID.get(mechanicID);
+        MechanicFactory factory = FACTORIES_BY_MECHANIC_ID.get(mechanicID);
+        if (factory != null)
+            return factory;
+
+        for (Entry<String, MechanicFactory> entry : FACTORIES_BY_MECHANIC_ID.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(mechanicID))
+                return entry.getValue();
+        }
+        return null;
     }
 
     /**

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/food/FoodMechanic.java
@@ -7,6 +7,7 @@ import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.mechanics.Mechanic;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
+import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.PotionUtils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 
@@ -40,12 +41,12 @@ public class FoodMechanic extends Mechanic {
 
         // This must be initialized in OraxenItemsLoadedEvent due to OraxenItems not
         // being loaded yet
-        replacementItem = section.isConfigurationSection("replacement") ? new ItemStack(Material.AIR) : null;
+        replacementItem = OraxenYaml.isConfigurationSection(section, "replacement") ? new ItemStack(Material.AIR) : null;
 
-        ConfigurationSection effectsSection = section.getConfigurationSection("effects");
+        ConfigurationSection effectsSection = OraxenYaml.getConfigurationSection(section, "effects");
         if (effectsSection != null)
             for (String effect : effectsSection.getKeys(false)) {
-                ConfigurationSection effectSection = effectsSection.getConfigurationSection(effect);
+                ConfigurationSection effectSection = OraxenYaml.getConfigurationSection(effectsSection, effect);
                 if (effectSection != null)
                     registerEffects(effectSection);
             }
@@ -70,7 +71,7 @@ public class FoodMechanic extends Mechanic {
 
     public void registerReplacement(ConfigurationSection section) {
         if (section.isString("minecraft_type")) {
-            Material material = Material.getMaterial(Objects.requireNonNull(section.getString("minecraft_type")));
+            Material material = OraxenYaml.getMaterial(Objects.requireNonNull(section.getString("minecraft_type")));
             if (material == null) {
                 Message.INVALID_MATERIAL
                         .log(AdventureUtils.tagResolver("minecraft_type", section.getString("minecraft_type")));

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
@@ -7,6 +7,7 @@ import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucible
 import io.th0rgal.oraxen.items.ItemUpdater;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
 import io.th0rgal.oraxen.recipes.listeners.RecipesEventsManager;
+import io.th0rgal.oraxen.utils.OraxenYaml;
 import net.Indyuce.mmoitems.MMOItems;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -30,7 +31,7 @@ public abstract class RecipeLoader {
     }
 
     protected ItemStack getResult() {
-        ConfigurationSection resultSection = getSection().getConfigurationSection("result");
+        ConfigurationSection resultSection = OraxenYaml.getConfigurationSection(getSection(), "result");
         if (resultSection == null) return null;
         ItemStack result;
         int amount = resultSection.getInt("amount", 1);
@@ -44,7 +45,7 @@ public abstract class RecipeLoader {
         else if (resultSection.isString("ecoitem_id"))
             result = new WrappedEcoItem(resultSection.getString("ecoitem_id")).build();
         else if (resultSection.isString("minecraft_type")) {
-            Material material = Material.getMaterial(resultSection.getString("minecraft_type", "AIR"));
+            Material material = OraxenYaml.getMaterial(resultSection.getString("minecraft_type", "AIR"));
             if (material == null || material.isAir()) return null;
             result = new ItemStack(material);
         } else result = resultSection.getItemStack("minecraft_item");
@@ -70,7 +71,7 @@ public abstract class RecipeLoader {
         }
 
         if (ingredientSection.isString("minecraft_type")) {
-            Material material = Material.getMaterial(ingredientSection.getString("minecraft_type", "AIR"));
+            Material material = OraxenYaml.getMaterial(ingredientSection.getString("minecraft_type", "AIR"));
             if (material == null || material.isAir()) return null;
             return new ItemStack(material);
         }
@@ -99,7 +100,7 @@ public abstract class RecipeLoader {
         }
 
         if (ingredientSection.isString("minecraft_type")) {
-            Material material = Material.getMaterial(ingredientSection.getString("minecraft_type", "AIR"));
+            Material material = OraxenYaml.getMaterial(ingredientSection.getString("minecraft_type", "AIR"));
             if (material == null || material.isAir()) return null;
             return new RecipeChoice.MaterialChoice(material);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/OraxenYaml.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/OraxenYaml.java
@@ -5,12 +5,86 @@ import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 
 public class OraxenYaml extends YamlConfiguration {
+
+    @Nullable
+    public static ConfigurationSection getConfigurationSection(@Nullable ConfigurationSection section,
+            @NotNull String path) {
+        if (section == null)
+            return null;
+
+        ConfigurationSection exact = section.getConfigurationSection(path);
+        if (exact != null)
+            return exact;
+
+        Object value = getIgnoreCase(section, path);
+        return value instanceof ConfigurationSection configurationSection ? configurationSection : null;
+    }
+
+    public static boolean isConfigurationSection(@Nullable ConfigurationSection section, @NotNull String path) {
+        return getConfigurationSection(section, path) != null;
+    }
+
+    public static boolean contains(@Nullable ConfigurationSection section, @NotNull String path) {
+        return getIgnoreCase(section, path) != null;
+    }
+
+    @Nullable
+    public static Object getIgnoreCase(@Nullable ConfigurationSection section, @NotNull String path) {
+        if (section == null)
+            return null;
+
+        Object exact = section.get(path);
+        if (exact != null)
+            return exact;
+
+        ConfigurationSection current = section;
+        String[] parts = path.split("\\.");
+        for (int i = 0; i < parts.length; i++) {
+            String actualKey = getActualKey(current, parts[i]);
+            if (actualKey == null)
+                return null;
+
+            if (i == parts.length - 1)
+                return current.get(actualKey);
+
+            current = current.getConfigurationSection(actualKey);
+            if (current == null)
+                return null;
+        }
+
+        return null;
+    }
+
+    @Nullable
+    public static String getActualKey(@Nullable ConfigurationSection section, @NotNull String key) {
+        if (section == null)
+            return null;
+        if (section.contains(key))
+            return key;
+
+        for (String existingKey : section.getKeys(false)) {
+            if (existingKey.equalsIgnoreCase(key))
+                return existingKey;
+        }
+        return null;
+    }
+
+    @Nullable
+    public static Material getMaterial(@Nullable String materialName) {
+        if (materialName == null || materialName.isBlank())
+            return null;
+
+        return Material.getMaterial(materialName.trim().toUpperCase(Locale.ROOT));
+    }
 
     public static boolean isValidYaml(File file) {
         YamlConfiguration config = new YamlConfiguration();
@@ -75,15 +149,18 @@ public class OraxenYaml extends YamlConfiguration {
 
     public static void copyConfigurationSection(ConfigurationSection source, ConfigurationSection target) {
         for (String key : source.getKeys(false)) {
-            Object sourceValue = source.get(key), targetValue = target.get(key);
+            String targetKey = getActualKey(target, key);
+            if (targetKey == null)
+                targetKey = key;
+            Object sourceValue = source.get(key), targetValue = target.get(targetKey);
 
             if (sourceValue instanceof ConfigurationSection sourceSection) {
                 ConfigurationSection targetSection;
                 if (targetValue instanceof ConfigurationSection existingSection) {
                     targetSection = existingSection;
-                } else targetSection = target.createSection(key);
+                } else targetSection = target.createSection(targetKey);
                 copyConfigurationSection(sourceSection, targetSection);
-            } else target.set(key, sourceValue);
+            } else target.set(targetKey, sourceValue);
         }
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/drops/Loot.java
@@ -6,6 +6,7 @@ import io.th0rgal.oraxen.compatibilities.provided.ecoitems.WrappedEcoItem;
 import io.th0rgal.oraxen.compatibilities.provided.executableitems.WrappedExecutableItem;
 import io.th0rgal.oraxen.compatibilities.provided.mythiccrucible.WrappedCrucibleItem;
 import io.th0rgal.oraxen.items.ItemUpdater;
+import io.th0rgal.oraxen.utils.OraxenYaml;
 import io.th0rgal.oraxen.utils.Utils;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import net.Indyuce.mmoitems.MMOItems;
@@ -79,7 +80,7 @@ public class Loot {
         } else if (executableItemId != null) {
             itemStack = new WrappedExecutableItem(executableItemId).build();
         } else if (minecraftType != null) {
-            Material material = Material.getMaterial(minecraftType);
+            Material material = OraxenYaml.getMaterial(minecraftType);
             itemStack = material != null ? new ItemStack(material) : null;
         } else if (config.containsKey("minecraft_item")) {
             itemStack = (ItemStack) config.get("minecraft_item");


### PR DESCRIPTION
## 🟠 feat: Case-Insensitive Configuration Parsing
- **Summary** - Configuration section names and Material values are now parsed case-insensitively.
- **Description** - Added shared helpers for case-insensitive YAML section lookup and material resolution, then applied them across item, mechanic, recipe, food replacement, drop, and model-data config parsing paths.

- **Changes** - `Components`/`components`, `Mechanics`/`mechanics`, `Pack`/`pack`, nested sections, mechanic IDs, and config Material values like `PAPER`, `paper`, and `Paper` now resolve consistently while existing case-sensitive configurations continue to work.
