### PR TITLE
Oraxen v1.216.0

### DIFF
--- a/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/ConfigsManager.java
@@ -142,6 +142,7 @@ public class ConfigsManager {
     public void validatesConfig() {
         ResourcesManager tempManager = new ResourcesManager(OraxenPlugin.get());
         mechanics = validate(tempManager, "mechanics.yml", defaultMechanics);
+        migrateLegacyBlockMechanics();
         settings = validate(tempManager, "settings.yml", defaultSettings);
         font = validate(tempManager, "font.yml", defaultFont);
         hud = validate(tempManager, "hud.yml", defaultHud);
@@ -181,6 +182,21 @@ public class ConfigsManager {
                 tempManager.extractConfigsInFolder("schematics", "schem");
         }
 
+    }
+
+    private void migrateLegacyBlockMechanics() {
+        File mechanicsFile = new File(plugin.getDataFolder(), "mechanics.yml");
+        if (!LegacyBlockMechanicMigration.migrate(mechanics))
+            return;
+
+        try {
+            MigrationBackups.moveToMigrated(plugin.getDataFolder(), mechanicsFile);
+            mechanics.save(mechanicsFile);
+            Logs.logSuccess("Migrated legacy block mechanics to the unified block mechanic");
+        } catch (IOException e) {
+            Logs.logError("Failed to save migrated mechanics.yml");
+            Logs.debug(e);
+        }
     }
 
     private void migrateLegacySoundFile() {

--- a/core/src/main/java/io/th0rgal/oraxen/config/LegacyBlockMechanicMigration.java
+++ b/core/src/main/java/io/th0rgal/oraxen/config/LegacyBlockMechanicMigration.java
@@ -1,0 +1,148 @@
+package io.th0rgal.oraxen.config;
+
+import io.th0rgal.oraxen.utils.OraxenYaml;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Migrates the pre-1.215 split block factory configuration to the unified
+ * {@code block} mechanic configuration introduced in 1.215.
+ */
+public final class LegacyBlockMechanicMigration {
+
+    private static final List<String> LEGACY_BLOCK_MECHANICS = List.of(
+            "noteblock", "stringblock", "chorusblock", "shaped_block"
+    );
+
+    private static final Map<String, String> MODERN_BLOCK_OPTION_KEYS = Map.of(
+            "tool_types", "tool-types",
+            "farmblock_check_delay", "farmblock-check-delay",
+            "sapling_growth_check_delay", "sapling-growth-check-delay",
+            "disable_vanilla_strings", "disable-vanilla-strings",
+            "remove_mineable_tag", "remove-mineable-tag",
+            "convert_vanilla_waxed", "convert-vanilla-waxed",
+            "handle_world_generation", "handle-world-generation"
+    );
+
+    private static final List<String> LEGACY_BLOCK_SOUND_KEYS = List.of(
+            "noteblock_and_block", "stringblock_and_furniture", "chorusblock"
+    );
+
+    private LegacyBlockMechanicMigration() {
+    }
+
+    public static boolean migrate(@NotNull final YamlConfiguration mechanicsConfig) {
+        final boolean soundsMigrated = migrateCustomBlockSounds(mechanicsConfig);
+        final List<ConfigurationSection> legacySections = LEGACY_BLOCK_MECHANICS.stream()
+                .map(legacyMechanic -> OraxenYaml.getConfigurationSection(mechanicsConfig, legacyMechanic))
+                .filter(section -> section != null)
+                .toList();
+        if (legacySections.isEmpty())
+            return soundsMigrated;
+
+        ConfigurationSection blockSection = OraxenYaml.getConfigurationSection(mechanicsConfig, "block");
+        if (blockSection == null) {
+            blockSection = mechanicsConfig.createSection("block");
+            OraxenYaml.invalidateKeyCache(mechanicsConfig);
+        }
+
+        final Set<String> toolTypes = new LinkedHashSet<>();
+        addToolTypes(toolTypes, blockSection, "tool-types");
+        addToolTypes(toolTypes, blockSection, "tool_types");
+
+        boolean enabled = blockSection.getBoolean("enabled", false);
+        for (final ConfigurationSection legacySection : legacySections) {
+            enabled |= legacySection.getBoolean("enabled", false);
+            addToolTypes(toolTypes, legacySection, "tool_types");
+            addToolTypes(toolTypes, legacySection, "tool-types");
+            copyLegacyFactoryOptions(legacySection, blockSection);
+        }
+
+        if (!toolTypes.isEmpty())
+            blockSection.set("tool-types", new ArrayList<>(toolTypes));
+        blockSection.set("enabled", enabled);
+        removeLegacyAliases(blockSection);
+
+        for (final String legacyMechanic : LEGACY_BLOCK_MECHANICS)
+            mechanicsConfig.set(legacyMechanic, null);
+
+        OraxenYaml.invalidateKeyCache(mechanicsConfig);
+        OraxenYaml.invalidateKeyCache(blockSection);
+        return true;
+    }
+
+    private static void copyLegacyFactoryOptions(final ConfigurationSection legacySection,
+            final ConfigurationSection blockSection) {
+        for (final String key : legacySection.getKeys(false)) {
+            if (key.equalsIgnoreCase("enabled"))
+                continue;
+
+            final String targetKey = MODERN_BLOCK_OPTION_KEYS.getOrDefault(key, key);
+            blockSection.set(targetKey, legacySection.get(key));
+        }
+    }
+
+    private static void removeLegacyAliases(final ConfigurationSection blockSection) {
+        for (final Map.Entry<String, String> alias : MODERN_BLOCK_OPTION_KEYS.entrySet()) {
+            if (!blockSection.contains(alias.getValue()))
+                continue;
+            blockSection.set(alias.getKey(), null);
+        }
+    }
+
+    private static void addToolTypes(final Set<String> toolTypes, final ConfigurationSection section, final String key) {
+        for (final Object value : section.getList(key, List.of())) {
+            if (value == null)
+                continue;
+
+            final String toolType = String.valueOf(value).trim();
+            if (toolType.isBlank() || toolType.equalsIgnoreCase("null"))
+                continue;
+
+            toolTypes.add(toolType);
+        }
+    }
+
+    private static boolean migrateCustomBlockSounds(final YamlConfiguration mechanicsConfig) {
+        final ConfigurationSection soundsSection = OraxenYaml.getConfigurationSection(mechanicsConfig, "custom_block_sounds");
+        if (soundsSection == null)
+            return false;
+
+        boolean changed = false;
+        boolean hasLegacyBlockSoundKey = false;
+        boolean blockSoundsEnabled = false;
+        for (final String legacyKey : LEGACY_BLOCK_SOUND_KEYS) {
+            if (!soundsSection.contains(legacyKey))
+                continue;
+
+            hasLegacyBlockSoundKey = true;
+            blockSoundsEnabled |= soundsSection.getBoolean(legacyKey, true);
+        }
+
+        if (hasLegacyBlockSoundKey && (!soundsSection.contains("block")
+                || soundsSection.getBoolean("block", true) != blockSoundsEnabled)) {
+            soundsSection.set("block", blockSoundsEnabled);
+            changed = true;
+        }
+
+        if (soundsSection.contains("stringblock_and_furniture")) {
+            final boolean furnitureSoundsEnabled = soundsSection.getBoolean("stringblock_and_furniture", true);
+            if (!soundsSection.contains("furniture")
+                    || soundsSection.getBoolean("furniture", true) != furnitureSoundsEnabled) {
+                soundsSection.set("furniture", furnitureSoundsEnabled);
+                changed = true;
+            }
+        }
+
+        if (changed)
+            OraxenYaml.invalidateKeyCache(soundsSection);
+        return changed;
+    }
+}

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/MechanicsManager.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.mechanics;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.api.events.OraxenNativeMechanicsRegisteredEvent;
 import io.th0rgal.oraxen.compatibilities.CompatibilitiesManager;
+import io.th0rgal.oraxen.config.LegacyBlockMechanicMigration;
 import io.th0rgal.oraxen.config.MigrationBackups;
 import io.th0rgal.oraxen.mechanics.provided.combat.knockbackstrike.KnockbackStrikeMechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.combat.bleeding.BleedingMechanicFactory;
@@ -165,28 +166,7 @@ public class MechanicsManager {
     }
 
     private static boolean migrateLegacyBlockFactory(final String mechanicId, final YamlConfiguration mechanicsConfig) {
-        if (!"block".equals(mechanicId) || OraxenYaml.getConfigurationSection(mechanicsConfig, "block") != null)
-            return false;
-
-        final List<String> legacyBlockMechanics = List.of("noteblock", "stringblock", "shaped_block");
-        if (legacyBlockMechanics.stream().noneMatch(legacyMechanic -> OraxenYaml.getConfigurationSection(mechanicsConfig, legacyMechanic) != null))
-            return false;
-
-        final ConfigurationSection blockSection = mechanicsConfig.createSection("block");
-        boolean enabled = false;
-        for (final String legacyMechanic : legacyBlockMechanics) {
-            final ConfigurationSection legacySection = OraxenYaml.getConfigurationSection(mechanicsConfig, legacyMechanic);
-            if (legacySection == null)
-                continue;
-
-            OraxenYaml.copyConfigurationSection(legacySection, blockSection);
-            enabled |= legacySection.getBoolean("enabled", false);
-            mechanicsConfig.set(legacyMechanic, null);
-        }
-        blockSection.set("enabled", enabled);
-        OraxenYaml.invalidateKeyCache(mechanicsConfig);
-        OraxenYaml.invalidateKeyCache(blockSection);
-        return true;
+        return "block".equals(mechanicId) && LegacyBlockMechanicMigration.migrate(mechanicsConfig);
     }
 
     private static void registerFactory(final String mechanicId, final FactoryConstructor constructor) {

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureFactory.java
@@ -194,7 +194,7 @@ public class FurnitureFactory extends MechanicFactory {
                         "height", MechanicConfigProperty.decimal("height", "Seat height offset", 0.0),
                         "yaw", MechanicConfigProperty.decimal("yaw", "Seat rotation", 0.0)
                 )),
-                MechanicConfigProperty.list("seats", "List of seat offsets relative to the furniture center formatted '<x>,<y>,<z>'"),
+                MechanicConfigProperty.list("seats", "List of seat offsets relative to the furniture center formatted '<x>,<y>,<z>' or '<x>,<y>,<z> <yaw>'"),
                 MechanicConfigProperty.list("barriers", "List of barrier block positions relative to furniture"),
                 MechanicConfigProperty.object("display_entity_properties", "Display entity configuration", Map.of(
                         "display_transform", MechanicConfigProperty.enumType("display_transform", "Display transform mode",

--- a/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/core/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -75,7 +75,6 @@ public class FurnitureMechanic extends Mechanic {
     public final boolean farmblockRequired;
     private final List<BlockLocation> barriers;
     private final boolean hasSeat;
-    private boolean hasSeatYaw;
     private final List<FurnitureSeat> seats;
     private final Drop drop;
     private final EvolvingFurniture evolvingFurniture;
@@ -86,7 +85,6 @@ public class FurnitureMechanic extends Mechanic {
     private final String modelEngineID;
     private final String placedItemId;
     private float seatHeight;
-    private float seatYaw;
     private final List<ClickAction> clickActions;
     private FurnitureType furnitureType;
     private final DisplayEntityProperties displayEntityProperties;
@@ -113,10 +111,18 @@ public class FurnitureMechanic extends Mechanic {
     public record FurnitureLight(BlockLocation offset, int lightLevel) {
     }
 
-    public record FurnitureSeat(double offsetX, double offsetY, double offsetZ) {
+    public record FurnitureSeat(double offsetX, double offsetY, double offsetZ, @Nullable Float yaw) {
+
+        public FurnitureSeat(double offsetX, double offsetY, double offsetZ) {
+            this(offsetX, offsetY, offsetZ, null);
+        }
 
         public Vector offset() {
             return new Vector(offsetX, offsetY, offsetZ);
+        }
+
+        public float yaw(float fallbackYaw) {
+            return yaw != null ? yaw : fallbackYaw;
         }
     }
 
@@ -339,21 +345,27 @@ public class FurnitureMechanic extends Mechanic {
         if (seatSection == null) return List.of();
 
         seatHeight = (float) seatSection.getDouble("height");
-        hasSeatYaw = seatSection.contains("yaw");
-        if (hasSeatYaw) seatYaw = (float) seatSection.getDouble("yaw");
-        return List.of(new FurnitureSeat(0, seatHeight - 1, 0));
+        boolean hasSeatYaw = seatSection.contains("yaw");
+        Float yaw = hasSeatYaw ? (float) seatSection.getDouble("yaw") : null;
+        return List.of(new FurnitureSeat(0, seatHeight - 1, 0, yaw));
     }
 
     @Nullable
     private FurnitureSeat parseSeat(Object seatObject) {
         if (!(seatObject instanceof String string)) {
-            Logs.logError("Invalid seat entry for furniture: " + getItemID() + ". Expected '<x>,<y>,<z>'.");
+            Logs.logError("Invalid seat entry for furniture: " + getItemID() + ". Expected '<x>,<y>,<z>' or '<x>,<y>,<z> <yaw>'.");
             return null;
         }
 
-        String[] offsetParts = string.trim().split("\\s*,\\s*");
+        String[] parts = string.trim().replaceAll("\\s*,\\s*", ",").split("\\s+");
+        if (parts.length < 1 || parts.length > 2) {
+            Logs.logError("Invalid seat entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z>' or '<x>,<y>,<z> <yaw>'.");
+            return null;
+        }
+
+        String[] offsetParts = parts[0].split(",");
         if (offsetParts.length != 3) {
-            Logs.logError("Invalid seat entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z>'.");
+            Logs.logError("Invalid seat entry '" + string + "' for furniture: " + getItemID() + ". Expected '<x>,<y>,<z>' or '<x>,<y>,<z> <yaw>'.");
             return null;
         }
 
@@ -361,9 +373,10 @@ public class FurnitureMechanic extends Mechanic {
             double offsetX = Double.parseDouble(offsetParts[0]);
             double offsetY = Double.parseDouble(offsetParts[1]);
             double offsetZ = Double.parseDouble(offsetParts[2]);
-            return new FurnitureSeat(offsetX, offsetY, offsetZ);
+            Float yaw = parts.length == 2 ? Float.parseFloat(parts[1]) : null;
+            return new FurnitureSeat(offsetX, offsetY, offsetZ, yaw);
         } catch (NumberFormatException exception) {
-            Logs.logError("Invalid seat entry '" + string + "' for furniture: " + getItemID() + ". Seat offsets must be numbers.");
+            Logs.logError("Invalid seat entry '" + string + "' for furniture: " + getItemID() + ". Seat offsets and yaw must be numbers.");
             return null;
         }
     }
@@ -1339,10 +1352,13 @@ public class FurnitureMechanic extends Mechanic {
     @Nullable
     private UUID spawnSeat(Location rootLocation, FurnitureSeat furnitureSeat, float yaw) {
         Vector rotatedOffset = rotateGroundOffset(furnitureSeat.offset(), yaw);
+        float rotationYaw = furnitureSeat.yaw(yaw);
         Location seatLocation = BlockHelpers.toCenterBlockLocation(rootLocation).add(rotatedOffset);
+        seatLocation.setYaw(rotationYaw);
+        seatLocation.setPitch(0);
         final ArmorStand seat = EntityUtils.spawnEntity(seatLocation, ArmorStand.class, (ArmorStand stand) -> {
             stand.setVisible(false);
-            stand.setRotation(hasSeatYaw ? seatYaw : yaw, 0);
+            stand.setRotation(rotationYaw, 0);
             stand.setInvulnerable(true);
             stand.setPersistent(true);
             stand.setAI(false);
@@ -1609,12 +1625,14 @@ public class FurnitureMechanic extends Mechanic {
             Entity seatEntity = Bukkit.getEntity(seatUuids.get(i));
             if (!(seatEntity instanceof ArmorStand seat)) continue;
 
-            Vector rotatedOffset = rotateGroundOffset(seats.get(i).offset(), yaw);
+            FurnitureSeat furnitureSeat = seats.get(i);
+            Vector rotatedOffset = rotateGroundOffset(furnitureSeat.offset(), yaw);
+            float rotationYaw = furnitureSeat.yaw(yaw);
             Location seatLocation = BlockHelpers.toCenterBlockLocation(rootLocation).add(rotatedOffset);
-            seatLocation.setYaw(hasSeatYaw ? seatYaw : yaw);
+            seatLocation.setYaw(rotationYaw);
             seatLocation.setPitch(0);
             seat.teleport(seatLocation);
-            seat.setRotation(hasSeatYaw ? seatYaw : yaw, 0);
+            seat.setRotation(rotationYaw, 0);
         }
     }
 

--- a/core/src/test/java/io/th0rgal/oraxen/config/LegacyBlockMechanicMigrationTest.java
+++ b/core/src/test/java/io/th0rgal/oraxen/config/LegacyBlockMechanicMigrationTest.java
@@ -1,0 +1,75 @@
+package io.th0rgal.oraxen.config;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LegacyBlockMechanicMigrationTest {
+
+    @Test
+    void migratesLegacySectionsEvenWhenLegacyBlockSectionExists() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("block.enabled", false);
+        config.set("block.tool_types", List.of("WOODEN"));
+        config.set("block.tool-types", List.of("STONE"));
+
+        config.set("noteblock.enabled", true);
+        config.set("noteblock.tool_types", Arrays.asList("IRON", null, "null"));
+        config.set("noteblock.farmblock_check_delay", 2000);
+        config.set("noteblock.remove_mineable_tag", true);
+
+        config.set("stringblock.enabled", true);
+        config.set("stringblock.tool_types", List.of("DIAMOND"));
+        config.set("stringblock.sapling_growth_check_delay", 3000);
+        config.set("stringblock.disable_vanilla_strings", true);
+
+        config.set("chorusblock.enabled", false);
+        config.set("shaped_block.enabled", true);
+        config.set("shaped_block.tool_types", List.of("NETHERITE"));
+        config.set("shaped_block.convert_vanilla_waxed", false);
+        config.set("shaped_block.handle_world_generation", false);
+
+        config.set("custom_block_sounds.block", true);
+        config.set("custom_block_sounds.furniture", true);
+        config.set("custom_block_sounds.noteblock_and_block", false);
+        config.set("custom_block_sounds.stringblock_and_furniture", false);
+        config.set("custom_block_sounds.chorusblock", false);
+
+        assertTrue(LegacyBlockMechanicMigration.migrate(config));
+
+        ConfigurationSection block = config.getConfigurationSection("block");
+        assertTrue(block.getBoolean("enabled"));
+        assertEquals(List.of("STONE", "WOODEN", "IRON", "DIAMOND", "NETHERITE"), block.getStringList("tool-types"));
+        assertNull(block.get("tool_types"));
+        assertEquals(2000, block.getInt("farmblock-check-delay"));
+        assertTrue(block.getBoolean("remove-mineable-tag"));
+        assertEquals(3000, block.getInt("sapling-growth-check-delay"));
+        assertTrue(block.getBoolean("disable-vanilla-strings"));
+        assertFalse(block.getBoolean("convert-vanilla-waxed"));
+        assertFalse(block.getBoolean("handle-world-generation"));
+
+        assertNull(config.getConfigurationSection("noteblock"));
+        assertNull(config.getConfigurationSection("stringblock"));
+        assertNull(config.getConfigurationSection("chorusblock"));
+        assertNull(config.getConfigurationSection("shaped_block"));
+        assertFalse(config.getBoolean("custom_block_sounds.block"));
+        assertFalse(config.getBoolean("custom_block_sounds.furniture"));
+    }
+
+    @Test
+    void returnsFalseWhenNothingLegacyExists() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("block.enabled", true);
+
+        assertFalse(LegacyBlockMechanicMigration.migrate(config));
+        assertTrue(config.getBoolean("block.enabled"));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.215.0
+pluginVersion=1.216.0

--- a/schemas/oraxen-schema.json
+++ b/schemas/oraxen-schema.json
@@ -7820,7 +7820,7 @@
         },
         "seats": {
           "type": "array",
-          "description": "List of seat offsets relative to the furniture center formatted \u0027\u003cx\u003e,\u003cy\u003e,\u003cz\u003e\u0027"
+          "description": "List of seat offsets relative to the furniture center formatted \u0027\u003cx\u003e,\u003cy\u003e,\u003cz\u003e\u0027 or \u0027\u003cx\u003e,\u003cy\u003e,\u003cz\u003e \u003cyaw\u003e\u0027"
         },
         "barriers": {
           "type": "array",


### PR DESCRIPTION
## Oraxen v1.216.0
This pull request is not ready to be merged.

## Fixes

### Legacy Block Mechanic Migration
- **Summary** - Migrate pre-1.215 split block mechanic configs into the unified `block` mechanic before mechanics are registered.
- **Description** - Servers upgrading from 1.214.0 or lower could keep a legacy `block:` mechanics.yml section with `enabled: false`, causing the 1.215 migration to skip `noteblock`, `stringblock`, `chorusblock`, and `shaped_block` factory settings. Item configs were converted to `Mechanics.block`, but the unified block mechanic stayed disabled, so migrated blocks had no textures and were not placeable. The migration now merges legacy sections even when an old `block:` section already exists and saves the active config before mechanics load.
- **Changes** - Added shared legacy block mechanics.yml migration, wired it into config validation and mechanic registration fallback, preserved legacy tool types/options/custom block sound settings, removed old factory sections after backup, and added regression tests for the skipped-migration case.

## Features

### Furniture Seats Yaw Support
- **Summary** - Allow multi-seat furniture configs to define per-seat yaw while preserving existing seat formats.
- **Description** - `furniture.seats` entries can now use either the existing `<x>,<y>,<z>` format or the new `<x>,<y>,<z> <yaw>` format, matching the yaw support already available for legacy `furniture.seat` configs. Seats without yaw continue to face the furniture yaw, while seats with yaw use their configured rotation.
- **Changes** - Added optional yaw to `FurnitureSeat`, updated multi-seat parsing and seat spawn/update rotation logic, preserved legacy `furniture.seat.yaw`, and refreshed furniture config schema descriptions.

```yaml
Mechanics:
  furniture:
    type: DISPLAY_ENTITY
    seats:
      - -0.75,-1.2,0 90 
      - 0,-1.2,0 30
      - 0.75,-1.2,0 # Seats without yaw still work.
```

## Chores
