### PR TITLE
Fix CommandAPI double-load error by adding classpath check

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/hopper/OraxenHopper.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hopper/OraxenHopper.java
@@ -65,7 +65,8 @@ public final class OraxenHopper {
         Platform platform = Platform.detect();
 
         BukkitHopper.register(plugin, deps -> {
-            // We check for files in the plugins folder since plugins aren't loaded yet in constructor
+            // We check for files in the plugins folder as a reliable baseline; the classpath check catches
+            // cases where the library is already loaded (e.g. installed server plugin with an atypical jar name)
             boolean hasCommandAPI = pluginJarExists(COMMANDAPI_PATTERN) || classExists("dev.jorel.commandapi.CommandAPI");
             boolean hasProtocolLib = pluginJarExists(PROTOCOLLIB_PATTERN) || classExists("com.comphenix.protocol.ProtocolLib");
             boolean hasPacketEvents = pluginJarExists(PACKETEVENTS_PATTERN) || classExists("com.github.retrooper.packetevents.PacketEvents");

--- a/core/src/main/java/io/th0rgal/oraxen/hopper/OraxenHopper.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hopper/OraxenHopper.java
@@ -66,9 +66,9 @@ public final class OraxenHopper {
 
         BukkitHopper.register(plugin, deps -> {
             // We check for files in the plugins folder since plugins aren't loaded yet in constructor
-            boolean hasCommandAPI = pluginJarExists(COMMANDAPI_PATTERN);
-            boolean hasProtocolLib = pluginJarExists(PROTOCOLLIB_PATTERN);
-            boolean hasPacketEvents = pluginJarExists(PACKETEVENTS_PATTERN);
+            boolean hasCommandAPI = pluginJarExists(COMMANDAPI_PATTERN) || classExists("dev.jorel.commandapi.CommandAPI");
+            boolean hasProtocolLib = pluginJarExists(PROTOCOLLIB_PATTERN) || classExists("com.comphenix.protocol.ProtocolLib");
+            boolean hasPacketEvents = pluginJarExists(PACKETEVENTS_PATTERN) || classExists("com.github.retrooper.packetevents.PacketEvents");
 
             // CommandAPI is required for Oraxen commands
             if (!hasCommandAPI) {
@@ -194,5 +194,14 @@ public final class OraxenHopper {
         );
 
         return files != null && files.length > 0;
+    }
+
+    private static boolean classExists(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/core/src/main/java/io/th0rgal/oraxen/hopper/OraxenHopper.java
+++ b/core/src/main/java/io/th0rgal/oraxen/hopper/OraxenHopper.java
@@ -198,9 +198,9 @@ public final class OraxenHopper {
 
     private static boolean classExists(String className) {
         try {
-            Class.forName(className);
+            Class.forName(className, false, OraxenHopper.class.getClassLoader());
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | LinkageError e) {
             return false;
         }
     }


### PR DESCRIPTION
Detects CommandAPI via classpath in addition to jar file check to prevent double `onLoad()` calls when CommandAPI is already installed on the server. Closes #1828.