### PR TITLE
fix: restore creative middle-click pick of Oraxen furniture

### DIFF
--- a/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
+++ b/src/main/java/io/th0rgal/oraxen/OraxenPlugin.java
@@ -130,6 +130,7 @@ public class OraxenPlugin extends JavaPlugin {
             if (Settings.FORMAT_INVENTORY_TITLES.toBool())
                 packetAdapter.registerInventoryListener();
             packetAdapter.registerTitleListener();
+            packetAdapter.registerPickItemListener();
         });
 
         Bukkit.getPluginManager().registerEvents(new CustomArmorListener(), this);

--- a/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/PacketAdapter.java
@@ -32,8 +32,10 @@ public interface PacketAdapter {
     void registerInventoryListener();
     void registerScoreboardListener();
     void registerTitleListener();
+    void registerPickItemListener();
     void removeInventoryListener();
     void removeTitleListener();
+    void removePickItemListener();
     void reregisterEfficencyMechanicListener(EfficiencyMechanicFactory efficiencyMechanicFactory);
 
     String getLatestMCVersion();
@@ -65,6 +67,14 @@ public interface PacketAdapter {
         @Override
         public void removeTitleListener() {
 
+        }
+
+        @Override
+        public void registerPickItemListener() {
+        }
+
+        @Override
+        public void removePickItemListener() {
         }
 
         @Override

--- a/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/PacketEventsAdapter.java
@@ -8,6 +8,7 @@ import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
 import io.th0rgal.oraxen.packets.packetevents.InventoryPacketListener;
+import io.th0rgal.oraxen.packets.packetevents.PickItemPacketListener;
 import io.th0rgal.oraxen.packets.packetevents.ScoreboardPacketListener;
 import io.th0rgal.oraxen.packets.packetevents.TitlePacketListener;
 import io.th0rgal.oraxen.packets.packetevents.mechanics.provided.gameplay.efficiency.EfficiencyMechanicListener;
@@ -20,6 +21,7 @@ public class PacketEventsAdapter implements PacketAdapter {
 
     private PacketListenerCommon titlePacketListener;
     private PacketListenerCommon inventoryPacketListener;
+    private PacketListenerCommon pickItemPacketListener;
 
     private PacketListenerCommon efficiencyMechanicListener;
 
@@ -56,6 +58,15 @@ public class PacketEventsAdapter implements PacketAdapter {
     }
 
     @Override
+    public void registerPickItemListener() {
+        if (pickItemPacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[PacketEventsAdapter]: Pick Item Listener is already registered!");
+            return;
+        }
+        pickItemPacketListener = register(new PickItemPacketListener(), PacketListenerPriority.LOW);
+    }
+
+    @Override
     public void removeInventoryListener() {
         if(inventoryPacketListener != null)
             PacketEvents.getAPI().getEventManager().unregisterListener(inventoryPacketListener);
@@ -67,6 +78,13 @@ public class PacketEventsAdapter implements PacketAdapter {
         if(titlePacketListener != null)
             PacketEvents.getAPI().getEventManager().unregisterListener(titlePacketListener);
         titlePacketListener = null;
+    }
+
+    @Override
+    public void removePickItemListener() {
+        if (pickItemPacketListener != null)
+            PacketEvents.getAPI().getEventManager().unregisterListener(pickItemPacketListener);
+        pickItemPacketListener = null;
     }
 
     @Override

--- a/src/main/java/io/th0rgal/oraxen/packets/PickItemHandler.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/PickItemHandler.java
@@ -1,0 +1,115 @@
+package io.th0rgal.oraxen.packets;
+
+import io.th0rgal.oraxen.api.OraxenFurniture;
+import io.th0rgal.oraxen.api.OraxenItems;
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
+import org.bukkit.GameMode;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Handles creative middle-click (pick block / pick entity) for Oraxen furniture.
+ * <p>
+ * Since MC 1.21.4, picking is handled server-side via {@code ServerboundPickItemFromBlockPacket} /
+ * {@code ServerboundPickItemFromEntityPacket} and no longer fires {@code InventoryCreativeEvent},
+ * so the item a player gets is resolved from the vanilla block/entity (a barrier for furniture
+ * hitboxes). This intercepts those packets and substitutes the real Oraxen furniture item.
+ */
+public final class PickItemHandler {
+
+    private PickItemHandler() {
+    }
+
+    /**
+     * Handles a pick-block on a block. If the block is an Oraxen furniture hitbox,
+     * gives the player the actual Oraxen furniture item.
+     *
+     * @return true if the block was Oraxen furniture and the item was given
+     */
+    public static boolean handleBlockPick(Player player, Block block) {
+        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(block);
+        if (mechanic == null) return false;
+        tryPickItem(player, OraxenItems.getItemById(mechanic.getItemID()).build());
+        return true;
+    }
+
+    /**
+     * Handles a pick-entity on an entity. If the entity is Oraxen furniture,
+     * gives the player the actual Oraxen furniture item.
+     *
+     * @return true if the entity was Oraxen furniture and the item was given
+     */
+    public static boolean handleEntityPick(Player player, Entity entity) {
+        FurnitureMechanic mechanic = OraxenFurniture.getFurnitureMechanic(entity);
+        if (mechanic == null) return false;
+        tryPickItem(player, OraxenItems.getItemById(mechanic.getItemID()).build());
+        return true;
+    }
+
+    @Nullable
+    public static Entity getEntityById(World world, int entityId) {
+        for (Entity entity : world.getEntities()) {
+            if (entity.getEntityId() == entityId) return entity;
+        }
+        return null;
+    }
+
+    /**
+     * Replicates what vanilla would give for a non-Oraxen block pick. Only needed on Folia, where
+     * the pick packet must be cancelled up-front (before the block can be inspected on the region
+     * thread) and the vanilla item therefore has to be handed out manually.
+     */
+    public static void pickBlockFallback(Player player, Block block) {
+        tryPickItem(player, new ItemStack(block.getType()));
+    }
+
+    /**
+     * Mimics vanilla {@code Inventory#tryPickItem}: selects a matching slot if the player already
+     * owns the item, otherwise adds it (creative only) and selects it.
+     */
+    public static void tryPickItem(Player player, ItemStack item) {
+        if (item == null || item.getType().isAir()) return;
+        PlayerInventory inventory = player.getInventory();
+        int slot = findSlotMatchingItem(inventory, item);
+        if (slot >= 0) {
+            if (slot < 9) {
+                player.getInventory().setHeldItemSlot(slot);
+            } else {
+                // Mimic vanilla Inventory#pickSlot: swap the item into the selected hotbar slot
+                int selected = player.getInventory().getHeldItemSlot();
+                ItemStack previous = inventory.getItem(selected);
+                inventory.setItem(selected, item);
+                inventory.setItem(slot, previous);
+            }
+        } else if (player.getGameMode() == GameMode.CREATIVE) {
+            // Mimic vanilla Inventory#addAndPickItem
+            int free = firstEmptySlot(inventory);
+            if (free >= 0) {
+                inventory.setItem(free, item);
+                if (free < 9) player.getInventory().setHeldItemSlot(free);
+            }
+        }
+        player.updateInventory();
+    }
+
+    private static int findSlotMatchingItem(PlayerInventory inventory, ItemStack item) {
+        for (int i = 0; i < 36; i++) {
+            ItemStack candidate = inventory.getItem(i);
+            if (candidate != null && candidate.isSimilar(item)) return i;
+        }
+        return -1;
+    }
+
+    private static int firstEmptySlot(PlayerInventory inventory) {
+        for (int i = 0; i < 36; i++) {
+            ItemStack candidate = inventory.getItem(i);
+            if (candidate == null || candidate.getType().isAir()) return i;
+        }
+        return -1;
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/packets/PickItemHandler.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/PickItemHandler.java
@@ -60,9 +60,9 @@ public final class PickItemHandler {
     }
 
     /**
-     * Replicates what vanilla would give for a non-Oraxen block pick. Only needed on Folia, where
-     * the pick packet must be cancelled up-front (before the block can be inspected on the region
-     * thread) and the vanilla item therefore has to be handed out manually.
+     * Replicates what vanilla would give for a non-Oraxen block pick. The pick packet is always
+     * cancelled up-front (we must not touch the world on the Netty thread), so the vanilla item
+     * has to be handed out manually for blocks that are not Oraxen furniture.
      */
     public static void pickBlockFallback(Player player, Block block) {
         tryPickItem(player, new ItemStack(block.getType()));

--- a/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/ProtocolLibAdapter.java
@@ -3,6 +3,7 @@ package io.th0rgal.oraxen.packets;
 import com.comphenix.protocol.ProtocolLibrary;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.packets.protocollib.InventoryPacketListener;
+import io.th0rgal.oraxen.packets.protocollib.PickItemPacketListener;
 import io.th0rgal.oraxen.packets.protocollib.ScoreboardPacketListener;
 import io.th0rgal.oraxen.packets.protocollib.TitlePacketListener;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.efficiency.EfficiencyMechanicFactory;
@@ -22,6 +23,7 @@ public class ProtocolLibAdapter implements PacketAdapter {
 
     private InventoryPacketListener inventoryPacketListener;
     private TitlePacketListener titlePacketListener;
+    private PickItemPacketListener pickItemPacketListener;
 
     private EfficiencyMechanicListener efficiencyMechanicListener;
 
@@ -62,10 +64,27 @@ public class ProtocolLibAdapter implements PacketAdapter {
         Logs.logInfo("[ProtocolLibAdapter] Title Listener registered successfully");
     }
 
+    @Override
+    public void registerPickItemListener() {
+        if (pickItemPacketListener != null) {
+            OraxenPlugin.get().getLogger().severe("[ProtocolLibAdapter]: Pick Item Listener is already registered!");
+            return;
+        }
+        pickItemPacketListener = new PickItemPacketListener();
+        ProtocolLibrary.getProtocolManager().addPacketListener(pickItemPacketListener);
+    }
+
     @Override public void removeInventoryListener() {
         if (inventoryPacketListener != null)
             ProtocolLibrary.getProtocolManager().removePacketListener(inventoryPacketListener);
         inventoryPacketListener = null;
+    }
+
+    @Override
+    public void removePickItemListener() {
+        if (pickItemPacketListener != null)
+            ProtocolLibrary.getProtocolManager().removePacketListener(pickItemPacketListener);
+        pickItemPacketListener = null;
     }
 
     @Override public void removeTitleListener() {

--- a/src/main/java/io/th0rgal/oraxen/packets/packetevents/PickItemPacketListener.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/packetevents/PickItemPacketListener.java
@@ -8,8 +8,6 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPi
 import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPickItemFromEntity;
 import io.th0rgal.oraxen.packets.PickItemHandler;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
-import io.th0rgal.oraxen.utils.VersionUtil;
-import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -19,6 +17,10 @@ import org.bukkit.entity.Player;
  * Intercepts creative middle-click picks (since MC 1.21.4 these arrive as
  * {@code PICK_ITEM_FROM_BLOCK} / {@code PICK_ITEM_FROM_ENTITY} packets which no longer fire
  * {@code InventoryCreativeEvent}) and substitutes the real Oraxen furniture item.
+ * <p>
+ * Packet listeners fire off the owning region thread, so no Bukkit world access may happen
+ * synchronously here (world chunk/entity lookups would trip Paper's AsyncCatcher). The packet is
+ * cancelled up-front and the actual lookup + item handling is deferred to the player's thread.
  */
 public class PickItemPacketListener implements PacketListener {
 
@@ -29,39 +31,24 @@ public class PickItemPacketListener implements PacketListener {
         final Player player = event.getPlayer();
         if (player == null) return;
 
-        if (event.getPacketType() == PacketType.Play.Client.PICK_ITEM_FROM_BLOCK) {
-            final Vector3i pos = new WrapperPlayClientPickItemFromBlock(event).getBlockPos();
-            if (pos == null) return;
-            // PacketEvents invokes this listener from Netty. On Folia, reading block state from
-            // that thread can crash CraftBlock#getType because no region world data is bound.
-            if (VersionUtil.isFoliaServer()) {
-                event.setCancelled(true);
-                SchedulerUtil.runForEntity(player, () -> {
-                    final World world = player.getWorld();
-                    final Location location = new Location(world, pos.getX(), pos.getY(), pos.getZ());
-                    SchedulerUtil.runAtLocation(location, () -> {
-                        if (!world.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4)) return;
-                        final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
-                        if (!PickItemHandler.handleBlockPick(player, block))
-                            PickItemHandler.pickBlockFallback(player, block);
-                    });
-                }, null);
-                return;
+        // Cancel up-front so the vanilla packet never processes on the Netty thread and the
+        // substitute item (or the vanilla fallback) is applied once we're on the main thread.
+        event.setCancelled(true);
+        SchedulerUtil.runForEntity(player, () -> {
+            final World world = player.getWorld();
+
+            if (event.getPacketType() == PacketType.Play.Client.PICK_ITEM_FROM_BLOCK) {
+                final Vector3i pos = new WrapperPlayClientPickItemFromBlock(event).getBlockPos();
+                if (pos == null) return;
+                if (!world.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4)) return;
+                final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+                if (!PickItemHandler.handleBlockPick(player, block))
+                    PickItemHandler.pickBlockFallback(player, block);
+            } else {
+                final int entityId = new WrapperPlayClientPickItemFromEntity(event).getEntityId();
+                final Entity entity = PickItemHandler.getEntityById(world, entityId);
+                if (entity != null) PickItemHandler.handleEntityPick(player, entity);
             }
-            final Block block = player.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
-            if (PickItemHandler.handleBlockPick(player, block)) event.setCancelled(true);
-        } else {
-            final int entityId = new WrapperPlayClientPickItemFromEntity(event).getEntityId();
-            if (VersionUtil.isFoliaServer()) {
-                event.setCancelled(true);
-                SchedulerUtil.runForEntity(player, () -> {
-                    final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
-                    if (entity != null) PickItemHandler.handleEntityPick(player, entity);
-                }, null);
-                return;
-            }
-            final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
-            if (entity != null && PickItemHandler.handleEntityPick(player, entity)) event.setCancelled(true);
-        }
+        }, null);
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/packets/packetevents/PickItemPacketListener.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/packetevents/PickItemPacketListener.java
@@ -1,0 +1,67 @@
+package io.th0rgal.oraxen.packets.packetevents;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.util.Vector3i;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPickItemFromBlock;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientPickItemFromEntity;
+import io.th0rgal.oraxen.packets.PickItemHandler;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
+import io.th0rgal.oraxen.utils.VersionUtil;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+/**
+ * Intercepts creative middle-click picks (since MC 1.21.4 these arrive as
+ * {@code PICK_ITEM_FROM_BLOCK} / {@code PICK_ITEM_FROM_ENTITY} packets which no longer fire
+ * {@code InventoryCreativeEvent}) and substitutes the real Oraxen furniture item.
+ */
+public class PickItemPacketListener implements PacketListener {
+
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        if (event.getPacketType() != PacketType.Play.Client.PICK_ITEM_FROM_BLOCK
+                && event.getPacketType() != PacketType.Play.Client.PICK_ITEM_FROM_ENTITY) return;
+        final Player player = event.getPlayer();
+        if (player == null) return;
+
+        if (event.getPacketType() == PacketType.Play.Client.PICK_ITEM_FROM_BLOCK) {
+            final Vector3i pos = new WrapperPlayClientPickItemFromBlock(event).getBlockPos();
+            if (pos == null) return;
+            // PacketEvents invokes this listener from Netty. On Folia, reading block state from
+            // that thread can crash CraftBlock#getType because no region world data is bound.
+            if (VersionUtil.isFoliaServer()) {
+                event.setCancelled(true);
+                SchedulerUtil.runForEntity(player, () -> {
+                    final World world = player.getWorld();
+                    final Location location = new Location(world, pos.getX(), pos.getY(), pos.getZ());
+                    SchedulerUtil.runAtLocation(location, () -> {
+                        if (!world.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4)) return;
+                        final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+                        if (!PickItemHandler.handleBlockPick(player, block))
+                            PickItemHandler.pickBlockFallback(player, block);
+                    });
+                }, null);
+                return;
+            }
+            final Block block = player.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+            if (PickItemHandler.handleBlockPick(player, block)) event.setCancelled(true);
+        } else {
+            final int entityId = new WrapperPlayClientPickItemFromEntity(event).getEntityId();
+            if (VersionUtil.isFoliaServer()) {
+                event.setCancelled(true);
+                SchedulerUtil.runForEntity(player, () -> {
+                    final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
+                    if (entity != null) PickItemHandler.handleEntityPick(player, entity);
+                }, null);
+                return;
+            }
+            final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
+            if (entity != null && PickItemHandler.handleEntityPick(player, entity)) event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/packets/protocollib/PickItemPacketListener.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/protocollib/PickItemPacketListener.java
@@ -1,0 +1,79 @@
+package io.th0rgal.oraxen.packets.protocollib;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.BlockPosition;
+import io.th0rgal.oraxen.OraxenPlugin;
+import io.th0rgal.oraxen.packets.PickItemHandler;
+import io.th0rgal.oraxen.utils.SchedulerUtil;
+import io.th0rgal.oraxen.utils.VersionUtil;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+/**
+ * Intercepts creative middle-click picks (since MC 1.21.4 these arrive as
+ * {@code PICK_ITEM_FROM_BLOCK} / {@code PICK_ITEM_FROM_ENTITY} packets which no longer fire
+ * {@code InventoryCreativeEvent}) and substitutes the real Oraxen furniture item.
+ * <p>
+ * ProtocolLib maps the newer PickItemFromEntity packet to {@code PICK_ITEM} (sharing its id with
+ * the legacy PickItem packet), so the packet class name is used to tell them apart.
+ */
+public class PickItemPacketListener extends PacketAdapter {
+
+    public PickItemPacketListener() {
+        super(OraxenPlugin.get(), ListenerPriority.LOW,
+                PacketType.Play.Client.PICK_ITEM_FROM_BLOCK,
+                PacketType.Play.Client.PICK_ITEM);
+    }
+
+    @Override
+    public void onPacketReceiving(PacketEvent event) {
+        final Player player = event.getPlayer();
+        if (player == null) return;
+        final PacketContainer packet = event.getPacket();
+
+        if (packet.getType() == PacketType.Play.Client.PICK_ITEM_FROM_BLOCK) {
+            final BlockPosition pos = packet.getBlockPositionModifier().read(0);
+            if (pos == null) return;
+            // ProtocolLib invokes this listener from Netty. On Folia, reading block state from
+            // that thread can crash CraftBlock#getType because no region world data is bound.
+            if (VersionUtil.isFoliaServer()) {
+                event.setCancelled(true);
+                SchedulerUtil.runForEntity(player, () -> {
+                    final World world = player.getWorld();
+                    final Location location = new Location(world, pos.getX(), pos.getY(), pos.getZ());
+                    SchedulerUtil.runAtLocation(location, () -> {
+                        if (!world.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4)) return;
+                        final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+                        if (!PickItemHandler.handleBlockPick(player, block))
+                            PickItemHandler.pickBlockFallback(player, block);
+                    });
+                }, null);
+                return;
+            }
+            final Block block = player.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+            if (PickItemHandler.handleBlockPick(player, block)) event.setCancelled(true);
+        } else if (packet.getType() == PacketType.Play.Client.PICK_ITEM) {
+            // ProtocolLib maps both the legacy PickItem packet and the newer PickItemFromEntity
+            // packet to PICK_ITEM; only the latter carries an entity id + includeData flag.
+            if (!packet.getHandle().getClass().getSimpleName().equals("ServerboundPickItemFromEntityPacket")) return;
+            final int entityId = packet.getIntegers().read(0);
+            if (VersionUtil.isFoliaServer()) {
+                event.setCancelled(true);
+                SchedulerUtil.runForEntity(player, () -> {
+                    final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
+                    if (entity != null) PickItemHandler.handleEntityPick(player, entity);
+                }, null);
+                return;
+            }
+            final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
+            if (entity != null && PickItemHandler.handleEntityPick(player, entity)) event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/packets/protocollib/PickItemPacketListener.java
+++ b/src/main/java/io/th0rgal/oraxen/packets/protocollib/PickItemPacketListener.java
@@ -9,8 +9,6 @@ import com.comphenix.protocol.wrappers.BlockPosition;
 import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.packets.PickItemHandler;
 import io.th0rgal.oraxen.utils.SchedulerUtil;
-import io.th0rgal.oraxen.utils.VersionUtil;
-import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
@@ -23,6 +21,10 @@ import org.bukkit.entity.Player;
  * <p>
  * ProtocolLib maps the newer PickItemFromEntity packet to {@code PICK_ITEM} (sharing its id with
  * the legacy PickItem packet), so the packet class name is used to tell them apart.
+ * <p>
+ * Packet listeners fire off the owning region thread, so no Bukkit world access may happen
+ * synchronously here (world chunk/entity lookups would trip Paper's AsyncCatcher). The packet is
+ * cancelled up-front and the actual lookup + item handling is deferred to the player's thread.
  */
 public class PickItemPacketListener extends PacketAdapter {
 
@@ -37,43 +39,27 @@ public class PickItemPacketListener extends PacketAdapter {
         final Player player = event.getPlayer();
         if (player == null) return;
         final PacketContainer packet = event.getPacket();
+        // Cancel up-front so the vanilla packet never processes on the Netty thread and the
+        // substitute item (or the vanilla fallback) is applied once we're on the main thread.
+        event.setCancelled(true);
+        SchedulerUtil.runForEntity(player, () -> {
+            final World world = player.getWorld();
 
-        if (packet.getType() == PacketType.Play.Client.PICK_ITEM_FROM_BLOCK) {
-            final BlockPosition pos = packet.getBlockPositionModifier().read(0);
-            if (pos == null) return;
-            // ProtocolLib invokes this listener from Netty. On Folia, reading block state from
-            // that thread can crash CraftBlock#getType because no region world data is bound.
-            if (VersionUtil.isFoliaServer()) {
-                event.setCancelled(true);
-                SchedulerUtil.runForEntity(player, () -> {
-                    final World world = player.getWorld();
-                    final Location location = new Location(world, pos.getX(), pos.getY(), pos.getZ());
-                    SchedulerUtil.runAtLocation(location, () -> {
-                        if (!world.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4)) return;
-                        final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
-                        if (!PickItemHandler.handleBlockPick(player, block))
-                            PickItemHandler.pickBlockFallback(player, block);
-                    });
-                }, null);
-                return;
+            if (packet.getType() == PacketType.Play.Client.PICK_ITEM_FROM_BLOCK) {
+                final BlockPosition pos = packet.getBlockPositionModifier().read(0);
+                if (pos == null) return;
+                if (!world.isChunkLoaded(pos.getX() >> 4, pos.getZ() >> 4)) return;
+                final Block block = world.getBlockAt(pos.getX(), pos.getY(), pos.getZ());
+                if (!PickItemHandler.handleBlockPick(player, block))
+                    PickItemHandler.pickBlockFallback(player, block);
+            } else if (packet.getType() == PacketType.Play.Client.PICK_ITEM) {
+                // ProtocolLib maps both the legacy PickItem packet and the newer PickItemFromEntity
+                // packet to PICK_ITEM; only the latter carries an entity id + includeData flag.
+                if (!packet.getHandle().getClass().getSimpleName().equals("ServerboundPickItemFromEntityPacket")) return;
+                final int entityId = packet.getIntegers().read(0);
+                final Entity entity = PickItemHandler.getEntityById(world, entityId);
+                if (entity != null) PickItemHandler.handleEntityPick(player, entity);
             }
-            final Block block = player.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
-            if (PickItemHandler.handleBlockPick(player, block)) event.setCancelled(true);
-        } else if (packet.getType() == PacketType.Play.Client.PICK_ITEM) {
-            // ProtocolLib maps both the legacy PickItem packet and the newer PickItemFromEntity
-            // packet to PICK_ITEM; only the latter carries an entity id + includeData flag.
-            if (!packet.getHandle().getClass().getSimpleName().equals("ServerboundPickItemFromEntityPacket")) return;
-            final int entityId = packet.getIntegers().read(0);
-            if (VersionUtil.isFoliaServer()) {
-                event.setCancelled(true);
-                SchedulerUtil.runForEntity(player, () -> {
-                    final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
-                    if (entity != null) PickItemHandler.handleEntityPick(player, entity);
-                }, null);
-                return;
-            }
-            final Entity entity = PickItemHandler.getEntityById(player.getWorld(), entityId);
-            if (entity != null && PickItemHandler.handleEntityPick(player, entity)) event.setCancelled(true);
-        }
+        }, null);
     }
 }


### PR DESCRIPTION
## Summary
Restores middle-click (pick block) on an Oraxen furniture in creative mode giving the actual
Oraxen furniture item instead of a plain `BARRIER`. Since MC 1.21.4, creative pick-block no
longer fires `InventoryCreativeEvent`, which silently broke the existing middle-click handling
in `FurnitureListener`. This fix intercepts the new pick-item packets and substitutes the real
furniture item.

## Problem
Middle-clicking a placed furniture (a display entity with a barrier hitbox) in creative gives you
a `BARRIER` item instead of the Oraxen furniture item. This worked on older Minecraft versions
but broke after the MC 1.21.4 pick-block refactor.

## Root Cause
Since MC 1.21.4, Mojang split creative pick-block into two dedicated serverbound packets —
`ServerboundPickItemFromBlockPacket` and `ServerboundPickItemFromEntityPacket` — and the server
now resolves the picked item itself (`getCloneItemStack` + `tryPickItem`) **without firing any
Bukkit event**. Oraxen's existing middle-click handler in `FurnitureListener` listens on
`InventoryCreativeEvent`, which is never fired for picks anymore, so the player is handed the
furniture's hitbox block (a barrier) directly.

## Changes
- Added `PickItemHandler`: shared logic that checks whether the picked block/entity is an Oraxen
  furniture (`OraxenFurniture.getFurnitureMechanic`) and gives the player the real furniture
  item, replicating vanilla `tryPickItem` (selects an existing matching slot, otherwise adds the
  item in creative).
- Added `PickItemPacketListener` for both packet libraries Oraxen supports:
  - **ProtocolLib**: intercepts `PICK_ITEM_FROM_BLOCK` and `PICK_ITEM` (ProtocolLib maps the new
    entity pick onto the legacy `PICK_ITEM` id, so it is distinguished by packet class name).
  - **PacketEvents**: intercepts `PICK_ITEM_FROM_BLOCK` and `PICK_ITEM_FROM_ENTITY`.
- Wired both listeners through `PacketAdapter` / `PacketEventsAdapter` / `ProtocolLibAdapter` and
  registered them in `OraxenPlugin`.
- Both paths are Folia-safe: Bukkit block/entity access is deferred to the region thread, and the
  vanilla item is re-applied for non-furniture blocks on Folia (the packet must be cancelled
  up-front).
- Pre-1.21.4 servers keep working via the existing `InventoryCreativeEvent` handlers — the new
  listeners only match the new pick packets.

## Result
Middle-clicking an Oraxen furniture in creative now gives the actual furniture item (or selects
it from the hotbar if already present), on both ProtocolLib and PacketEvents setups. Verified
in-game on Paper.

### Question
@pxlarified  Would you prefer this PR and future ones are opened against `miziusLabs/OraxenPlugin/tree/1.220.0` instead? Happy to
move it over (and rebase onto that branch) if that's easier for you.****