### PR TITLE
fix: account for furniture rotation in seat yaw

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureMechanic.java
@@ -134,6 +134,10 @@ public class FurnitureMechanic extends Mechanic {
         public float yaw(float fallbackYaw) {
             return yaw != null ? yaw : fallbackYaw;
         }
+
+        public float rotatedYaw(float furnitureYaw) {
+            return yaw != null ? ((yaw + furnitureYaw) % 360) : furnitureYaw;
+        }
     }
 
     public enum RestrictedRotation {
@@ -1362,7 +1366,7 @@ public class FurnitureMechanic extends Mechanic {
     @Nullable
     private UUID spawnSeat(Location rootLocation, FurnitureSeat furnitureSeat, float yaw) {
         Vector rotatedOffset = furnitureSeat.rotatedOffset(yaw);
-        float rotationYaw = furnitureSeat.yaw(yaw);
+        float rotationYaw = furnitureSeat.rotatedYaw(yaw);
         Location seatLocation = BlockHelpers.toCenterBlockLocation(rootLocation).add(rotatedOffset);
         seatLocation.setYaw(rotationYaw);
         seatLocation.setPitch(0);
@@ -1637,7 +1641,7 @@ public class FurnitureMechanic extends Mechanic {
 
             FurnitureSeat furnitureSeat = seats.get(i);
             Vector rotatedOffset = furnitureSeat.rotatedOffset(yaw);
-            float rotationYaw = furnitureSeat.yaw(yaw);
+            float rotationYaw = furnitureSeat.rotatedYaw(yaw);
             Location seatLocation = BlockHelpers.toCenterBlockLocation(rootLocation).add(rotatedOffset);
             seatLocation.setYaw(rotationYaw);
             seatLocation.setPitch(0);

--- a/src/test/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSeatTest.java
+++ b/src/test/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureSeatTest.java
@@ -30,6 +30,25 @@ class FurnitureSeatTest {
         assertSeatMatchesBarrier(new FurnitureMechanic.FurnitureSeat(0, -1.3, 1), yaw, expectedX, expectedZ);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0, 0, 0",
+            "0, 90, 90, 0",
+            "90, 0, 90, 90",
+            "90, 90, 180, 90",
+            "180, 0, 180, 180",
+            "180, 90, 270, 180",
+            "270, 0, 270, 270",
+            "270, 90, 0, 270"
+    })
+    void seatYawRotatesWithFurniture(float furnitureYaw, float seatYaw, float expectedIfConfigured, float expectedIfNull) {
+        FurnitureMechanic.FurnitureSeat configured = new FurnitureMechanic.FurnitureSeat(0, 0, 0, seatYaw);
+        FurnitureMechanic.FurnitureSeat fallback = new FurnitureMechanic.FurnitureSeat(0, 0, 0, null);
+
+        assertEquals(expectedIfConfigured, configured.rotatedYaw(furnitureYaw), 1.0e-9);
+        assertEquals(expectedIfNull, fallback.rotatedYaw(furnitureYaw), 1.0e-9);
+    }
+
     private static void assertSeatMatchesBarrier(FurnitureMechanic.FurnitureSeat seat, float yaw,
                                                  double expectedX, double expectedZ) {
         Vector rotated = seat.rotatedOffset(yaw);


### PR DESCRIPTION
Fix furniture seat yaw rotation for rotated furniture

## Problem
When using furniture seats with an explicit `yaw` value, the seated character's facing direction was in furniture-local yaw but was being treated as world yaw. This meant seats only faced correctly when the furniture was at yaw 0.

For example, a picnic table with seats configured with yaw `90` and `270` to face inward would work at yaw 0, but break at yaw 90/180/270.

## Root Cause
`FurnitureSeat.yaw(float)` returned the configured seat yaw directly without transforming it from furniture-local space to world space. The seat's local facing direction was not being rotated by the furniture's world yaw.

## Changes
- `FurnitureMechanic.java`: Added `FurnitureSeat.rotatedYaw(float furnitureYaw)` which transforms the configured seat yaw from furniture-local space to world space.
- Updated `spawnSeat` and `updateFurnitureSeats` to use `rotatedYaw` instead of `yaw` when setting the seat's world rotation.
- `FurnitureSeatTest.java`: Added `seatYawRotatesWithFurniture` parameterized test covering all four cardinal furniture yaws.

## Result
Seat yaw is now correctly rotated with the furniture. A seat configured with `yaw: 90` faces 90° relative to the furniture's forward direction, which is properly transformed to the correct world-space yaw based on the furniture's placement rotation.
