### PR TITLE
fix: Set text effects default encoding to effect_font

### DIFF
--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -47,14 +47,14 @@ Glyphs:
 
 # Shader-based text effects (rainbow, wave, shake, etc.)
 # These effects apply to any text using a color encoding detected by shaders.
-# Default encoding (alpha_lsb) preserves the base color by using RGB low bits.
+# Default encoding (effect_font) uses dedicated effect font glyphs.
 # Effect definitions and GLSL snippets live in text_effects.yml.
 # Text effects compatible with 1.21.11+
 TextEffects:
   enabled: true # Master toggle for all text effects
   shader:
     template: auto # auto, effects_only, animated_only
-    encoding: alpha_lsb # Encoding strategy for text effects
+    encoding: effect_font # Encoding strategy for text effects
 
 Chat:
   # If glyphs do not show up in chat, try setting this to LEGACY


### PR DESCRIPTION
## 🟠 TextEffects Default Encoding
- **Summary** - Changed the default `TextEffects.shader.encoding` value in `settings.yml` from `alpha_lsb` to `effect_font`.
- **Description** - `alpha_lsb` is deprecated on most versions, so the default configuration now uses the supported `effect_font` encoding strategy.

- **Changes** - Updated `core/src/main/resources/settings.yml` and adjusted the nearby default encoding comment to describe `effect_font`.
