### PR TITLE
Oraxen v1.215.0

### DIFF
--- a/.codefactor.yml
+++ b/.codefactor.yml
@@ -1,0 +1,3 @@
+exclude:
+  # Version-specific Minecraft internals intentionally duplicate adapter logic.
+  - "v*/src/main/java/io/th0rgal/oraxen/nms/v*/NMSHandler.java"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Oraxen supports both ProtocolLib and PacketEvents:
 
 Dependencies are managed via gradle/oraxenLibs.versions.toml:
 - **libraries-bukkit**: Loaded via plugin.yml libraries (Adventure, Gson, etc.)
-- **libraries-shade**: Shaded and relocated (BStats, ProtectionLib, InventoryFramework)
+- **libraries-shade**: Shaded and relocated (BStats, ProtectionLib, TriumphGUI)
 - **plugins**: Soft dependencies (ProtocolLib, PlaceholderAPI, MythicMobs, etc.)
 
 All shaded dependencies are relocated to io.th0rgal.oraxen.shaded.* to avoid conflicts.

--- a/README.md
+++ b/README.md
@@ -151,10 +151,6 @@ compileOnly 'io.th0rgal:oraxen:VERSION'
             <artifactId>PlayerAnimator</artifactId>
         </exclusion>
         <exclusion>
-            <groupId>com.github.stefvanschie.inventoryframework</groupId>
-            <artifactId>IF</artifactId>
-        </exclusion>
-        <exclusion>
             <groupId>io.th0rgal</groupId>
             <artifactId>protectionlib</artifactId>
         </exclusion>

--- a/core/src/main/java/io/th0rgal/oraxen/commands/RecipesCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/RecipesCommand.java
@@ -43,7 +43,7 @@ public class RecipesCommand {
                             Message.RECIPE_NO_RECIPE.send(sender);
                             return;
                         }
-                        OraxenPlugin.get().getInvManager().getRecipesShowcase(0, recipes).show(player);
+                        OraxenPlugin.get().getInvManager().getRecipesShowcase(0, recipes).open(player);
                     } else
                         Message.NOT_PLAYER.send(sender);
                 });

--- a/core/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/ReloadCommand.java
@@ -21,7 +21,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,15 +45,11 @@ public class ReloadCommand {
                 // Use runForEntity for Folia compatibility - inventory must be accessed on player's region thread
                 SchedulerUtil.runForEntity(player, () -> {
                     PlayerInventory inventory = player.getInventory();
-                    for (int i = 0; i < inventory.getSize(); i++) {
-                        ItemStack oldItem = inventory.getItem(i);
-                        ItemStack newItem = ItemUpdater.updateItem(oldItem);
-                        if (oldItem == null || oldItem.equals(newItem))
-                            continue;
-                        inventory.setItem(i, newItem);
-                    }
+                    ItemUpdater.updateInventory(inventory);
+                    ItemUpdater.updateInventory(player.getEnderChest());
                 });
             }
+            ItemUpdater.updateLoadedEntityContents();
         }
 
         if (Settings.UPDATE_FURNITURE.toBool() && Settings.UPDATE_FURNITURE_ON_RELOAD.toBool()) {

--- a/core/src/main/java/io/th0rgal/oraxen/commands/TotemAnimationCommand.java
+++ b/core/src/main/java/io/th0rgal/oraxen/commands/TotemAnimationCommand.java
@@ -1,7 +1,5 @@
 package io.th0rgal.oraxen.commands;
 
-import com.github.retrooper.packetevents.PacketEvents;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityStatus;
 import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.ArgumentSuggestions;
 import dev.jorel.commandapi.arguments.EntitySelectorArgument;
@@ -11,7 +9,6 @@ import io.papermc.paper.datacomponent.item.DeathProtection;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.items.ItemBuilder;
-import io.th0rgal.oraxen.packets.PacketAdapter;
 import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.VersionUtil;
 import org.bukkit.EntityEffect;
@@ -25,8 +22,6 @@ import java.util.Locale;
 import java.util.stream.Stream;
 
 public class TotemAnimationCommand {
-
-    private static final int TOTEM_ANIMATION_STATUS = 35;
 
     CommandAPICommand getTotemAnimationCommand() {
         return new CommandAPICommand("totem-animation")
@@ -99,9 +94,6 @@ public class TotemAnimationCommand {
     private void sendTotemStatus(Player target) {
         if (VersionUtil.isPaperServer()) {
             target.sendEntityEffect(EntityEffect.PROTECTED_FROM_DEATH, target);
-        } else if (PacketAdapter.isPacketEventsEnabled()) {
-            PacketEvents.getAPI().getPlayerManager()
-                    .sendPacket(target, new WrapperPlayServerEntityStatus(target.getEntityId(), TOTEM_ANIMATION_STATUS));
         } else {
             target.playEffect(EntityEffect.TOTEM_RESURRECT);
         }

--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -65,7 +65,6 @@ public class ConfigsManager {
     private File itemsFolder;
     private File glyphsFolder;
     private File schematicsFolder;
-    private File gesturesFolder;
 
     public ConfigsManager(JavaPlugin plugin) {
         this.plugin = plugin;
@@ -169,14 +168,6 @@ public class ConfigsManager {
             schematicsFolder.mkdirs();
             if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
                 tempManager.extractConfigsInFolder("schematics", "schem");
-        }
-
-        // check gestures
-        gesturesFolder = new File(plugin.getDataFolder(), "gestures");
-        if (!gesturesFolder.exists()) {
-            gesturesFolder.mkdirs();
-            if (Settings.GENERATE_DEFAULT_CONFIGS.toBool())
-                tempManager.extractConfigsInFolder("gestures", "yml");
         }
 
     }

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -137,6 +137,8 @@ public enum Settings {
 
     POLYMATH_SERVER("Pack.upload.polymath.server"),
     POLYMATH_SECRET("Pack.upload.polymath.secret"),
+    LOBFILE_API_KEY("Pack.upload.lobfile.api-key"),
+    LOBFILE_PACK_NAME("Pack.upload.lobfile.pack-name"),
 
     SEND_PRE_JOIN("Pack.dispatch.send_pre_join"),
     SEND_ON_JOIN("Pack.dispatch.send_on_join"),

--- a/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/Settings.java
@@ -75,6 +75,8 @@ public enum Settings {
     // ItemUpdater
     UPDATE_ITEMS("ItemUpdater.update_items"),
     UPDATE_ITEMS_ON_RELOAD("ItemUpdater.update_items_on_reload"),
+    UPDATE_TILE_ENTITY_CONTENTS("ItemUpdater.update_tile_entity_contents"),
+    UPDATE_ENTITY_CONTENTS("ItemUpdater.update_entity_contents"),
     OVERRIDE_RENAMED_ITEMS("ItemUpdater.override_renamed_items"),
     OVERRIDE_ITEM_LORE("ItemUpdater.override_item_lore"),
 

--- a/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
+++ b/core/src/main/java/io/th0rgal/oraxen/items/ItemUpdater.java
@@ -1,5 +1,6 @@
 package io.th0rgal.oraxen.items;
 
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
 import com.jeff_media.morepersistentdatatypes.DataType;
 import com.jeff_media.persistentdataserializer.PersistentDataSerializer;
 import io.th0rgal.oraxen.OraxenPlugin;
@@ -10,10 +11,20 @@ import io.th0rgal.oraxen.utils.AdventureUtils;
 import io.th0rgal.oraxen.utils.ItemUtils;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
 import io.th0rgal.oraxen.utils.VersionUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -26,7 +37,11 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.*;
@@ -39,17 +54,55 @@ import static io.th0rgal.oraxen.items.ItemBuilder.UNSTACKABLE_KEY;
 
 public class ItemUpdater implements Listener {
 
+    private static final Set<Material> TILE_ENTITY_TYPES = EnumSet.of(
+            Material.BARREL,
+            Material.CHEST,
+            Material.TRAPPED_CHEST,
+            Material.CRAFTER,
+            Material.DECORATED_POT,
+            Material.HOPPER,
+            Material.DROPPER,
+            Material.DISPENSER,
+            Material.CAMPFIRE,
+            Material.SOUL_CAMPFIRE,
+            Material.SMOKER,
+            Material.FURNACE,
+            Material.BLAST_FURNACE,
+            Material.BREWING_STAND,
+            Material.JUKEBOX
+    );
+
+    static {
+        TILE_ENTITY_TYPES.addAll(Tag.SHULKER_BOXES.getValues());
+    }
+
+    public ItemUpdater() {
+        if (!Settings.UPDATE_ITEMS.toBool()) return;
+        SchedulerUtil.runTaskLater(OraxenPlugin.get(), 2L, ItemUpdater::updateLoadedContents);
+    }
+
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         if (!Settings.UPDATE_ITEMS.toBool()) return;
 
-        PlayerInventory inventory = event.getPlayer().getInventory();
-        for (int i = 0; i < inventory.getSize(); i++) {
-            ItemStack oldItem = inventory.getItem(i);
-            ItemStack newItem = ItemUpdater.updateItem(oldItem);
-            if (oldItem == null || oldItem.equals(newItem)) continue;
-            inventory.setItem(i, newItem);
-        }
+        updateInventory(event.getPlayer().getInventory());
+        updateInventory(event.getPlayer().getEnderChest());
+    }
+
+    @EventHandler
+    public void onEntityLoad(EntityAddToWorldEvent event) {
+        if (!Settings.UPDATE_ITEMS.toBool() || !Settings.UPDATE_ENTITY_CONTENTS.toBool()) return;
+
+        Entity entity = event.getEntity();
+        SchedulerUtil.runForEntityLater(entity, 2L, () -> updateEntityInventories(entity), () -> {});
+    }
+
+    @EventHandler
+    public void onChunkLoad(ChunkLoadEvent event) {
+        if (!Settings.UPDATE_ITEMS.toBool() || !Settings.UPDATE_TILE_ENTITY_CONTENTS.toBool() || event.isNewChunk()) return;
+
+        Chunk chunk = event.getChunk();
+        SchedulerUtil.runAtLocation(chunkLocation(chunk), () -> updateTileEntityInventories(chunk));
     }
 
     @EventHandler
@@ -144,6 +197,73 @@ public class ItemUpdater implements Listener {
 
     private static final NamespacedKey IF_UUID = Objects.requireNonNull(NamespacedKey.fromString("oraxen:if-uuid"));
     private static final NamespacedKey MF_GUI = Objects.requireNonNull(NamespacedKey.fromString("oraxen:mf-gui"));
+
+    public static void updateLoadedEntityContents() {
+        if (!Settings.UPDATE_ITEMS.toBool() || !Settings.UPDATE_ENTITY_CONTENTS.toBool()) return;
+
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                SchedulerUtil.runForEntity(entity, () -> updateEntityInventories(entity), () -> {});
+            }
+        }
+    }
+
+    private static void updateLoadedContents() {
+        updateLoadedEntityContents();
+
+        if (!Settings.UPDATE_TILE_ENTITY_CONTENTS.toBool()) return;
+        for (World world : Bukkit.getWorlds()) {
+            for (Chunk chunk : world.getLoadedChunks()) {
+                SchedulerUtil.runAtLocation(chunkLocation(chunk), () -> updateTileEntityInventories(chunk));
+            }
+        }
+    }
+
+    private static Location chunkLocation(Chunk chunk) {
+        return new Location(chunk.getWorld(), chunk.getX() * 16, 0, chunk.getZ() * 16);
+    }
+
+    private static void updateTileEntityInventories(Chunk chunk) {
+        for (BlockState tileEntity : chunk.getTileEntities()) {
+            if (!TILE_ENTITY_TYPES.contains(tileEntity.getType()) || !(tileEntity instanceof InventoryHolder holder)) continue;
+            updateInventory(holder.getInventory());
+        }
+    }
+
+    public static void updateEntityInventories(Entity entity) {
+        if (entity instanceof ItemFrame itemFrame) itemFrame.setItem(updateItem(itemFrame.getItem()), false);
+        if (entity instanceof ItemDisplay itemDisplay) itemDisplay.setItemStack(updateItem(itemDisplay.getItemStack()));
+        if (entity instanceof Item item) item.setItemStack(updateItem(item.getItemStack()));
+        if (entity instanceof InventoryHolder holder) updateInventory(holder.getInventory());
+        if (entity instanceof Player player) updateInventory(player.getEnderChest());
+        if (entity instanceof LivingEntity livingEntity) updateEquipment(livingEntity);
+    }
+
+    private static void updateEquipment(LivingEntity livingEntity) {
+        EntityEquipment equipment = livingEntity.getEquipment();
+        if (equipment == null) return;
+
+        for (EquipmentSlot slot : EquipmentSlot.values()) {
+            try {
+                ItemStack oldItem = equipment.getItem(slot);
+                ItemStack newItem = updateItem(oldItem);
+                if (oldItem == null || oldItem.equals(newItem)) continue;
+                equipment.setItem(slot, newItem);
+            } catch (IllegalArgumentException ignored) {
+                // Some entity types do not support every slot exposed by the API.
+            }
+        }
+    }
+
+    public static void updateInventory(Inventory inventory) {
+        for (int i = 0; i < inventory.getSize(); i++) {
+            ItemStack oldItem = inventory.getItem(i);
+            ItemStack newItem = updateItem(oldItem);
+            if (oldItem == null || oldItem.equals(newItem)) continue;
+            inventory.setItem(i, newItem);
+        }
+    }
+
     public static ItemStack updateItem(ItemStack oldItem) {
         String id = OraxenItems.getIdByItem(oldItem);
         if (id == null) return oldItem;

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/shaped/ShapedBlockMechanicListener.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/shaped/ShapedBlockMechanicListener.java
@@ -220,15 +220,19 @@ public class ShapedBlockMechanicListener implements Listener {
         if (!event.isNewChunk()) return;
 
         Chunk chunk = event.getChunk();
+        Location chunkLocation = new Location(chunk.getWorld(), chunk.getX() << 4,
+            chunk.getWorld().getMinHeight(), chunk.getZ() << 4);
 
         // Schedule conversion for next tick to ensure chunk is fully loaded
-        SchedulerUtil.runTaskLater(1L, () -> convertWaxedCopperInChunk(chunk));
+        SchedulerUtil.runAtLocationLater(chunkLocation, 1L, () -> convertWaxedCopperInChunk(chunk));
     }
 
     /**
      * Convert all waxed copper blocks in a chunk to non-waxed variants.
      */
     private void convertWaxedCopperInChunk(Chunk chunk) {
+        if (!chunk.isLoaded()) return;
+
         int minY = chunk.getWorld().getMinHeight();
         int maxY = chunk.getWorld().getMaxHeight();
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/MultiVersionPackGenerator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/MultiVersionPackGenerator.java
@@ -61,7 +61,7 @@ import java.util.List;
  *   generation:
  *     multi_version_packs: true
  *   upload:
- *     type: polymath  # self-host is not supported for multi-version
+ *     type: lobfile  # self-host is not supported for multi-version
  * </pre>
  *
  * @see PackVersionManager

--- a/core/src/main/java/io/th0rgal/oraxen/pack/generation/MultiVersionPackValidator.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/generation/MultiVersionPackValidator.java
@@ -32,7 +32,7 @@ public final class MultiVersionPackValidator {
         if ("self-host".equals(uploadType)) {
             Logs.logError("Multi-version packs are incompatible with 'self-host' upload type!");
             Logs.logError("Self-host can only serve a single pack file at /pack.zip");
-            Logs.logError("Change 'Pack.upload.type' to 'polymath' or 'external' to use multi-version packs");
+            Logs.logError("Change 'Pack.upload.type' to 'lobfile', 'polymath', or 'external' to use multi-version packs");
             hasErrors = true;
         }
 

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/HostingProviderFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/HostingProviderFactory.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.pack.upload;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Settings;
 import io.th0rgal.oraxen.pack.upload.hosts.HostingProvider;
+import io.th0rgal.oraxen.pack.upload.hosts.Lobfile;
 import io.th0rgal.oraxen.pack.upload.hosts.Polymath;
 import io.th0rgal.oraxen.utils.logs.Logs;
 import org.bukkit.configuration.ConfigurationSection;
@@ -34,6 +35,11 @@ public final class HostingProviderFactory {
     public static HostingProvider createHostingProvider(boolean allowSelfHost) {
         HostingProvider provider = switch (Settings.UPLOAD_TYPE.toString().toLowerCase(Locale.ROOT)) {
             case "polymath" -> new Polymath(Settings.POLYMATH_SERVER.toString());
+            case "lobfile" -> {
+                ConfigurationSection lobfileConfig = OraxenPlugin.get().getConfigsManager().getSettings()
+                        .getConfigurationSection("Pack.upload.lobfile");
+                yield new Lobfile(lobfileConfig);
+            }
             case "self-host" -> {
                 if (!allowSelfHost) {
                     Logs.logError("SelfHost cannot be used with multi-version packs, falling back to Polymath");

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/MultiVersionUploadManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/MultiVersionUploadManager.java
@@ -169,7 +169,7 @@ public class MultiVersionUploadManager {
         EventUtils.callEvent(event);
 
         // Upload pack (provider calculates SHA-1 internally)
-        boolean success = provider.uploadPack(packVersion.getPackFile());
+        boolean success = provider.uploadPack(packVersion.getPackFile(), packVersion.getMinecraftVersion());
         if (!success) {
             throw new IOException("Failed to upload pack");
         }

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/HostingProvider.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/HostingProvider.java
@@ -7,6 +7,10 @@ public interface HostingProvider {
 
     boolean uploadPack(File resourcePack);
 
+    default boolean uploadPack(File resourcePack, String packName) {
+        return uploadPack(resourcePack);
+    }
+
     String getPackURL();
 
     byte[] getSHA1();

--- a/core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/Lobfile.java
+++ b/core/src/main/java/io/th0rgal/oraxen/pack/upload/hosts/Lobfile.java
@@ -1,0 +1,179 @@
+package io.th0rgal.oraxen.pack.upload.hosts;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import io.th0rgal.oraxen.utils.SHA1Utils;
+import io.th0rgal.oraxen.utils.logs.Logs;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.bukkit.configuration.ConfigurationSection;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+import java.util.UUID;
+
+public class Lobfile implements HostingProvider {
+
+    private static final String UPLOAD_URL = "https://lobfile.com/api/v3/upload";
+    private static final String DEFAULT_PACK_NAME = "Oraxen";
+
+    private final String apiKey;
+    private final String packName;
+    private String packUrl;
+    private String sha1;
+    private UUID packUUID;
+
+    public Lobfile(ConfigurationSection config) {
+        this(
+                config != null ? config.getString("api-key", "") : "",
+                config != null ? config.getString("pack-name", DEFAULT_PACK_NAME) : DEFAULT_PACK_NAME
+        );
+    }
+
+    Lobfile(String apiKey, String packName) {
+        this.apiKey = apiKey != null ? apiKey.trim() : "";
+        this.packName = sanitizePackName(packName);
+    }
+
+    @Override
+    public boolean uploadPack(File resourcePack) {
+        return uploadPackWithName(resourcePack, packName);
+    }
+
+    @Override
+    public boolean uploadPack(File resourcePack, String packVersion) {
+        return uploadPackWithName(resourcePack, buildVersionedPackName(packVersion));
+    }
+
+    private boolean uploadPackWithName(File resourcePack, String uploadPackName) {
+        if (apiKey.isBlank()) {
+            Logs.logError("The Lobfile resource pack could not be uploaded because Pack.upload.lobfile.api-key is not set.");
+            return false;
+        }
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            calculateSHA1(resourcePack);
+
+            HttpPost request = new HttpPost(UPLOAD_URL);
+            request.setHeader("X-API-Key", apiKey);
+            request.setEntity(createUploadEntity(resourcePack, uploadPackName));
+
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                String responseString = EntityUtils.toString(response.getEntity());
+                JsonObject jsonOutput = parseResponse(responseString);
+                if (jsonOutput == null) return false;
+
+                if (jsonOutput.has("success") && jsonOutput.get("success").getAsBoolean() && jsonOutput.has("url")) {
+                    packUrl = jsonOutput.get("url").getAsString();
+                    return true;
+                }
+
+                logUploadError(jsonOutput);
+                return false;
+            }
+        } catch (IllegalStateException | IOException | NoSuchAlgorithmException ex) {
+            Logs.logError("The resource pack has not been uploaded to Lobfile.");
+            if (ex.getMessage() != null) Logs.logWarning(ex.getMessage());
+            if (io.th0rgal.oraxen.config.Settings.DEBUG.toBool()) ex.printStackTrace();
+            return false;
+        }
+    }
+
+    private HttpEntity createUploadEntity(File resourcePack, String uploadPackName) throws IOException, NoSuchAlgorithmException {
+        return MultipartEntityBuilder.create()
+                .addBinaryBody("file", resourcePack, ContentType.APPLICATION_OCTET_STREAM, buildUploadFileName(uploadPackName))
+                .addTextBody("sha_256", digest(resourcePack, "SHA-256"))
+                .build();
+    }
+
+    private void calculateSHA1(File file) throws IOException, NoSuchAlgorithmException {
+        sha1 = digest(file, "SHA-1");
+        packUUID = UUID.nameUUIDFromBytes(sha1.getBytes());
+    }
+
+    private static String digest(File file, String algorithm) throws IOException, NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance(algorithm);
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return SHA1Utils.bytesToHex(digest.digest());
+    }
+
+    private JsonObject parseResponse(String responseString) {
+        try {
+            return JsonParser.parseString(responseString).getAsJsonObject();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            Logs.logError("The resource pack could not be uploaded to Lobfile due to a malformed response.");
+            Logs.logWarning("Response: " + responseString);
+            return null;
+        }
+    }
+
+    private void logUploadError(JsonObject jsonOutput) {
+        if (jsonOutput.has("error")) {
+            JsonElement error = jsonOutput.get("error");
+            Logs.logError("Lobfile error: " + (error.isJsonPrimitive() ? error.getAsString() : error));
+        } else {
+            Logs.logError("Lobfile did not return an upload URL.");
+        }
+        Logs.logError("Response: " + jsonOutput);
+    }
+
+    @NotNull
+    static String buildUploadFileName(String packName) {
+        String sanitized = sanitizePackName(packName);
+        return sanitized.toLowerCase(Locale.ROOT).endsWith(".zip") ? sanitized : sanitized + ".zip";
+    }
+
+    @NotNull
+    static String sanitizePackName(String packName) {
+        if (packName == null || packName.isBlank()) return DEFAULT_PACK_NAME;
+        String sanitized = packName.trim().replaceAll("[^A-Za-z0-9._-]", "_");
+        return sanitized.isBlank() ? DEFAULT_PACK_NAME : sanitized;
+    }
+
+    @NotNull
+    String buildVersionedPackName(String packVersion) {
+        String baseName = packName.toLowerCase(Locale.ROOT).endsWith(".zip")
+                ? packName.substring(0, packName.length() - 4)
+                : packName;
+        return baseName + "_" + sanitizePackName(packVersion);
+    }
+
+    @Override
+    public String getPackURL() {
+        return packUrl;
+    }
+
+    @Override
+    public byte[] getSHA1() {
+        return SHA1Utils.hexToBytes(sha1);
+    }
+
+    @Override
+    public String getOriginalSHA1() {
+        return sha1;
+    }
+
+    @Override
+    public UUID getPackUUID() {
+        return packUUID;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/BlastingLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/BlastingLoader.java
@@ -15,7 +15,7 @@ public class BlastingLoader extends RecipeLoader {
 		if (inputSection == null) return;
 		RecipeChoice recipeChoice = getRecipeChoice(inputSection);
 		if (recipeChoice == null) return;
-		BlastingRecipe recipe = new BlastingRecipe(getNamespacedKey(), getResult(),
+		BlastingRecipe recipe = new BlastingRecipe(getNamespacedKey(), getValidResult(),
 				recipeChoice, getSection().getInt("experience"), getSection().getInt("cookingTime"));
 		loadRecipe(recipe);
 	}

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/CampfireLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/CampfireLoader.java
@@ -15,7 +15,7 @@ public class CampfireLoader extends RecipeLoader {
 		if (inputSection == null) return;
 		RecipeChoice recipeChoice = getRecipeChoice(inputSection);
 		if (recipeChoice == null) return;
-		CampfireRecipe recipe = new CampfireRecipe(getNamespacedKey(), getResult(),
+		CampfireRecipe recipe = new CampfireRecipe(getNamespacedKey(), getValidResult(),
 				recipeChoice, getSection().getInt("experience"), getSection().getInt("cookingTime"));
 		loadRecipe(recipe);
 	}

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/FurnaceLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/FurnaceLoader.java
@@ -16,7 +16,7 @@ public class FurnaceLoader extends RecipeLoader {
         if (inputSection == null) return;
         RecipeChoice recipeChoice = getRecipeChoice(inputSection);
         if (recipeChoice == null) return;
-        FurnaceRecipe recipe = new FurnaceRecipe(getNamespacedKey(), getResult(),
+        FurnaceRecipe recipe = new FurnaceRecipe(getNamespacedKey(), getValidResult(),
                 recipeChoice, getSection().getInt("experience"), getSection().getInt("cookingTime"));
         // addToWhitelistedRecipes(recipe); <- no whitelist for furnace recipes
         loadRecipe(recipe);

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/RecipeLoader.java
@@ -54,6 +54,13 @@ public abstract class RecipeLoader {
         return result;
     }
 
+    protected ItemStack getValidResult() {
+        ItemStack result = getResult();
+        if (result == null || result.isEmpty())
+            throw new IllegalArgumentException("Recipe result is missing or invalid");
+        return result;
+    }
+
     protected ItemStack getIndredientItemStack(ConfigurationSection ingredientSection) {
         if (ingredientSection.isString("oraxen_item"))
             return ItemUpdater.updateItem(OraxenItems.getItemById(ingredientSection.getString("oraxen_item")).build());

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/ShapedLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/ShapedLoader.java
@@ -15,7 +15,7 @@ public class ShapedLoader extends RecipeLoader {
 
     @Override
     public void registerRecipe() {
-        ShapedRecipe recipe = new ShapedRecipe(getNamespacedKey(), getResult());
+        ShapedRecipe recipe = new ShapedRecipe(getNamespacedKey(), getValidResult());
 
         List<String> shape = getSection().getStringList("shape");
         recipe.shape(shape.toArray(new String[0]));

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/ShapelessLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/ShapelessLoader.java
@@ -14,7 +14,7 @@ public class ShapelessLoader extends RecipeLoader {
 
     @Override
     public void registerRecipe() {
-        ShapelessRecipe recipe = new ShapelessRecipe(getNamespacedKey(), getResult());
+        ShapelessRecipe recipe = new ShapelessRecipe(getNamespacedKey(), getValidResult());
         ConfigurationSection ingredientsSection = getSection().getConfigurationSection("ingredients");
 
         for (String ingredientLetter : Objects.requireNonNull(ingredientsSection).getKeys(false)) {

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/SmokingLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/SmokingLoader.java
@@ -15,7 +15,7 @@ public class SmokingLoader extends RecipeLoader {
 		if (inputSection == null) return;
 		RecipeChoice recipeChoice = getRecipeChoice(inputSection);
 		if (recipeChoice == null) return;
-		SmokingRecipe recipe = new SmokingRecipe(getNamespacedKey(), getResult(),
+		SmokingRecipe recipe = new SmokingRecipe(getNamespacedKey(), getValidResult(),
 				recipeChoice, getSection().getInt("experience"), getSection().getInt("cookingTime"));
 		loadRecipe(recipe);
 	}

--- a/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/StonecuttingLoader.java
+++ b/core/src/main/java/io/th0rgal/oraxen/recipes/loaders/StonecuttingLoader.java
@@ -15,7 +15,7 @@ public class StonecuttingLoader extends RecipeLoader {
 		if (inputSection == null) return;
 		RecipeChoice recipeChoice = getRecipeChoice(inputSection);
 		if (recipeChoice == null) return;
-		StonecuttingRecipe recipe = new StonecuttingRecipe(getNamespacedKey(), getResult(), recipeChoice);
+		StonecuttingRecipe recipe = new StonecuttingRecipe(getNamespacedKey(), getValidResult(), recipeChoice);
 		loadRecipe(recipe);
 	}
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/InvManager.java
@@ -1,6 +1,6 @@
 package io.th0rgal.oraxen.utils.inventories;
 
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
+import dev.triumphteam.gui.guis.Gui;
 import dev.triumphteam.gui.guis.PaginatedGui;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
 import org.bukkit.entity.Player;
@@ -27,7 +27,7 @@ public class InvManager {
     }
 
 
-    public ChestGui getRecipesShowcase(final int page, final List<CustomRecipe> filteredRecipes) {
+    public Gui getRecipesShowcase(final int page, final List<CustomRecipe> filteredRecipes) {
         return new RecipesView().create(page, filteredRecipes);
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/utils/inventories/RecipesView.java
+++ b/core/src/main/java/io/th0rgal/oraxen/utils/inventories/RecipesView.java
@@ -1,14 +1,14 @@
 package io.th0rgal.oraxen.utils.inventories;
 
-import com.github.stefvanschie.inventoryframework.gui.GuiItem;
-import com.github.stefvanschie.inventoryframework.gui.type.ChestGui;
-import com.github.stefvanschie.inventoryframework.pane.StaticPane;
+import dev.triumphteam.gui.guis.Gui;
+import dev.triumphteam.gui.guis.GuiItem;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.font.FontManager;
 import io.th0rgal.oraxen.items.ItemBuilder;
 import io.th0rgal.oraxen.recipes.CustomRecipe;
+import io.th0rgal.oraxen.utils.AdventureUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -22,53 +22,51 @@ public class RecipesView {
             fontManager.getShift(-7) +
             fontManager.getGlyphFromName("menu_recipe").getCharacter();
 
-    public ChestGui create(final int page, final List<CustomRecipe> filteredRecipes) {
-        final ChestGui gui = new ChestGui(6, menuTexture);
+    public Gui create(final int page, final List<CustomRecipe> filteredRecipes) {
+        final Gui gui = Gui.gui().rows(6).title(AdventureUtils.LEGACY_SERIALIZER.deserialize(menuTexture)).create();
 
         final CustomRecipe currentRecipe = filteredRecipes.get(page);
 
         // Check if last page
         final boolean lastPage = filteredRecipes.size() - 1 == page;
-        final StaticPane pane = new StaticPane(9, 6);
-        pane.addItem(new GuiItem(currentRecipe.getResult()), 4, 0);
+        gui.setItem(1, 5, new GuiItem(currentRecipe.getResult()));
 
         for (int i = 0; i < currentRecipe.getIngredients().size(); i++) {
             final ItemStack itemStack = currentRecipe.getIngredients().get(i);
             if (itemStack != null && itemStack.getType() != Material.AIR)
-                pane.addItem(new GuiItem(itemStack), 3 + i % 3, 2 + i / 3);
+                gui.setItem(3 + i / 3, 4 + i % 3, new GuiItem(itemStack));
         }
 
         // Close RecipeShowcase inventory button
-        pane.addItem(new GuiItem((OraxenItems.getItemById("exit_icon") == null
+        gui.setItem(6, 5, new GuiItem((OraxenItems.getItemById("exit_icon") == null
                 ? new ItemBuilder(Material.BARRIER)
                 : OraxenItems.getItemById("exit_icon"))
                 .setDisplayName(Message.EXIT_MENU).build(),
-                (event -> event.getWhoClicked().closeInventory())), 4, 5);
+                (event -> event.getWhoClicked().closeInventory())));
 
         // Previous Page button
         if (page > 0)
-            pane.addItem(new GuiItem((OraxenItems.getItemById("arrow_previous_icon") == null
+            gui.setItem(4, 2, new GuiItem((OraxenItems.getItemById("arrow_previous_icon") == null
                     ? new ItemBuilder(Material.ARROW)
                     : OraxenItems.getItemById("arrow_previous_icon"))
                     .setDisplayName(ChatColor.YELLOW + "Open page " + page)
                     .build(),
                     event -> create(page - 1,
-                            filteredRecipes).show(event.getWhoClicked())),
-                    1, 3);
+                            filteredRecipes).open(event.getWhoClicked())));
 
         // Next page button
         if (!lastPage)
-            pane.addItem(new GuiItem((OraxenItems.getItemById("arrow_next_icon") == null
+            gui.setItem(4, 8, new GuiItem((OraxenItems.getItemById("arrow_next_icon") == null
                     ? new ItemBuilder(Material.ARROW)
                     : OraxenItems.getItemById("arrow_next_icon"))
                     .setDisplayName(ChatColor.YELLOW + "Open page " + (page + 2))
                     .build(),
                     event -> create(page + 1, filteredRecipes)
-                            .show(event.getWhoClicked())),
-                    7, 3);
+                            .open(event.getWhoClicked())));
 
-        gui.addPane(pane);
-        gui.setOnGlobalClick(event -> event.setCancelled(true));
+        gui.setDefaultClickAction(event -> event.setCancelled(true));
+        gui.setOutsideClickAction(event -> event.setCancelled(true));
+        gui.setDragAction(event -> event.setCancelled(true));
         return gui;
     }
 

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -84,6 +84,8 @@ CustomBlocks:
 ItemUpdater:
   # Update the items in player inventory to the latest in config when player joins
   update_items: true
+  update_tile_entity_contents: true # Update items in loaded block inventories, such as chests and furnaces
+  update_entity_contents: true # Update items held by loaded entities, such as item frames, mobs and ender chests
   override_renamed_items: false
   override_item_lore: false # If lore should be overriden, enable to ensure it is identical to the OraxenItem's lore
   update_items_on_reload: true # If Oraxen should update all the items of online players on /oraxen reload items/all

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -113,7 +113,7 @@ Pack:
     #
     # Requirements:
     # - ViaVersion OR ProtocolSupport plugin for version detection (without these, all players get server version pack)
-    # - Upload type must be "polymath" or "external" (NOT "self-host" - can only serve one file)
+    # - Upload type must be "lobfile", "polymath", or "external" (NOT "self-host" - can only serve one file)
     #
     # How it works:
     # - On player join, detects their client version via ViaVersion/ProtocolSupport API
@@ -203,10 +203,13 @@ Pack:
 
   upload:
     enabled: true
-    type: polymath #transfer.sh, polymath, or self-host
+    type: polymath #lobfile, polymath, self-host, or external
     polymath:
       server: atlas.oraxen.com # you can also host your own polymath instance
       secret: "oraxen" # change this if you host your own polymath to limit access to resource pack uploading
+    lobfile:
+      api-key: ""
+      pack-name: Oraxen
     self-host:
       host: "0.0.0.0" # The IP address to bind the HTTP server to (0.0.0.0 = listen on all interfaces)
       port: 8080 # The port the HTTP server will listen on

--- a/core/src/main/resources/settings.yml
+++ b/core/src/main/resources/settings.yml
@@ -209,7 +209,7 @@ Pack:
       secret: "oraxen" # change this if you host your own polymath to limit access to resource pack uploading
     lobfile:
       api-key: ""
-      pack-name: Oraxen
+      pack-name: Oraxen # Will use <pack-name>_<version> when using multi version packs
     self-host:
       host: "0.0.0.0" # The IP address to bind the HTTP server to (0.0.0.0 = listen on all interfaces)
       port: 8080 # The port the HTTP server will listen on

--- a/core/src/test/java/io/th0rgal/oraxen/pack/upload/hosts/LobfileTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/pack/upload/hosts/LobfileTest.java
@@ -1,0 +1,37 @@
+package io.th0rgal.oraxen.pack.upload.hosts;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LobfileTest {
+
+    @Test
+    void buildUploadFileName_appendsZipExtension() {
+        assertEquals("Oraxen_1.21.4.zip", Lobfile.buildUploadFileName("Oraxen_1.21.4"));
+    }
+
+    @Test
+    void buildUploadFileName_keepsExistingZipExtension() {
+        assertEquals("Oraxen.zip", Lobfile.buildUploadFileName("Oraxen.zip"));
+    }
+
+    @Test
+    void buildUploadFileName_sanitizesUnsafeCharacters() {
+        assertEquals("Oraxen_Pack_1.21.4.zip", Lobfile.buildUploadFileName("Oraxen Pack/1.21.4"));
+    }
+
+    @Test
+    void buildVersionedPackName_usesConfiguredBaseNameAndVersion() {
+        Lobfile lobfile = new Lobfile("api-key", "Oraxen");
+
+        assertEquals("Oraxen_1.21.4", lobfile.buildVersionedPackName("1.21.4"));
+    }
+
+    @Test
+    void buildVersionedPackName_stripsZipExtensionFromConfiguredBaseName() {
+        Lobfile lobfile = new Lobfile("api-key", "Oraxen.zip");
+
+        assertEquals("Oraxen_1.21.4", lobfile.buildVersionedPackName("1.21.4"));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.214.0
+pluginVersion=1.215.0

--- a/gradle/oraxenLibs.versions.toml
+++ b/gradle/oraxenLibs.versions.toml
@@ -125,10 +125,6 @@ javax-json = { module = "org.glassfish:javax.json", version = "1.1.4" }
 # Repo: https://repo.oraxen.com/releases/
 protectionlib = { module = "io.th0rgal:protectionlib", version = "1.8.1" }
 
-# InventoryFramework https://github.com/stefvanschie/IF
-# Repo: Maven Central
-inventoryframework = { module = "com.github.stefvanschie.inventoryframework:IF", version = "0.11.6" }
-
 # Repo: Maven Central
 # https://github.com/mfnalex/CustomBlockData
 custom-block-data = { module = "com.jeff-media:custom-block-data", version = "2.2.5" }
@@ -170,7 +166,6 @@ libraries-shade = [
     "triumph-gui",
     "javax-json",
     "protectionlib",
-    "inventoryframework",
     "custom-block-data",
     "more-persistent-data-types",
     "persistent-data-serializer",


### PR DESCRIPTION
## 🟢 Oraxen v1.215.0

### 🟠 fix: Folia Shaped Block Chunk Conversion
- **Summary** - Schedule shaped-block waxed copper chunk conversion on the chunk's region thread instead of the Folia global scheduler.
- **Description** - Newly generated chunks can trigger waxed copper conversion after load. On Folia 1.21.11, running that delayed conversion globally can read block state from the wrong context and hit a null `Level.getCurrentWorldData()` path. The conversion now uses `SchedulerUtil.runAtLocationLater` with the chunk location and skips work if the chunk unloads before the delayed task runs.

- **Changes** - Updated `ShapedBlockMechanicListener#onChunkLoad` to dispatch conversion through the region scheduler, and added an `isLoaded` guard before scanning chunk blocks.

### 🟠 fix: Optional PacketEvents Startup
- **Summary** - Keep Oraxen command registration from hard-requiring PacketEvents when the optional plugin is not installed.
- **Description** - Oraxen 1.214.0 added the totem animation command with direct PacketEvents class references. Servers without PacketEvents could throw `NoClassDefFoundError: com/github/retrooper/packetevents/wrapper/PacketWrapper` while enabling Oraxen, disabling the plugin and preventing players from joining through setups such as Velocity. The command now uses Bukkit/Paper entity effect APIs without loading PacketEvents classes.
- **Changes** - Removed direct PacketEvents usage from `TotemAnimationCommand`.

### 🟠 fix: Recipe Result Validation
- **Summary** - Prevent invalid recipe outputs from being passed into Bukkit recipe constructors.
- **Description** - Recipe configurations with invalid or missing outputs could result in null `ItemStack` results being silently passed into Bukkit recipe constructors, causing errors that were difficult to trace back to the misconfigured recipe.
- **Changes** - Added shared recipe result validation so invalid recipe outputs are reported before null `ItemStack` results are passed into Bukkit recipe constructors.

### 🟠 feat: Loaded Item State Updates
- **Summary** - Update loaded item state beyond player inventories so existing in-world and loaded container items are refreshed safely.
- **Description** - Oraxen now applies the existing item update routine to loaded entities, entity inventories and equipment, player ender chests, and loaded tile-entity inventories. Startup, entity load, chunk load, player join, and item reload paths now cover loaded server state without editing offline playerdata from disk.

- **Changes** - Added loaded entity and tile-entity updater gates, scheduled startup and chunk/entity scans through existing Folia-safe scheduler helpers, reused `ItemUpdater.updateItem` for all touched inventories, and updated reload handling to refresh ender chests plus loaded entity contents.

### 🟠 chore: TriumphGUI Inventory Migration
- **Summary** - Replace Oraxen’s remaining InventoryFramework GUI usage with TriumphGUI to improve Oraxen jar size.
- **Description** - The recipe showcase inventory now uses TriumphGUI while preserving its existing 6-row layout, recipe/result slots, close button, previous/next navigation, click cancellation, drag cancellation, and outside-click handling. InventoryFramework is no longer declared in the shaded dependency bundle or documentation. **This improved the Oraxen `.jar` size from 5.1MB to 3.2MB.**

- **Changes** - Migrated `RecipesView`, updated recipe showcase opening through `InvManager`/`RecipesCommand`, removed the InventoryFramework version catalog entry from `libraries-shade`, and cleaned obsolete InventoryFramework documentation references.

### 🟠 chore: CodeFactor NMS Handler Exclusions
- **Summary** - Exclude version-specific NMS handler adapters from CodeFactor analysis.
- **Description** - CodeFactor’s remaining C-grade files were version-bound `NMSHandler` adapters whose duplication comes from mirroring Minecraft internals across supported server versions. The furniture file already shows no active CodeFactor issues on its detail page, so behavior-sensitive gameplay code was left unchanged.

- **Changes** - Added `.codefactor.yml` with an exclude pattern for versioned `NMSHandler.java` files so the intentional adapter duplication no longer drives repository grades.


### 🟠 chore: Stop Gestures Folder Generation
- **Summary** - Stop creating the unused `plugins/Oraxen/gestures` folder during Oraxen startup.
- **Description** - Oraxen previously initialized a `gestures` data folder and attempted to extract bundled gesture YAML configs when default config generation was enabled. No gesture resources are bundled in the current resource tree, so this startup path only produced an empty, unused folder.

- **Changes** - Removed the `gesturesFolder` field and the `validatesConfig()` block that created and populated `plugins/Oraxen/gestures`.

### 🟠 feat: Lobfile Pack Hosting
- **Summary** - Add Lobfile as a built-in pack host with support for single and multi-version resource pack uploads.
- **Description** - Oraxen can now use `Pack.upload.type: lobfile` with `Pack.upload.lobfile.api-key` and `Pack.upload.lobfile.pack-name`. Single-pack uploads use the configured pack name, while multi-version uploads name each Lobfile upload with `<lobfile.pack-name>_<version>` so multiple generated packs can coexist.

- **Changes** - Added a Lobfile hosting provider for `https://lobfile.com/api/v3/upload`, wired it into the hosting provider factory and default settings, passed version context through multi-version uploads, refreshed multi-version configuration guidance, and added tests for Lobfile upload filename generation.