### PR TITLE
Follow-up fixes for PR #1826 (v1.214.0)

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/commands/RemoveBrandingCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/RemoveBrandingCommand.java
@@ -25,10 +25,16 @@ public class RemoveBrandingCommand {
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
 
     CommandAPICommand getRemoveBrandingCommand() {
-        return new CommandAPICommand("remove-branding")
+        CommandAPICommand confirmed = new CommandAPICommand("confirm")
                 .withPermission("oraxen.command.remove-branding")
                 .executes((sender, args) -> {
                     removeBranding(sender);
+                });
+        return new CommandAPICommand("remove-branding")
+                .withPermission("oraxen.command.remove-branding")
+                .withSubcommand(confirmed)
+                .executes((sender, args) -> {
+                    Message.REMOVE_BRANDING_CONFIRM.send(sender);
                 });
     }
 
@@ -72,12 +78,19 @@ public class RemoveBrandingCommand {
         }
     }
 
+    // Vanilla MC populates these keys from the bundled per-locale language file when the
+    // resource pack doesn't override them, so the cleanest "remove branding" is to drop the
+    // Oraxen-injected overrides entirely rather than replace them with English literals.
+    private static final String[] BRANDED_KEYS = {
+            "menu.game",
+            "menu.disconnect",
+            "menu.returnToGame",
+            "resourcePack.server.name"
+    };
+
     private int updateLangFile(Path path) throws IOException {
         JsonObject lang = readLangFile(path);
-        lang.addProperty("menu.game", "");
-        lang.addProperty("menu.disconnect", "<gray>See you soon!");
-        lang.addProperty("menu.returnToGame", "Back to the server");
-        lang.addProperty("resourcePack.server.name", "Resource Pack");
+        for (String key : BRANDED_KEYS) lang.remove(key);
 
         Files.writeString(path, GSON.toJson(lang) + System.lineSeparator(), StandardCharsets.UTF_8);
         return 1;

--- a/core/src/main/java/io/th0rgal/oraxen/commands/RemoveDefaultsCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/RemoveDefaultsCommand.java
@@ -28,13 +28,19 @@ import java.util.stream.Stream;
 public class RemoveDefaultsCommand {
 
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-    private static final String GLOBAL_LANG_NOTICE = "This file is for editing all languages at once. To, edit a specific language, use the corresponding file in the 'languages' folder.";
+    private static final String GLOBAL_LANG_NOTICE = "This file is for editing all languages at once. To edit a specific language, use the corresponding file in the 'languages' folder.";
 
     CommandAPICommand getRemoveDefaultsCommand() {
-        return new CommandAPICommand("remove-defaults")
+        CommandAPICommand confirmed = new CommandAPICommand("confirm")
                 .withPermission("oraxen.command.remove-defaults")
                 .executes((sender, args) -> {
                     removeDefaults(sender);
+                });
+        return new CommandAPICommand("remove-defaults")
+                .withPermission("oraxen.command.remove-defaults")
+                .withSubcommand(confirmed)
+                .executes((sender, args) -> {
+                    Message.REMOVE_DEFAULTS_CONFIRM.send(sender);
                 });
     }
 
@@ -53,7 +59,7 @@ public class RemoveDefaultsCommand {
 
         Path globalLang = dataFolder.resolve("pack/lang/global.json");
         deletePath(dataFolder.resolve("pack/lang"), true, Set.of(globalLang), deletedFiles, failedFiles);
-        clearGlobalLang(globalLang, deletedFiles, failedFiles);
+        clearGlobalLang(globalLang, failedFiles);
         deletePath(dataFolder.resolve("pack/font"), true, deletedFiles, failedFiles);
         deletePath(dataFolder.resolve("pack/sounds"), true, deletedFiles, failedFiles);
         deleteKnownDefaultFiles(dataFolder, "recipes", deletedFiles, failedFiles);
@@ -126,7 +132,9 @@ public class RemoveDefaultsCommand {
         }
     }
 
-    private void clearGlobalLang(Path globalLang, AtomicInteger updatedFiles, AtomicInteger failedFiles) {
+    // The global lang file is rewritten in place rather than deleted, so it does
+    // not contribute to the deleted-files count reported to the player.
+    private void clearGlobalLang(Path globalLang, AtomicInteger failedFiles) {
         try {
             Files.createDirectories(globalLang.getParent());
             JsonObject json = Files.isRegularFile(globalLang) ? readJsonObject(globalLang) : new JsonObject();
@@ -135,7 +143,6 @@ public class RemoveDefaultsCommand {
             clearedJson.addProperty("DO_NOT_ALTER_THIS_LINE",
                     notice != null && notice.isJsonPrimitive() ? notice.getAsString() : GLOBAL_LANG_NOTICE);
             Files.writeString(globalLang, GSON.toJson(clearedJson) + System.lineSeparator(), StandardCharsets.UTF_8);
-            updatedFiles.incrementAndGet();
         } catch (IOException e) {
             failedFiles.incrementAndGet();
             Logs.logWarning("Failed to clear default language entries from global.json");

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -189,10 +189,26 @@ public class ConfigsManager {
         for (String key : defaultConfiguration.getKeys(true)) {
             if (!skippedYamlKeys.stream().filter(key::startsWith).toList().isEmpty())
                 continue;
-            if (configuration.get(key) == null) {
+            Object currentValue = configuration.get(key);
+            if (currentValue == null) {
                 updated = true;
                 Message.UPDATING_CONFIG.log(AdventureUtils.tagResolver("option", key));
                 configuration.set(key, defaultConfiguration.get(key));
+                continue;
+            }
+            // Migrate language values that lost a required placeholder (e.g. older
+            // installs of general.reload missing the new <reloaded> tag introduced in 1.214.0).
+            if (configName.startsWith("languages/")
+                    && currentValue instanceof String currentString
+                    && defaultConfiguration.get(key) instanceof String defaultString) {
+                for (String placeholder : REQUIRED_LANG_PLACEHOLDERS.getOrDefault(key, List.of())) {
+                    if (defaultString.contains(placeholder) && !currentString.contains(placeholder)) {
+                        updated = true;
+                        Message.UPDATING_CONFIG.log(AdventureUtils.tagResolver("option", key));
+                        configuration.set(key, defaultString);
+                        break;
+                    }
+                }
             }
         }
 
@@ -220,6 +236,13 @@ public class ConfigsManager {
 
     private final List<String> removedYamlKeys = List.of(
             "armorpotioneffects");
+
+    // Keys in user language files that must be re-migrated if they're missing a
+    // placeholder that the bundled default provides. Without this, servers
+    // upgrading would keep the old reload string and the placeholder would render as nothing.
+    private static final Map<String, List<String>> REQUIRED_LANG_PLACEHOLDERS = Map.of(
+            "general.reload", List.of("<reloaded>")
+    );
 
     /**
      * Holds parsing state for glyph configuration processing.

--- a/core/src/main/java/io/th0rgal/oraxen/config/Message.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Message.java
@@ -70,8 +70,10 @@ public enum Message {
     VERSION("command.version"),
     REMOVE_BRANDING_SUCCESS("command.remove_branding.success"),
     REMOVE_BRANDING_FAILED("command.remove_branding.failed"),
+    REMOVE_BRANDING_CONFIRM("command.remove_branding.confirm"),
     REMOVE_DEFAULTS_SUCCESS("command.remove_defaults.success"),
     REMOVE_DEFAULTS_FAILED("command.remove_defaults.failed"),
+    REMOVE_DEFAULTS_CONFIRM("command.remove_defaults.confirm"),
 
     RECIPE_NO_BUILDER("command.recipe.no_builder"),
     RECIPE_NO_FURNACE("command.recipe.no_furnace"),

--- a/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
+++ b/core/src/main/java/io/th0rgal/oraxen/font/Glyph.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 public class Glyph {
 
-    public static final Character WHITESPACE_GLYPH = '\ue000';
+    public static final char WHITESPACE_GLYPH = '\ue000';
 
     private boolean fileChanged = false;
 
@@ -280,6 +280,9 @@ public class Glyph {
      * @return JsonObject for the font provider
      */
     public JsonObject toJson() {
+        if (unicodeRows.isEmpty()) {
+            return null;
+        }
         final JsonObject output = new JsonObject();
         final JsonArray chars = new JsonArray();
 

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticListener.java
@@ -149,7 +149,10 @@ public class BackpackCosmeticListener implements Listener {
         scheduleBackpackMountResync(player);
     }
 
+    // Schedules two resyncs because mount/dismount packets can arrive out of order with the
+    // passenger-list updates the client uses; the second pass is a safety net for that race.
     private void scheduleBackpackMountResync(Player player) {
+        manager.requestResync(player);
         SchedulerUtil.runTaskLater(1L, () -> manager.resyncBackpackMount(player));
         SchedulerUtil.runTaskLater(2L, () -> manager.resyncBackpackMount(player));
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/cosmetic/backpack/BackpackCosmeticManager.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -43,9 +44,7 @@ public class BackpackCosmeticManager {
         // Generate a unique entity ID for the armor stand
         int entityId = NMSHandlers.getHandler().getNextEntityId();
 
-        // Create backpack data with initial yaw locked to body yaw
-        float initialYaw = player.getBodyYaw();
-        BackpackData data = new BackpackData(entityId, mechanic, displayItem, initialYaw, player.getLocation());
+        BackpackData data = new BackpackData(entityId, mechanic, displayItem);
         activeBackpacks.put(playerId, data);
 
         // Spawn the backpack for all nearby players
@@ -182,10 +181,13 @@ public class BackpackCosmeticManager {
             BackpackData data = entry.getValue();
             BackpackCosmeticMechanic mechanic = data.getMechanic();
             int viewDistance = mechanic.getViewDistance();
+            boolean viewersChanged = false;
+
             // Also ensure owner can see their own backpack if enabled
             if (mechanic.isVisibleToSelf() && !data.getViewers().contains(owner.getUniqueId())) {
                 spawnBackpackForViewer(owner, owner, data);
                 data.addViewer(owner.getUniqueId());
+                viewersChanged = true;
             }
 
             // Find new viewers
@@ -198,20 +200,38 @@ public class BackpackCosmeticManager {
                 if (inRange && !isViewer) {
                     spawnBackpackForViewer(potentialViewer, owner, data);
                     data.addViewer(potentialViewer.getUniqueId());
+                    viewersChanged = true;
                 } else if (!inRange && isViewer) {
                     data.getViewers().remove(potentialViewer.getUniqueId());
                     NMSHandlers.getHandler().sendEntityDestroy(potentialViewer, data.getEntityId());
+                    viewersChanged = true;
                 }
             }
 
             // Remove offline viewers
-            data.getViewers().removeIf(viewerId -> {
+            viewersChanged |= data.getViewers().removeIf(viewerId -> {
                 Player viewer = Bukkit.getPlayer(viewerId);
                 return viewer == null || !viewer.isOnline();
             });
 
-            resyncBackpackMount(owner);
+            // Only resync mount packets when the viewer set or passenger list actually changed;
+            // periodic resyncs every tick are an O(N*M) packet storm.
+            int[] currentPassengers = getMergedPassengerIds(owner, data.getEntityId());
+            if (viewersChanged || data.consumeNeedsResync()
+                    || !Arrays.equals(currentPassengers, data.getLastSyncedPassengers())) {
+                resyncBackpackMount(owner);
+                data.setLastSyncedPassengers(currentPassengers);
+            }
         }
+    }
+
+    /**
+     * Force a resync of the mount packets on the next refresh tick.
+     * Called from passenger mount/dismount events.
+     */
+    public void requestResync(Player owner) {
+        BackpackData data = activeBackpacks.get(owner.getUniqueId());
+        if (data != null) data.markNeedsResync();
     }
 
     private void spawnBackpackForViewers(Player owner, BackpackData data) {
@@ -251,8 +271,6 @@ public class BackpackCosmeticManager {
 
         // Send initial head rotation to face the right direction
         NMSHandlers.getHandler().sendEntityHeadRotation(viewer, data.getEntityId(), owner.getBodyYaw());
-
-        // Debug: io.th0rgal.oraxen.utils.logs.Logs.logSuccess("[Backpack] Spawned and mounted armor stand for " + owner.getName());
     }
 
     private void sendBackpackMountPacket(Player viewer, Player owner, BackpackData data) {
@@ -284,32 +302,6 @@ public class BackpackCosmeticManager {
         data.getViewers().clear();
     }
 
-    private Location calculateBackpackLocation(Player player, BackpackData data) {
-        Location loc = player.getLocation().clone();
-        BackpackCosmeticMechanic mechanic = data.getMechanic();
-
-        // Use body yaw directly - in Minecraft, body yaw only changes when player
-        // actually moves/turns their body, not when just looking around with head.
-        // This provides natural backpack behavior without complex tracking.
-        float bodyYaw = player.getBodyYaw();
-        double yawRad = Math.toRadians(bodyYaw);
-
-        double offsetX = mechanic.getOffsetX();
-        double offsetZ = mechanic.getOffsetZ();
-
-        // Rotate offset based on body direction
-        double rotatedX = offsetX * Math.cos(yawRad) - offsetZ * Math.sin(yawRad);
-        double rotatedZ = offsetX * Math.sin(yawRad) + offsetZ * Math.cos(yawRad);
-
-        loc.add(rotatedX, mechanic.getOffsetY(), rotatedZ);
-
-        // Set yaw to body yaw and pitch to 0
-        loc.setYaw(bodyYaw);
-        loc.setPitch(0);
-
-        return loc;
-    }
-
     private boolean isWithinViewDistance(Player viewer, Player target, int viewDistance) {
         if (!viewer.getWorld().equals(target.getWorld())) return false;
         return viewer.getLocation().distanceSquared(target.getLocation()) <= viewDistance * viewDistance;
@@ -319,10 +311,7 @@ public class BackpackCosmeticManager {
      * Clean up when plugin disables
      */
     public void cleanup() {
-        for (Map.Entry<UUID, BackpackData> entry : activeBackpacks.entrySet()) {
-            // Always destroy for all viewers, regardless of owner online status
-            destroyBackpackForViewers(entry.getValue());
-        }
+        activeBackpacks.values().forEach(this::destroyBackpackForViewers);
         activeBackpacks.clear();
     }
 
@@ -334,31 +323,13 @@ public class BackpackCosmeticManager {
         private final BackpackCosmeticMechanic mechanic;
         private final ItemStack displayItem;
         private final Set<UUID> viewers = ConcurrentHashMap.newKeySet();
-        private float lockedYaw;
-        private Location lastPosition;
+        private volatile boolean needsResync;
+        private volatile int[] lastSyncedPassengers = new int[0];
 
-        public BackpackData(int entityId, BackpackCosmeticMechanic mechanic, ItemStack displayItem, float initialYaw, Location initialPosition) {
+        public BackpackData(int entityId, BackpackCosmeticMechanic mechanic, ItemStack displayItem) {
             this.entityId = entityId;
             this.mechanic = mechanic;
             this.displayItem = displayItem;
-            this.lockedYaw = initialYaw;
-            this.lastPosition = initialPosition.clone();
-        }
-
-        public float getLockedYaw() {
-            return lockedYaw;
-        }
-
-        public void setLockedYaw(float yaw) {
-            this.lockedYaw = yaw;
-        }
-
-        public Location getLastPosition() {
-            return lastPosition;
-        }
-
-        public void setLastPosition(Location pos) {
-            this.lastPosition = pos.clone();
         }
 
         public int getEntityId() {
@@ -379,6 +350,24 @@ public class BackpackCosmeticManager {
 
         public void addViewer(UUID viewerId) {
             viewers.add(viewerId);
+        }
+
+        void markNeedsResync() {
+            this.needsResync = true;
+        }
+
+        boolean consumeNeedsResync() {
+            if (!needsResync) return false;
+            needsResync = false;
+            return true;
+        }
+
+        int[] getLastSyncedPassengers() {
+            return lastSyncedPassengers;
+        }
+
+        void setLastSyncedPassengers(int[] passengers) {
+            this.lastSyncedPassengers = passengers;
         }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -351,7 +351,7 @@ public class FurnitureMechanic extends Mechanic {
             return null;
         }
 
-        String[] offsetParts = string.trim().split(",");
+        String[] offsetParts = string.trim().split("\\s*,\\s*");
         if (offsetParts.length != 3) {
             Logs.logError("Invalid seat entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z>'.");
             return null;
@@ -375,7 +375,8 @@ public class FurnitureMechanic extends Mechanic {
             return null;
         }
 
-        String[] parts = string.trim().split("\\s+");
+        // Collapse whitespace around commas first so the outer space-split still produces 2 parts.
+        String[] parts = string.trim().replaceAll("\\s*,\\s*", ",").split("\\s+");
         if (parts.length != 2) {
             Logs.logError("Invalid light entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z> <level>'.");
             return null;
@@ -406,7 +407,8 @@ public class FurnitureMechanic extends Mechanic {
             return null;
         }
 
-        String[] parts = string.trim().split("\\s+");
+        // Collapse whitespace around commas first so the outer space-split still produces 2 parts.
+        String[] parts = string.trim().replaceAll("\\s*,\\s*", ",").split("\\s+");
         if (parts.length != 2) {
             Logs.logError("Invalid hitbox entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z> <width>,<height>'.");
             return null;
@@ -425,7 +427,11 @@ public class FurnitureMechanic extends Mechanic {
             double offsetZ = Double.parseDouble(offsetParts[2]);
             float width = Float.parseFloat(sizeParts[0]);
             float height = Float.parseFloat(sizeParts[1]);
-            return width > 0 && height > 0 ? new FurnitureHitbox(offsetX, offsetY, offsetZ, width, height) : null;
+            if (width <= 0 || height <= 0) {
+                Logs.logError("Invalid hitbox entry '" + string + "' for furniture: " + getItemID() + ". Width and height must be positive.");
+                return null;
+            }
+            return new FurnitureHitbox(offsetX, offsetY, offsetZ, width, height);
         } catch (NumberFormatException exception) {
             Logs.logError("Invalid hitbox entry '" + string + "' for furniture: " + getItemID() + ". Hitbox values must be numbers.");
             return null;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscListener.java
@@ -28,6 +28,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Arrays;
 
@@ -51,11 +52,17 @@ public class MiscListener implements Listener {
 
         // Only cancel when the user actually typed a rename. Repair/enchant operations leave
         // renameText empty (or matching the original plain-text display name) and must go through.
+        // Use ItemMeta.displayName() rather than ItemStack.displayName(): the latter wraps the
+        // name in square brackets ([Cool Sword]) but anvil.getRenameText() returns the raw text,
+        // so comparing against the bracketed form would never match.
         String renameText = anvil.getRenameText();
         if (renameText == null || renameText.isEmpty()) return;
 
-        String inputPlain = AdventureUtils.PLAIN_TEXT.serialize(inputItem.displayName());
-        if (renameText.equals(inputPlain)) return;
+        ItemMeta inputMeta = inputItem.getItemMeta();
+        if (inputMeta != null && inputMeta.hasDisplayName()) {
+            String inputPlain = AdventureUtils.PLAIN_TEXT.serialize(inputMeta.displayName());
+            if (renameText.equals(inputPlain)) return;
+        }
 
         event.setResult(null);
     }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/misc/MiscListener.java
@@ -1,9 +1,8 @@
 package io.th0rgal.oraxen.mechanics.provided.misc.misc;
 
-import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.Utils;
-import io.th0rgal.oraxen.utils.VersionUtil;
 import io.th0rgal.protectionlib.ProtectionLib;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -29,7 +28,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Arrays;
 
@@ -39,20 +37,25 @@ import static org.bukkit.event.entity.EntityDamageEvent.DamageCause.FIRE_TICK;
 public class MiscListener implements Listener {
 
     public MiscListener(MiscMechanicFactory factory) {
-        if (VersionUtil.isPaperServer()) {
-            OraxenPlugin.get().getServer().getPluginManager().registerEvents(new PaperOnlyListeners(factory), OraxenPlugin.get());
-        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPreventAnvilRename(PrepareAnvilEvent event) {
-        ItemStack inputItem = event.getInventory().getFirstItem();
+        AnvilInventory anvil = event.getInventory();
+        ItemStack inputItem = anvil.getFirstItem();
         ItemStack resultItem = event.getResult();
         if (inputItem == null || resultItem == null || inputItem.getType() == Material.AIR) return;
 
         MiscMechanic mechanic = MiscMechanicFactory.get().getMechanic(inputItem);
         if (mechanic == null || !mechanic.preventsRenaming()) return;
-        if (!hasDifferentDisplayName(inputItem, resultItem)) return;
+
+        // Only cancel when the user actually typed a rename. Repair/enchant operations leave
+        // renameText empty (or matching the original plain-text display name) and must go through.
+        String renameText = anvil.getRenameText();
+        if (renameText == null || renameText.isEmpty()) return;
+
+        String inputPlain = AdventureUtils.PLAIN_TEXT.serialize(inputItem.displayName());
+        if (renameText.equals(inputPlain)) return;
 
         event.setResult(null);
     }
@@ -234,14 +237,6 @@ public class MiscListener implements Listener {
         return MiscMechanicFactory.get().getMechanic(itemID);
     }
 
-    private boolean hasDifferentDisplayName(ItemStack inputItem, ItemStack resultItem) {
-        ItemMeta inputMeta = inputItem.getItemMeta();
-        ItemMeta resultMeta = resultItem.getItemMeta();
-        if (inputMeta == null || resultMeta == null) return false;
-        if (inputMeta.hasDisplayName() != resultMeta.hasDisplayName()) return true;
-        return resultMeta.hasDisplayName() && !inputMeta.getDisplayName().equals(resultMeta.getDisplayName());
-    }
-
     private Material getStrippedLog(Material log) {
         return switch (log) {
             case OAK_LOG -> Material.STRIPPED_OAK_LOG;
@@ -273,8 +268,4 @@ public class MiscListener implements Listener {
         return mechanic != null && mechanic.piglinIgnoreWhenEquipped();
     }
 
-    private record PaperOnlyListeners(MiscMechanicFactory factory) implements Listener {
-
-
-    }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/soulbound/SoulBoundMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/misc/soulbound/SoulBoundMechanicListener.java
@@ -11,13 +11,11 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class SoulBoundMechanicListener implements Listener {
@@ -34,7 +32,6 @@ public class SoulBoundMechanicListener implements Listener {
         if (event.getKeepInventory())
             return;
 
-        Random random = ThreadLocalRandom.current();
         List<ItemStack> items = new ArrayList<>();
         for (Iterator<ItemStack> iterator = event.getDrops().iterator(); iterator.hasNext();) {
             ItemStack drop = iterator.next();
@@ -43,7 +40,8 @@ public class SoulBoundMechanicListener implements Listener {
                 continue;
 
             SoulBoundMechanic mechanic = (SoulBoundMechanic) factory.getMechanic(itemID);
-            if (random.nextInt(100) >= mechanic.getLoseChance() * 100) {
+            // Keep the drop with probability (1 - loseChance).
+            if (ThreadLocalRandom.current().nextDouble() >= mechanic.getLoseChance()) {
                 items.add(drop);
                 iterator.remove();
             }
@@ -85,8 +83,9 @@ public class SoulBoundMechanicListener implements Listener {
             return null;
 
         try {
-            return (List<ItemStack>) GET_ITEMS_TO_KEEP_METHOD.invoke(event);
-        } catch (IllegalAccessException | InvocationTargetException ignored) {
+            Object result = GET_ITEMS_TO_KEEP_METHOD.invoke(event);
+            return result instanceof List<?> ? (List<ItemStack>) result : null;
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
             return null;
         }
     }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/PackMcmetaUtils.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.utils.VirtualFile;
 import io.th0rgal.oraxen.utils.ResourcePackFormatUtil;
 import io.th0rgal.oraxen.utils.logs.Logs;
@@ -169,7 +170,11 @@ public class PackMcmetaUtils {
             file.setInputStream(new ByteArrayInputStream(content));
             JsonElement parsed = JsonParser.parseString(new String(content, StandardCharsets.UTF_8));
             return parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
-        } catch (Exception ignored) {
+        } catch (Exception exception) {
+            if (Settings.DEBUG.toBool()) {
+                Logs.logWarning("PackMcmetaUtils.readVirtualFileJsonObject failed for "
+                        + file.getPath() + ": " + exception.getMessage());
+            }
             return null;
         }
     }
@@ -183,11 +188,21 @@ public class PackMcmetaUtils {
                 ? overlays.getAsJsonArray("entries")
                 : new JsonArray();
 
+        // De-duplicate by directory. Existing entries from the user's pack take precedence
+        // over freshly-imported ones with the same directory.
+        java.util.Set<String> seenDirectories = new java.util.HashSet<>();
         JsonArray mergedEntries = new JsonArray();
-        for (JsonElement entry : additionalEntries) {
-            mergedEntries.add(entry.deepCopy());
-        }
         for (JsonElement entry : existingEntries) {
+            mergedEntries.add(entry.deepCopy());
+            if (entry.isJsonObject() && entry.getAsJsonObject().has("directory")) {
+                seenDirectories.add(entry.getAsJsonObject().get("directory").getAsString());
+            }
+        }
+        for (JsonElement entry : additionalEntries) {
+            String directory = entry.isJsonObject() && entry.getAsJsonObject().has("directory")
+                    ? entry.getAsJsonObject().get("directory").getAsString()
+                    : null;
+            if (directory != null && !seenDirectories.add(directory)) continue;
             mergedEntries.add(entry.deepCopy());
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/ResourcePack.java
@@ -1038,8 +1038,9 @@ public class ResourcePack {
         final JsonObject output = new JsonObject();
         final JsonArray providers = new JsonArray();
         for (final Glyph glyph : fontManager.getGlyphs()) {
-            if (!glyph.hasBitmap())
-                providers.add(glyph.toJson());
+            if (glyph.hasBitmap()) continue;
+            JsonObject glyphJson = glyph.toJson();
+            if (glyphJson != null) providers.add(glyphJson);
         }
         for (FontManager.GlyphBitMap glyphBitMap : FontManager.glyphBitMaps.values()) {
             providers.add(glyphBitMap.toJson(fontManager));

--- a/core/src/main/java/io/th0rgal/oraxen/utils/OS.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/OS.java
@@ -99,22 +99,44 @@ public class OS {
     }
 
     private void initMacOsInfo(final String name, final String version, final String arch) {
-        String[] versions = version.split("\\.");
-        double numericVersion = Double.parseDouble(versions[0] + "." + versions[1]);
-        if (numericVersion < 10)
-            this.osInfo = new OsInfo(name, version, arch, "Mac OS " + version);
-        else {
-            String macOsVersionName = Integer.parseInt(versions[0]) >= 12 ? macOs.get(versions[0]) : macOs.get(version);
-            String platformName = macOsVersionName != null ? "macOS " + macOsVersionName + " (" + version + ")" : "macOS " + version;
-            this.osInfo = new OsInfo(name, version, arch,
-                    platformName);
+        if (version == null || version.isBlank()) {
+            this.osInfo = new OsInfo(name, version, arch, "macOS");
+            return;
         }
+        String[] versions = version.split("\\.");
+        int major;
+        try {
+            major = Integer.parseInt(versions[0]);
+        } catch (NumberFormatException e) {
+            this.osInfo = new OsInfo(name, version, arch, "macOS " + version);
+            return;
+        }
+        if (major < 10) {
+            this.osInfo = new OsInfo(name, version, arch, "Mac OS " + version);
+            return;
+        }
+        String macOsVersionName = major >= 12 ? macOs.get(versions[0]) : macOs.get(version);
+        String platformName = macOsVersionName != null
+                ? "macOS " + macOsVersionName + " (" + version + ")"
+                : "macOS " + version;
+        this.osInfo = new OsInfo(name, version, arch, platformName);
     }
 
     private void initDarwinOsInfo(final String name, final String version, final String arch) {
-        String[] versions = version.split("\\.");
-        int numericVersion = Integer.parseInt(versions[0]);
-        this.osInfo = new OsInfo(name, version, arch, "OS X " + darwin.get(numericVersion) + " (" + version + ")");
+        if (version == null || version.isBlank()) {
+            this.osInfo = new OsInfo(name, version, arch, "OS X");
+            return;
+        }
+        int numericVersion;
+        try {
+            numericVersion = Integer.parseInt(version.split("\\.")[0]);
+        } catch (NumberFormatException e) {
+            this.osInfo = new OsInfo(name, version, arch, "OS X " + version);
+            return;
+        }
+        String codename = darwin.get(numericVersion);
+        this.osInfo = new OsInfo(name, version, arch,
+                codename != null ? "OS X " + codename + " (" + version + ")" : "OS X " + version);
     }
 
     private void initLinuxOsInfo(final String name, final String version, final String arch) {

--- a/core/src/main/java/io/th0rgal/oraxen/utils/PacketHelpers.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/PacketHelpers.java
@@ -1,5 +1,7 @@
 package io.th0rgal.oraxen.utils;
 
+import io.th0rgal.oraxen.config.Settings;
+import io.th0rgal.oraxen.utils.logs.Logs;
 import net.kyori.adventure.text.Component;
 
 public class PacketHelpers {
@@ -20,6 +22,9 @@ public class PacketHelpers {
         try {
             return toJson(readJson(json));
         } catch (RuntimeException exception) {
+            if (Settings.DEBUG.toBool()) {
+                Logs.logWarning("PacketHelpers.translateJson failed, returning original payload: " + exception.getMessage());
+            }
             return json;
         }
     }
@@ -27,7 +32,7 @@ public class PacketHelpers {
     public static Component translateTitle(Component component) {
         return AdventureUtils.MINI_MESSAGE.deserialize(
             AdventureUtils.parseMiniMessageThroughLegacy(component)
-                .replaceAll("\\\\(?!u)(?!n)(?!\")", "")
+                .replaceAll(BACKSLASH_REMOVAL_REGEX, "")
         );
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/BreakerSystem.java
@@ -203,18 +203,16 @@ public abstract class BreakerSystem {
     }
 
     private List<Location> furnitureBarrierLocations(FurnitureMechanic furnitureMechanic, Block block) {
-        if (!breakerLocations.contains(block.getLocation())) return List.of(block.getLocation());
-
         // Get base entity directly - we're already on the correct thread context
         // (main thread for Bukkit, region thread for Folia) from block damage events.
         if (furnitureMechanic == null) return Collections.singletonList(block.getLocation());
-        
+
         Entity furnitureBaseEntity = furnitureMechanic.getBaseEntity(block);
         if (furnitureBaseEntity == null) return Collections.singletonList(block.getLocation());
-        
+
         return furnitureMechanic.getLocations(
                 FurnitureMechanic.getFurnitureYaw(furnitureBaseEntity),
-                furnitureBaseEntity.getLocation(), 
+                furnitureBaseEntity.getLocation(),
                 furnitureMechanic.getBarriers());
     }
 

--- a/core/src/main/java/io/th0rgal/oraxen/utils/breaker/CustomBlockMiningListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/breaker/CustomBlockMiningListener.java
@@ -37,7 +37,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CustomBlockMiningListener implements Listener {
 
     private static final NamespacedKey BREAK_SPEED_KEY = NamespacedKey.fromString("oraxen:custom_breaking_speed");
+    // Vanilla baseline: a hardness-1 block under a bare hand takes ~4.17 ticks per hit
+    // (1 / 0.24 ≈ 4.17). Dividing 0.24 by the block hardness gives the per-tick fraction we
+    // need to add to the player's BLOCK_BREAK_SPEED attribute to match the custom hardness.
+    private static final double VANILLA_BREAK_SPEED_BASE = 0.24D;
     private final Map<UUID, AttributeModifier> modifierMap = new ConcurrentHashMap<>();
+    // Cache of the resolved AttributeModifier constructor (varies by server version).
+    private static volatile ModifierFactory cachedModifierFactory;
 
     /**
      * Returns true if the BLOCK_BREAK_SPEED attribute is available on this server version.
@@ -137,7 +143,7 @@ public class CustomBlockMiningListener implements Listener {
         if (BREAK_SPEED_KEY == null || blockBreakSpeed == null) return null;
 
         final double speedFactor = Math.max(0.01D,
-                0.24D / miningProfile.hardness() * getToolSpeedMultiplier(player, miningProfile.drop()));
+                VANILLA_BREAK_SPEED_BASE / miningProfile.hardness() * getToolSpeedMultiplier(player, miningProfile.drop()));
         return instantiateModifier(speedFactor - 1.0D);
     }
 
@@ -188,12 +194,29 @@ public class CustomBlockMiningListener implements Listener {
 
     @Nullable
     private AttributeModifier instantiateModifier(final double amount) {
+        ModifierFactory factory = cachedModifierFactory;
+        if (factory == null) {
+            factory = resolveModifierFactory();
+            cachedModifierFactory = factory;
+        }
+        return factory == null ? null : factory.create(amount);
+    }
+
+    @Nullable
+    private ModifierFactory resolveModifierFactory() {
         try {
             final Class<?> slotGroupClass = Class.forName("org.bukkit.inventory.EquipmentSlotGroup");
             final Object handGroup = slotGroupClass.getField("HAND").get(null);
             final Constructor<AttributeModifier> constructor = AttributeModifier.class.getConstructor(
                     NamespacedKey.class, double.class, AttributeModifier.Operation.class, slotGroupClass);
-            return constructor.newInstance(BREAK_SPEED_KEY, amount, AttributeModifier.Operation.MULTIPLY_SCALAR_1, handGroup);
+            return amount -> {
+                try {
+                    return constructor.newInstance(BREAK_SPEED_KEY, amount,
+                            AttributeModifier.Operation.MULTIPLY_SCALAR_1, handGroup);
+                } catch (ReflectiveOperationException ignored) {
+                    return null;
+                }
+            };
         } catch (ReflectiveOperationException ignored) {
             // Fall through to older constructor variants.
         }
@@ -201,13 +224,18 @@ public class CustomBlockMiningListener implements Listener {
         try {
             final Constructor<AttributeModifier> constructor = AttributeModifier.class.getConstructor(
                     UUID.class, String.class, double.class, AttributeModifier.Operation.class, EquipmentSlot.class);
-            return constructor.newInstance(
-                    UUID.nameUUIDFromBytes(BREAK_SPEED_KEY.asString().getBytes()),
-                    BREAK_SPEED_KEY.getKey().toLowerCase(Locale.ROOT),
-                    amount,
-                    AttributeModifier.Operation.MULTIPLY_SCALAR_1,
-                    EquipmentSlot.HAND
-            );
+            return amount -> {
+                try {
+                    return constructor.newInstance(
+                            UUID.nameUUIDFromBytes(BREAK_SPEED_KEY.asString().getBytes()),
+                            BREAK_SPEED_KEY.getKey().toLowerCase(Locale.ROOT),
+                            amount,
+                            AttributeModifier.Operation.MULTIPLY_SCALAR_1,
+                            EquipmentSlot.HAND);
+                } catch (ReflectiveOperationException ignored) {
+                    return null;
+                }
+            };
         } catch (ReflectiveOperationException ignored) {
             // Fall through to the oldest constructor variant.
         }
@@ -215,15 +243,25 @@ public class CustomBlockMiningListener implements Listener {
         try {
             final Constructor<AttributeModifier> constructor = AttributeModifier.class.getConstructor(
                     UUID.class, String.class, double.class, AttributeModifier.Operation.class);
-            return constructor.newInstance(
-                    UUID.nameUUIDFromBytes(BREAK_SPEED_KEY.asString().getBytes()),
-                    BREAK_SPEED_KEY.getKey().toLowerCase(Locale.ROOT),
-                    amount,
-                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-            );
+            return amount -> {
+                try {
+                    return constructor.newInstance(
+                            UUID.nameUUIDFromBytes(BREAK_SPEED_KEY.asString().getBytes()),
+                            BREAK_SPEED_KEY.getKey().toLowerCase(Locale.ROOT),
+                            amount,
+                            AttributeModifier.Operation.MULTIPLY_SCALAR_1);
+                } catch (ReflectiveOperationException ignored) {
+                    return null;
+                }
+            };
         } catch (ReflectiveOperationException ignored) {
             return null;
         }
+    }
+
+    @FunctionalInterface
+    private interface ModifierFactory {
+        @Nullable AttributeModifier create(double amount);
     }
 
     private record MiningProfile(double hardness, Drop drop) {}

--- a/core/src/main/resources/languages/english.yml
+++ b/core/src/main/resources/languages/english.yml
@@ -122,9 +122,11 @@ command:
   remove_branding:
     success: "<prefix><#55ffa4>Oraxen branding removed from <#43fa8c><files><#55ffa4> language file(s). Disabled default assets and the welcome sound. Run <#43c9fa>/oraxen reload all<#55ffa4> to regenerate the pack and configs."
     failed: "<prefix><#fa4943>Failed to remove Oraxen branding. Check the console for details."
+    confirm: "<prefix><#fa9343>This will rewrite pack language files. Run <#43c9fa>/oraxen remove-branding confirm<#fa9343> to proceed."
   remove_defaults:
     success: "<prefix><#55ffa4>Removed <#43fa8c><files><#55ffa4> default file(s). Disabled default configs, default assets and the welcome sound. Required glyphs were kept. Run <#43c9fa>/oraxen reload all<#55ffa4> to regenerate the pack and configs."
     failed: "<prefix><#fa4943>Removed <#43fa8c><deleted><#fa4943> default file(s), but failed to remove <#43fa8c><failed><#fa4943>. Check the console for details."
+    confirm: "<prefix><#fa9343>This will permanently delete default items, recipes, glyphs, models and textures shipped with Oraxen. Run <#43c9fa>/oraxen remove-defaults confirm<#fa9343> to proceed."
 
 mechanics:
   not_enough_exp: "<prefix><#fa4943>You need more experience to do this"


### PR DESCRIPTION
## Summary

PR #1826 (v1.214.0) bundled 22 changes across 91 files. While reviewing it I tested the merged plugin live on `demo.oraxen.com` (Paper 1.21.11 + Fabric 1.21.11 client) and found a confirmed user-visible regression plus a handful of bugs, smells, and nits worth addressing before the next release.

The most user-visible one — issue **B1** — is a config-migration bug: the PR added a new `<reloaded>` placeholder to `general.reload` in the bundled `english.yml`, but the plugin doesn't migrate existing language files on upgrade. Every server upgrading to 1.214.0 sees `Successfully reloaded ` (empty placeholder, no period). I reproduced it on the demo server before this branch, then re-verified that after this branch the placeholder migrates automatically.

## Fixes

**Bugs (B-prefixed in the review):**

- **B1** `ConfigsManager.validate` now re-migrates language YAML keys whose default value introduced a new placeholder. Targeted at `general.reload`'s new `<reloaded>` tag for now.
- **B2** `OS.java` guards bare-major macOS/Darwin version strings like `15` and `15.0.1` instead of throwing `ArrayIndexOutOfBoundsException`.
- **B3** `PacketHelpers.translateJson` logs swallowed exceptions under `DEBUG` instead of silently returning the original payload.
- **B4** Soulbound drop chance now uses `ThreadLocalRandom.current().nextDouble() < loseChance` instead of `nextInt(100) >= loseChance * 100` (precision was lost and intent inverted for fractional values).
- **B5** Soulbound reflection invocation catches `ReflectiveOperationException | RuntimeException` (was only catching `IllegalAccessException | InvocationTargetException`; Folia / mocked events can throw other types).
- **B6** Anvil `prevent_renaming` now checks the actual rename text the user typed, letting repair/enchant operations through; previously the string-based display-name comparison gave false positives on Oraxen-styled items.
- **B7** `/oraxen remove-defaults` and `/oraxen remove-branding` now require a `confirm` subcommand. Bare invocations print a warning.
- **B8** `clearGlobalLang` no longer inflates the player-facing deleted-files count with non-deletion edits.
- **B9** `FurnitureMechanic` seat/light/hitbox parsers tolerate whitespace around commas (`"0, 0, 0 1, 1"` no longer fails). Whitespace adjacent to commas is normalised before the outer space-split so multi-line list configs work as naturally written.
- **B10** Hitboxes with non-positive width/height now log an explicit error instead of silently being dropped.
- **B12** `PackMcmetaUtils.mergeOverlayEntries` de-duplicates overlay entries by `directory` so importing a pack that already declares the same overlay no longer produces a duplicate entry.
- **B13** `BreakerSystem.furnitureBarrierLocations` no longer short-circuits on the `breakerLocations` membership check; multi-barrier furniture now gets the full barrier list every call.
- **B14** `BackpackCosmeticManager` only re-sends mount packets when the viewer set or passenger ids actually changed (gated by a `needsResync` flag and a snapshot comparison). Previously every active backpack re-broadcast packets to every viewer once per second.

**Smells / nits cleaned up:**

- **S4** `PacketHelpers.translateTitle` reuses `BACKSLASH_REMOVAL_REGEX` instead of duplicating the literal.
- **S5** `CustomBlockMiningListener` extracts `0.24` into `VANILLA_BREAK_SPEED_BASE` with a comment.
- **S6** The reflection-resolved `AttributeModifier` constructor is cached in a static `ModifierFactory`.
- **S7/S8/S9** Dead `calculateBackpackLocation`, `lockedYaw`/`lastPosition` fields, and over-complex `cleanup()` removed.
- **S11** Empty `PaperOnlyListeners` record removed.
- **S12, N1** Unused `Random` reference + import dropped from Soulbound.
- **S13** `/oraxen remove-branding` now clears the Oraxen-injected language keys entirely (Minecraft falls back to its per-locale defaults) instead of overwriting them with English literals.
- **S14** `PackMcmetaUtils.readVirtualFileJsonObject` logs read failures under `DEBUG` with the failing file path.
- **S16** `Glyph.toJson` returns `null` for empty `unicodeRows`; `ResourcePack` skips those.
- **N2** Leftover commented debug log removed from `BackpackCosmeticManager`.
- **N5** Stray comma in the global lang notice (`"To, edit..."`) fixed.
- **N6** Furniture parser error messages include the offending input string.
- **N7** `WHITESPACE_GLYPH` changed from boxed `Character` to primitive `char`.

**New strings:**

- `command.remove_branding.confirm` and `command.remove_defaults.confirm` added to `english.yml`.

## Test plan

- [x] Build with `CI=1 ./gradlew shadowJar -x test`, deploy to demo.oraxen.com.
- [x] Confirm Oraxen loads cleanly (`Loaded 16 glyphs, 0 reference glyphs, 1 animated glyphs`).
- [x] On startup, verify `plugins/Oraxen/languages/english.yml` is auto-migrated so `general.reload` contains `<reloaded>`.
- [x] `/oraxen reload items` prints `Successfully reloaded items.` (was empty placeholder before).
- [x] `/oraxen reload pack`, `messages`, `huds`, `all` all show the correct type.
- [x] `/oraxen remove-branding` prints the confirm prompt instead of running.
- [x] `/oraxen remove-defaults` prints the confirm prompt instead of running.
- [x] `/oraxen inv` opens without `LinkageError` (PacketEvents fix intact).
- [x] `/oraxen recipes show all` arrow renders with no count badge.
- [x] Furniture YAML with `"0, 0, 0 1, 1"`-style whitespace-around-commas parses without errors.
- [ ] Multi-player tests for backpack passenger merging and glide/swim hide — couldn't run on demo server with only one connected client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config migration and multiple gameplay/event-driven code paths (anvil, backpacks, soulbound), so behavioral changes could affect servers in subtle ways despite being targeted fixes.
> 
> **Overview**
> Fixes several post-`v1.214.0` regressions and edge cases, notably by enhancing config validation to re-migrate user `languages/*.yml` entries when newly-required placeholders (e.g. `general.reload`’s `<reloaded>`) are missing.
> 
> Makes destructive maintenance commands safer and more accurate: `/oraxen remove-branding` and `/oraxen remove-defaults` now require an explicit `confirm` subcommand (with new language strings), `remove-branding` now *removes* branded lang keys instead of overwriting them, and `remove-defaults` no longer counts the in-place `global.json` rewrite as a deleted file.
> 
> Improves gameplay/pack robustness and performance: backpack cosmetics now gate mount resync packets on viewer/passenger changes (and request resync from mount/dismount events), furniture parsing tolerates whitespace around commas and logs clearer hitbox errors, `PackMcmetaUtils` de-duplicates overlay entries and logs JSON read failures under `DEBUG`, anvil rename-prevention now checks actual rename text to avoid blocking repairs/enchants, and several small hardening/cleanup tweaks (macOS/Darwin version parsing, soulbound chance math + reflection safety, glyph JSON null-guard, cached `AttributeModifier` reflection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d2be010c0ea1030b557d3a7b4b498193b33ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->